### PR TITLE
Get druid compiling on mac with minimal functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ name = "druid"
 version = "0.2.0"
 dependencies = [
  "druid-shell 0.2.0",
- "kurbo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet-common 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -430,7 +430,7 @@ name = "piet"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -439,7 +439,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -453,7 +453,7 @@ dependencies = [
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet-cairo 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet-direct2d 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,7 +468,7 @@ dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -479,7 +479,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -811,7 +811,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum js-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f0edfcbe54ba2071053f2e67f5dfbcea344b69aedfb371b76e27392427a5750f"
-"checksum kurbo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f77c5f5c9d4ce0da64bf0603bef3f818e75edbe0e5552666892dca27583ecbd3"
+"checksum kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2b957a4dfbd317dba024db63c05192b35156e09785fd7e026524ce5390ac6c88"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,8 +171,8 @@ version = "0.2.0"
 dependencies = [
  "druid-shell 0.2.0",
  "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -186,8 +186,8 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "piet"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,17 +435,17 @@ dependencies = [
 
 [[package]]
 name = "piet-cairo"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-common"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -454,33 +454,33 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-cairo 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-direct2d 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-web 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-cairo 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-direct2d 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-web 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-direct2d"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "kurbo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -827,11 +827,11 @@ dependencies = [
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
-"checksum piet 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6159205d94492d7a3a994453962e5802a30928df6c60cc7e2b3569fb1df265d8"
-"checksum piet-cairo 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8d62a79522d88f71eacf566628e55e485b7098dc083f908f36dc8e0047cecefa"
-"checksum piet-common 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7ef47c4daca4883aec89d1bf41ab823b2a88f16a496780b923be143474da21b"
-"checksum piet-direct2d 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ceef59e137b22e707a81b8ac1ee0ee40e427d5b0405372518bb0a3e984549f2"
-"checksum piet-web 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d94adb5abdf091d5618907e83a5c359455e1bb156c4404c19ca6d2e1651febe6"
+"checksum piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1c80a4f78b007b0e317e46926daa8e93eecd97d4ecba6dcf99502a6c3c05c8"
+"checksum piet-cairo 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6bb723ae52a0b0d3b834564e8ab022afaca775d7b08de2d99d56e23e43fd8ed3"
+"checksum piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95b5830eca10c9de0ed1454237cac28e66181b185518be1e8811f6e5b486ad8b"
+"checksum piet-direct2d 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38147f6e1668ad1c725374f26e58fa6785fdc487ca7527ab91116198edb35bcf"
+"checksum piet-web 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec8a5d1053c0e2ded9e12ddd4097c0943c15ef29a8333d974690d7b66f62bda2"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "xi-editor/druid" }
 [dependencies]
 piet-common = "0.0.1"
 piet = "0.0.1"
-kurbo = "0.2.0"
+kurbo = "0.2.1"
 
 
 [dependencies.druid-shell]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ default-target = "x86_64-pc-windows-msvc"
 travis-ci = { repository = "xi-editor/druid" }
 
 [dependencies]
-piet-common = "0.0.1"
-piet = "0.0.1"
+piet-common = "0.0.2"
+piet = "0.0.2"
 kurbo = "0.2.1"
 
 

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["os::macos-apis", "os::windows-apis", "gui"]
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-piet-common = "0.0.1"
-piet = "0.0.1"
+piet-common = "0.0.2"
+piet = "0.0.2"
 
 lazy_static = "1.0"
 time = "0.1.39"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -33,4 +33,4 @@ core-graphics = "0.17.3"
 cairo-rs = { version = "0.5.0", default_features = false }
 
 [dev-dependencies]
-kurbo = "0.2"
+kurbo = "0.2.1"

--- a/druid-shell/src/keycodes.rs
+++ b/druid-shell/src/keycodes.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The xi-editor Authors.
+// Copyright 2018 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Windows implementation of features at the application scope.
+//! Keycode constants.
 
-use win_main;
+/// Modifier mask for alt key in `keydown` and `char` events.
+pub const M_ALT: u32 = 1;
 
-pub struct Application;
+/// Modifier mask for control key in `keydown` and `char` events.
+pub const M_CTRL: u32 = 2;
 
-impl Application {
-    pub fn quit() {
-        win_main::request_quit();
-    }
-}
+/// Modifier mask for shift key in `keydown` and `char` events.
+pub const M_SHIFT: u32 = 4;
+

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -39,6 +39,7 @@ extern crate piet;
 extern crate piet_common;
 
 pub mod error;
+pub mod keycodes;
 pub mod window;
 
 #[cfg(target_os = "windows")]
@@ -46,8 +47,6 @@ pub mod windows;
 #[cfg(target_os = "windows")]
 pub use windows as platform;
 
-#[cfg(target_os = "windows")]
-pub use windows::application;
 #[cfg(target_os = "windows")]
 use windows::dcomp;
 #[cfg(target_os = "windows")]
@@ -60,6 +59,7 @@ pub use mac as platform;
 
 pub use error::Error;
 
+pub use platform::application;
 pub use platform::dialog;
 pub use platform::menu;
 pub use platform::util;

--- a/druid-shell/src/mac/application.rs
+++ b/druid-shell/src/mac/application.rs
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Windows implementation of features at the application scope.
+//! macOS implementation of features at the application scope.
 
-use win_main;
+use cocoa::appkit::NSApp;
+use cocoa::base::nil;
 
 pub struct Application;
 
 impl Application {
     pub fn quit() {
-        win_main::request_quit();
+        unsafe {
+            let () = msg_send![NSApp(), terminate: nil];
+        }
     }
 }

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -56,7 +56,6 @@ use piet::RenderContext;
 
 use dcomp::{D3D11Device, DCompositionDevice, DCompositionTarget, DCompositionVisual};
 use dialog::{get_file_dialog_path, FileDialogOptions, FileDialogType};
-use keycodes::{M_ALT, M_CTRL, M_SHIFT};
 use menu::Menu;
 use util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 use Error;

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -56,6 +56,7 @@ use piet::RenderContext;
 
 use dcomp::{D3D11Device, DCompositionDevice, DCompositionTarget, DCompositionVisual};
 use dialog::{get_file_dialog_path, FileDialogOptions, FileDialogType};
+use keycodes::{M_ALT, M_CTRL, M_SHIFT};
 use menu::Menu;
 use util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 use Error;
@@ -140,15 +141,6 @@ trait WndProc {
     fn window_proc(&self, hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM)
         -> Option<LRESULT>;
 }
-
-/// Modifier mask for alt key in `keydown` and `char` events.
-pub const M_ALT: u32 = 1;
-
-/// Modifier mask for control key in `keydown` and `char` events.
-pub const M_CTRL: u32 = 2;
-
-/// Modifier mask for shift key in `keydown` and `char` events.
-pub const M_SHIFT: u32 = 4;
 
 // State and logic for the winapi window procedure entry point. Note that this level
 // implements policies such as the use of Direct2D for painting.

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -51,8 +51,7 @@ impl Widget for AnimWidget {
                 &fg,
                 1.0,
                 None,
-            )
-            .unwrap();
+            );
     }
 
     fn layout(

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -55,8 +55,7 @@ impl Widget for FooWidget {
                 &fg,
                 1.0,
                 None,
-            )
-            .unwrap();
+            );
     }
 
     fn layout(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,7 +885,7 @@ impl WinHandler for UiMain {
         let mut state = self.state.borrow_mut();
         state.anim_frame();
         {
-            paint_ctx.clear(0x272822).unwrap();
+            paint_ctx.clear(0x272822);
         }
         let root = state.graph.root;
         let bc = BoxConstraints::tight(state.inner.layout_ctx.size);

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -74,8 +74,7 @@ impl Widget for Label {
         let pos = (geom.pos.0, geom.pos.1 + font_size);
         paint_ctx
             .render_ctx
-            .draw_text(&text_layout, pos, &brush)
-            .unwrap();
+            .draw_text(&text_layout, pos, &brush);
     }
 
     fn layout(
@@ -134,8 +133,7 @@ impl Widget for Button {
             );
             paint_ctx
                 .render_ctx
-                .fill(rect, &brush, FillRule::NonZero)
-                .unwrap();
+                .fill(rect, &brush, FillRule::NonZero);
         }
         self.label.paint(paint_ctx, geom);
     }

--- a/src/widget/key_listener.rs
+++ b/src/widget/key_listener.rs
@@ -14,7 +14,7 @@
 
 //! Widget for forwarding key events to a listener.
 
-use druid_shell::windows::M_ALT;
+use druid_shell::keycodes::M_ALT;
 
 use widget::Widget;
 use {HandlerCtx, Id, KeyEvent, KeyVariant, Ui};


### PR DESCRIPTION
Most event handling functionality is still stubbed out, and there are some loose ends, but as of this point, druid compiles on macOS and displays the calculator example.