### PR TITLE
Set level to 4 on window creation (#43)

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -133,6 +133,7 @@ impl WindowBuilder {
                 NO,
             );
 
+            window.setLevel_(4);
             window.autorelease();
             window.cascadeTopLeftFromPoint_(NSPoint::new(20.0, 20.0));
             window.setTitle_(make_nsstring(&self.title));

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -408,7 +408,8 @@ impl WindowHandle {
             current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
             if let Some(ref nsview) = self.nsview {
                 let window: id = msg_send![*nsview.load(), window];
-                window.makeKeyAndOrderFront_(nil)
+                window.makeKeyAndOrderFront_(nil);
+                window.setLevel_(0)
             }
         }
     }


### PR DESCRIPTION
This fixes #43 as far as I can tell. I just followed @ratmice's ideas and this seemed the correct place to set the level.

On my Mac: without this level it flashes behind the terminal before going in front, with level 4 set it starts up in front of the terminal as expected.