### PR TITLE
Send mouse move messages when mouse is down (mac)

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -215,6 +215,10 @@ lazy_static! {
             mouse_move as extern "C" fn(&mut Object, Sel, id),
         );
         decl.add_method(
+            sel!(mouseDragged:),
+            mouse_move as extern "C" fn(&mut Object, Sel, id),
+        );
+        decl.add_method(
             sel!(scrollWheel:),
             scroll_wheel as extern "C" fn(&mut Object, Sel, id),
         );


### PR DESCRIPTION
The NSView `mouseDragged` method is called instead of `mouseMoved` when the mouse is down.

See https://stackoverflow.com/questions/16736279/mousemoved-event-stopping-when-mouse-is-down