### PR TITLE
Expose BoxConstraints members, add some Debug impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ enum AnimState {
     AnimFrameRequested,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct BoxConstraints {
     min_width: f32,
     max_width: f32,
@@ -743,6 +743,16 @@ impl BoxConstraints {
             clamp(size.0, self.min_width, self.max_width),
             clamp(size.1, self.min_height, self.max_height),
         )
+    }
+
+    /// Returns the max size of these constraints.
+    pub fn max(&self) -> (f32, f32) {
+        (self.max_width, self.max_height)
+    }
+
+    /// Returns the min size of these constraints.
+    pub fn min(&self) -> (f32, f32) {
+        (self.min_width, self.min_height)
     }
 }
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -152,6 +152,7 @@ pub trait Widget {
     fn on_child_removed(&mut self, child: Id) {}
 }
 
+#[derive(Debug, Clone)]
 pub struct MouseEvent {
     /// X coordinate in px units, relative to top left of widget.
     pub x: f32,


### PR DESCRIPTION
Without these exposed it's impossible to implement a widget in an external crate.