### PR TITLE
Update piet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.2",
+ "piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,51 +424,56 @@ dependencies = [
 
 [[package]]
 name = "piet"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-cairo"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-common"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
- "piet-cairo 0.0.2",
- "piet-direct2d 0.0.2",
- "piet-web 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-direct2d"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -824,7 +829,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9987e7c13a91d9cf0efe59cca48a3a7a70e2b11695d5a4640f85ae71e28f5e73"
-"checksum kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "579b47bb5a9e87b84c7f8ac3d267ece79a438f460054706bcc350ccab7d14836"
+"checksum kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "74a2af7a4e1995cf3711d494b399128b80fc8fa9789220c2bdbf640f6708c037"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -841,6 +846,11 @@ dependencies = [
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
+"checksum piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b55f39da64b1490af57af1defbfbeaf91cf382e3e0d2eec598c31f606e449cf"
+"checksum piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "02c69f1195c0ba740dc67303d71e163a8f0b2f2a82a289bd4ef668f30961996a"
+"checksum piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e5f3a5c27ac4758f7a15927ffb81b0b191242623121b9938a14389f01e1692aa"
+"checksum piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb67f6a62271ae8b28ab0b22b197974949c5f6d6bbb3524136bc48a58dff863"
+"checksum piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f5a9493fd33f9ec3cd1c81aff029fe3c005cef0d5f41645dd9c3c41b813765f"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,6 @@ name = "druid"
 version = "0.2.0"
 dependencies = [
  "druid-shell 0.2.0",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -192,8 +189,7 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.2",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -429,7 +425,6 @@ dependencies = [
 [[package]]
 name = "piet"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -437,51 +432,43 @@ dependencies = [
 [[package]]
 name = "piet-cairo"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
 ]
 
 [[package]]
 name = "piet-common"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-cairo 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-direct2d 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-web 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
+ "piet-cairo 0.0.2",
+ "piet-direct2d 0.0.2",
+ "piet-web 0.0.2",
 ]
 
 [[package]]
 name = "piet-direct2d"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -854,11 +841,6 @@ dependencies = [
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
-"checksum piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1c80a4f78b007b0e317e46926daa8e93eecd97d4ecba6dcf99502a6c3c05c8"
-"checksum piet-cairo 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6bb723ae52a0b0d3b834564e8ab022afaca775d7b08de2d99d56e23e43fd8ed3"
-"checksum piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95b5830eca10c9de0ed1454237cac28e66181b185518be1e8811f6e5b486ad8b"
-"checksum piet-direct2d 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38147f6e1668ad1c725374f26e58fa6785fdc487ca7527ab91116198edb35bcf"
-"checksum piet-web 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec8a5d1053c0e2ded9e12ddd4097c0943c15ef29a8333d974690d7b66f62bda2"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,6 @@ default-target = "x86_64-pc-windows-msvc"
 [badges]
 travis-ci = { repository = "xi-editor/druid" }
 
-[dependencies]
-piet-common = "0.0.2"
-piet = "0.0.2"
-kurbo = "0.2.1"
-
 [dependencies.druid-shell]
 path = "druid-shell"
 version = "0.2.0"

--- a/druid-shell/Cargo.lock
+++ b/druid-shell/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.2",
+ "piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -417,51 +417,56 @@ dependencies = [
 
 [[package]]
 name = "piet"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-cairo"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-common"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
- "piet-cairo 0.0.2",
- "piet-direct2d 0.0.2",
- "piet-web 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-direct2d"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
-version = "0.0.2"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2",
+ "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -817,7 +822,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9987e7c13a91d9cf0efe59cca48a3a7a70e2b11695d5a4640f85ae71e28f5e73"
-"checksum kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "579b47bb5a9e87b84c7f8ac3d267ece79a438f460054706bcc350ccab7d14836"
+"checksum kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "74a2af7a4e1995cf3711d494b399128b80fc8fa9789220c2bdbf640f6708c037"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -834,6 +839,11 @@ dependencies = [
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
+"checksum piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b55f39da64b1490af57af1defbfbeaf91cf382e3e0d2eec598c31f606e449cf"
+"checksum piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "02c69f1195c0ba740dc67303d71e163a8f0b2f2a82a289bd4ef668f30961996a"
+"checksum piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e5f3a5c27ac4758f7a15927ffb81b0b191242623121b9938a14389f01e1692aa"
+"checksum piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb67f6a62271ae8b28ab0b22b197974949c5f6d6bbb3524136bc48a58dff863"
+"checksum piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f5a9493fd33f9ec3cd1c81aff029fe3c005cef0d5f41645dd9c3c41b813765f"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/druid-shell/Cargo.lock
+++ b/druid-shell/Cargo.lock
@@ -180,11 +180,9 @@ dependencies = [
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.2",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -420,7 +418,6 @@ dependencies = [
 [[package]]
 name = "piet"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -428,51 +425,43 @@ dependencies = [
 [[package]]
 name = "piet-cairo"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
 ]
 
 [[package]]
 name = "piet-common"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-cairo 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-direct2d 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-web 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
+ "piet-cairo 0.0.2",
+ "piet-direct2d 0.0.2",
+ "piet-web 0.0.2",
 ]
 
 [[package]]
 name = "piet-direct2d"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.2",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -845,11 +834,6 @@ dependencies = [
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
-"checksum piet 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1c80a4f78b007b0e317e46926daa8e93eecd97d4ecba6dcf99502a6c3c05c8"
-"checksum piet-cairo 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6bb723ae52a0b0d3b834564e8ab022afaca775d7b08de2d99d56e23e43fd8ed3"
-"checksum piet-common 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95b5830eca10c9de0ed1454237cac28e66181b185518be1e8811f6e5b486ad8b"
-"checksum piet-direct2d 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38147f6e1668ad1c725374f26e58fa6785fdc487ca7527ab91116198edb35bcf"
-"checksum piet-web 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec8a5d1053c0e2ded9e12ddd4097c0943c15ef29a8333d974690d7b66f62bda2"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-piet-common = "0.0.2"
-piet = "0.0.2"
+piet-common = { path = "../../fontville/piet/piet-common" }
+#piet-common = "0.0.2"
 
 lazy_static = "1.0"
 time = "0.1.39"
@@ -32,6 +32,3 @@ cocoa = "0.18.4"
 objc = "0.2.5"
 core-graphics = "0.17.3"
 cairo-rs = { version = "0.5.0", default_features = false }
-
-[dev-dependencies]
-kurbo = "0.2.1"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2018"
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-piet-common = { path = "../../fontville/piet/piet-common" }
-#piet-common = "0.0.2"
+piet-common = "0.0.3"
 
 lazy_static = "1.0"
 time = "0.1.39"

--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate druid_shell;
-extern crate kurbo;
-extern crate piet;
-extern crate piet_common;
-
 use std::any::Any;
 use std::cell::RefCell;
 
-use kurbo::{Line, Rect};
-use piet::{FillRule, RenderContext};
+use piet_common::kurbo::{Line, Rect};
+use piet_common::{FillRule, RenderContext};
 
 use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 use druid_shell::keycodes::MenuKey;

--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 use std::cell::RefCell;
 
 use piet_common::kurbo::{Line, Rect};
-use piet_common::{FillRule, RenderContext};
+use piet_common::{Color, FillRule, RenderContext};
 
 use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 use druid_shell::keycodes::MenuKey;
@@ -24,6 +24,9 @@ use druid_shell::menu::Menu;
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
 use druid_shell::window::{MouseEvent, WinHandler, WindowHandle};
+
+const BG_COLOR: Color = Color::rgb24(0x27_28_22);
+const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
 
 #[derive(Default)]
 struct HelloState {
@@ -37,8 +40,8 @@ impl WinHandler for HelloState {
     }
 
     fn paint(&self, rc: &mut piet_common::Piet) -> bool {
-        let bg = rc.solid_brush(0x272822ff).unwrap();
-        let fg = rc.solid_brush(0xf0f0eaff).unwrap();
+        let bg = rc.solid_brush(BG_COLOR);
+        let fg = rc.solid_brush(FG_COLOR);
         let (width, height) = *self.size.borrow();
         let rect = Rect::new(0.0, 0.0, width, height);
         rc.fill(rect, &bg, FillRule::NonZero);

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -18,7 +18,7 @@ use std::cell::RefCell;
 use time::get_time;
 
 use piet_common::kurbo::{Line, Rect};
-use piet_common::{FillRule, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
+use piet_common::{Color, FillRule, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
 #[cfg(target_os = "windows")]
 use druid_shell::platform::PresentStrategy;
@@ -26,6 +26,9 @@ use druid_shell::platform::PresentStrategy;
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
 use druid_shell::window::{WinHandler, WindowHandle};
+
+const BG_COLOR: Color = Color::rgb24(0x27_28_22);
+const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
 
 struct PerfTest(RefCell<PerfState>);
 
@@ -43,8 +46,8 @@ impl WinHandler for PerfTest {
     fn paint(&self, rc: &mut Piet) -> bool {
         let mut state = self.0.borrow_mut();
         let (width, height) = state.size;
-        let bg = rc.solid_brush(0x272822ff).unwrap();
-        let fg = rc.solid_brush(0xf0f0eaff).unwrap();
+        let bg = rc.solid_brush(BG_COLOR);
+        let fg = rc.solid_brush(FG_COLOR);
         let rect = Rect::new(0.0, 0.0, width, height);
         rc.fill(rect, &bg, FillRule::NonZero);
 

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -12,19 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate druid_shell;
-extern crate kurbo;
-extern crate piet;
-extern crate piet_common;
-extern crate time;
-
 use std::any::Any;
 use std::cell::RefCell;
 
 use time::get_time;
 
-use kurbo::{Line, Rect};
-use piet::{FillRule, FontBuilder, RenderContext, Text, TextLayoutBuilder};
+use piet_common::kurbo::{Line, Rect};
+use piet_common::{FillRule, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
 #[cfg(target_os = "windows")]
 use druid_shell::platform::PresentStrategy;
@@ -46,7 +40,7 @@ impl WinHandler for PerfTest {
         self.0.borrow_mut().handle = handle.clone();
     }
 
-    fn paint(&self, rc: &mut piet_common::Piet) -> bool {
+    fn paint(&self, rc: &mut Piet) -> bool {
         let mut state = self.0.borrow_mut();
         let (width, height) = state.size;
         let bg = rc.solid_brush(0x272822ff).unwrap();

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -14,6 +14,9 @@
 
 //! Platform abstraction for druid toolkit.
 
+pub use piet_common as piet;
+pub use piet_common::kurbo;
+
 #[cfg(target_os = "windows")]
 #[macro_use]
 extern crate winapi;

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -40,8 +40,7 @@ use std::sync::{Arc, Mutex, Weak};
 
 use cairo::{Context, QuartzSurface};
 
-use piet::RenderContext;
-use piet_common::Piet;
+use piet_common::{Piet, RenderContext};
 
 use crate::platform::dialog::{FileDialogOptions, FileDialogType};
 use crate::util::make_nsstring;

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -52,7 +52,7 @@ use direct2d;
 use direct2d::math::SizeU;
 use direct2d::render_target::{GenericRenderTarget, HwndRenderTarget, RenderTarget};
 
-use piet::RenderContext;
+use piet_common::{Piet, RenderContext};
 
 use crate::menu::Menu;
 use crate::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
@@ -215,7 +215,7 @@ impl MyWndProc {
         rt.begin_draw();
         let anim;
         {
-            let mut piet_ctx = piet_common::Piet::new(&self.d2d_factory, &self.dwrite_factory, rt);
+            let mut piet_ctx = Piet::new(&self.d2d_factory, &self.dwrite_factory, rt);
             anim = self.handler.paint(&mut piet_ctx);
             if let Err(e) = piet_ctx.finish() {
                 // TODO: use proper log infrastructure

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -14,22 +14,17 @@
 
 //! Example of animation frames.
 
-extern crate druid;
-extern crate druid_shell;
-extern crate kurbo;
-extern crate piet;
-
-use kurbo::Line;
-use piet::RenderContext;
+use druid::kurbo::Line;
+use druid::piet::RenderContext;
 
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
 
-use druid::{Ui, UiMain, UiState};
-
 use druid::widget::Widget;
-use druid::{BoxConstraints, Geometry, LayoutResult};
-use druid::{HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx};
+use druid::{
+    BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, MouseEvent, PaintCtx, Ui,
+    UiMain, UiState,
+};
 
 /// A custom widget with animations.
 struct AnimWidget(f32);

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -15,7 +15,7 @@
 //! Example of animation frames.
 
 use druid::kurbo::Line;
-use druid::piet::RenderContext;
+use druid::piet::{Color, RenderContext};
 
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
@@ -26,12 +26,14 @@ use druid::{
     UiMain, UiState,
 };
 
+const BG_COLOR: Color = Color::rgb24(0xfb_f8_ef);
+
 /// A custom widget with animations.
 struct AnimWidget(f32);
 
 impl Widget for AnimWidget {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
-        let fg = paint_ctx.render_ctx.solid_brush(0xf0f0eaff).unwrap();
+        let fg = paint_ctx.render_ctx.solid_brush(BG_COLOR);
         let (x, y) = geom.pos;
         paint_ctx.render_ctx.stroke(
             Line::new(

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -15,7 +15,7 @@
 //! Sample GUI app.
 
 use druid::kurbo::Rect;
-use druid::piet::{FillRule, RenderContext};
+use druid::piet::{Color, FillRule, RenderContext};
 
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
@@ -26,6 +26,9 @@ use druid::{
     UiState,
 };
 
+const BG_COLOR: Color = Color::rgb24(0xfb_f8_ef);
+const MOUSE_BOX_COLOR: Color = Color::rgb24(0xb8_32_5a);
+
 struct FooWidget {
     pos: (f64, f64),
     size: (f64, f64),
@@ -33,9 +36,9 @@ struct FooWidget {
 
 impl Widget for FooWidget {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
-        paint_ctx.render_ctx.clear(0xfbf8ef);
+        paint_ctx.render_ctx.clear(BG_COLOR);
 
-        let fg = paint_ctx.render_ctx.solid_brush(0xb8325aff).unwrap();
+        let fg = paint_ctx.render_ctx.solid_brush(MOUSE_BOX_COLOR);
         let (x, y) = geom.pos;
         let (x, y) = (x as f64, y as f64);
         let (x, y) = (x + self.pos.0, y + self.pos.1);

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -14,24 +14,17 @@
 
 //! Sample GUI app.
 
-extern crate druid;
-extern crate druid_shell;
-extern crate kurbo;
-extern crate piet;
-
-use kurbo::Rect;
-use piet::FillRule;
-use piet::RenderContext;
+use druid::kurbo::Rect;
+use druid::piet::{FillRule, RenderContext};
 
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
 
-use druid::{Ui, UiMain, UiState};
-
 use druid::widget::{ScrollEvent, Widget};
-use druid::HandlerCtx;
-use druid::{BoxConstraints, Geometry, LayoutResult};
-use druid::{Id, LayoutCtx, PaintCtx};
+use druid::{
+    BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui, UiMain,
+    UiState,
+};
 
 struct FooWidget {
     pos: (f64, f64),

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -15,7 +15,7 @@
 //! Sample GUI app.
 
 use druid::kurbo::Line;
-use druid::piet::RenderContext;
+use druid::piet::{Color, RenderContext};
 
 use druid_shell::keycodes::MenuKey;
 use druid_shell::menu::Menu;
@@ -28,6 +28,7 @@ use druid::{
     PaintCtx, Ui, UiMain, UiState,
 };
 
+const STROKECOLOR: Color = Color::rgb24(0xfb_f8_ef);
 const COMMAND_EXIT: u32 = 0x100;
 const COMMAND_OPEN: u32 = 0x101;
 
@@ -36,7 +37,7 @@ struct FooWidget;
 
 impl Widget for FooWidget {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
-        let fg = paint_ctx.render_ctx.solid_brush(0xf0f0eaff).unwrap();
+        let fg = paint_ctx.render_ctx.solid_brush(STROKECOLOR);
 
         let (x, y) = geom.pos;
         paint_ctx.render_ctx.stroke(

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -14,26 +14,19 @@
 
 //! Sample GUI app.
 
-extern crate druid;
-extern crate druid_shell;
-extern crate kurbo;
-extern crate piet;
-
-use kurbo::Line;
-use piet::RenderContext;
+use druid::kurbo::Line;
+use druid::piet::RenderContext;
 
 use druid_shell::keycodes::MenuKey;
 use druid_shell::menu::Menu;
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
 
-use druid::widget::{Button, Padding, Row};
-use druid::{FileDialogOptions, FileDialogType};
-use druid::{Ui, UiMain, UiState};
-
-use druid::widget::Widget;
-use druid::{BoxConstraints, Geometry, LayoutResult};
-use druid::{Id, LayoutCtx, PaintCtx};
+use druid::widget::{Button, Padding, Row, Widget};
+use druid::{
+    BoxConstraints, FileDialogOptions, FileDialogType, Geometry, Id, LayoutCtx, LayoutResult,
+    PaintCtx, Ui, UiMain, UiState,
+};
 
 const COMMAND_EXIT: u32 = 0x100;
 const COMMAND_OPEN: u32 = 0x101;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
-use druid_shell::piet::{Piet, RenderContext};
+use druid_shell::piet::{Color, Piet, RenderContext};
 
 use druid_shell::application::Application;
 pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
@@ -38,6 +38,9 @@ pub mod widget;
 use graph::Graph;
 use widget::NullWidget;
 pub use widget::{KeyEvent, KeyVariant, MouseEvent, Widget};
+
+//FIXME: this should come from a theme or environment at some point.
+const BACKGROUND_COLOR: Color = Color::rgb24(0x27_28_22);
 
 /// The top-level handler for the UI.
 ///
@@ -928,7 +931,7 @@ impl WinHandler for UiMain {
         let mut state = self.state.borrow_mut();
         state.anim_frame();
         {
-            paint_ctx.clear(0x272822);
+            paint_ctx.clear(BACKGROUND_COLOR);
         }
         let root = state.graph.root;
         let bc = BoxConstraints::tight(state.inner.layout_ctx.size);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 
 //! Simple entity-component-system based GUI.
 
+pub use druid_shell::{kurbo, piet};
+
 use std::any::Any;
 use std::cell::RefCell;
 use std::char;
@@ -23,7 +25,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
-use piet::RenderContext;
+use druid_shell::piet::{Piet, RenderContext};
 
 use druid_shell::application::Application;
 pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
@@ -180,7 +182,7 @@ pub struct PaintCtx<'a, 'b: 'a> {
     is_active: bool,
     is_hot: bool,
     is_focused: bool,
-    pub render_ctx: &'a mut piet_common::Piet<'b>,
+    pub render_ctx: &'a mut Piet<'b>,
 }
 
 #[derive(Debug)]
@@ -649,7 +651,7 @@ impl Ui {
     // The following methods are really UiState methods, but don't need access to listeners
     // so are more concise to implement here.
 
-    fn paint(&mut self, render_ctx: &mut piet_common::Piet, root: Id) {
+    fn paint(&mut self, render_ctx: &mut Piet, root: Id) {
         // Do pre-order traversal on graph, painting each node in turn.
         //
         // Implemented as a recursion, but we could use an explicit queue instead.
@@ -922,7 +924,7 @@ impl WinHandler for UiMain {
         state.dispatch_events();
     }
 
-    fn paint(&self, paint_ctx: &mut piet_common::Piet) -> bool {
+    fn paint(&self, paint_ctx: &mut Piet) -> bool {
         let mut state = self.state.borrow_mut();
         state.anim_frame();
         {

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -17,11 +17,16 @@
 use std::any::Any;
 
 use crate::kurbo::Rect;
-use crate::piet::{FillRule, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
+use crate::piet::{Color, FillRule, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
 use crate::widget::Widget;
 use crate::{BoxConstraints, Geometry, LayoutResult};
 use crate::{HandlerCtx, Id, LayoutCtx, MouseEvent, PaintCtx, Ui};
+
+const BUTTON_BG_COLOR: Color = Color::rgba32(0x40_40_48_ff);
+const BUTTON_HOVER_COLOR: Color = Color::rgba32(0x50_50_58_ff);
+const BUTTON_PRESSED_COLOR: Color = Color::rgba32(0x60_60_68_ff);
+const LABEL_TEXT_COLOR: Color = Color::rgba32(0xf0_f0_ea_ff);
 
 /// A text label with no interaction.
 pub struct Label {
@@ -64,7 +69,7 @@ impl Widget for Label {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
         let font_size = 15.0;
         let text_layout = self.get_layout(paint_ctx.render_ctx, font_size);
-        let brush = paint_ctx.render_ctx.solid_brush(0xf0f0eaff).unwrap();
+        let brush = paint_ctx.render_ctx.solid_brush(LABEL_TEXT_COLOR);
 
         let pos = (geom.pos.0, geom.pos.1 + font_size);
         paint_ctx.render_ctx.draw_text(&text_layout, pos, &brush);
@@ -111,11 +116,11 @@ impl Widget for Button {
             let is_active = paint_ctx.is_active();
             let is_hot = paint_ctx.is_hot();
             let bg_color = match (is_active, is_hot) {
-                (true, true) => 0x606068ff,
-                (false, true) => 0x505058ff,
-                _ => 0x404048ff,
+                (true, true) => BUTTON_PRESSED_COLOR,
+                (false, true) => BUTTON_HOVER_COLOR,
+                _ => BUTTON_BG_COLOR,
             };
-            let brush = paint_ctx.render_ctx.solid_brush(bg_color).unwrap();
+            let brush = paint_ctx.render_ctx.solid_brush(bg_color);
             let (x, y) = geom.pos;
             let (width, height) = geom.size;
             let rect = Rect::new(

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -16,9 +16,8 @@
 
 use std::any::Any;
 
-use kurbo::Rect;
-use piet::{FillRule, FontBuilder, RenderContext, Text, TextLayoutBuilder};
-use piet_common::Piet;
+use crate::kurbo::Rect;
+use crate::piet::{FillRule, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
 use crate::widget::Widget;
 use crate::{BoxConstraints, Geometry, LayoutResult};

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -20,9 +20,11 @@ use crate::widget::Widget;
 use crate::{BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui};
 
 use crate::kurbo::Rect;
-use crate::piet::{FillRule, RenderContext};
+use crate::piet::{Color, FillRule, RenderContext};
 
 const BOX_HEIGHT: f64 = 24.;
+const BACKGROUND_COLOR: Color = Color::rgb24(0x55_55_55);
+const BAR_COLOR: Color = Color::rgb24(0xf0_f0_ea);
 
 pub struct ProgressBar {
     value: f64,
@@ -41,11 +43,8 @@ impl ProgressBar {
 
 impl Widget for ProgressBar {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
-        let background_color = 0x55_55_55_ff;
-        let bar_color = 0xf0f0eaff;
-
         //Paint the background
-        let brush = paint_ctx.render_ctx.solid_brush(background_color).unwrap();
+        let brush = paint_ctx.render_ctx.solid_brush(BACKGROUND_COLOR);
 
         let (x, y) = geom.pos;
         let (width, height) = geom.size;
@@ -59,7 +58,7 @@ impl Widget for ProgressBar {
         paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
 
         //Paint the bar
-        let brush = paint_ctx.render_ctx.solid_brush(bar_color).unwrap();
+        let brush = paint_ctx.render_ctx.solid_brush(BAR_COLOR);
 
         let (width, height) = geom.size;
         let (x, y) = geom.pos;

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -19,8 +19,8 @@ use std::any::Any;
 use crate::widget::Widget;
 use crate::{BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui};
 
-use kurbo::Rect;
-use piet::{FillRule, RenderContext};
+use crate::kurbo::Rect;
+use crate::piet::{FillRule, RenderContext};
 
 const BOX_HEIGHT: f64 = 24.;
 

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -20,9 +20,11 @@ use crate::{
 };
 
 use crate::kurbo::Rect;
-use crate::piet::{FillRule, RenderContext};
+use crate::piet::{Color, FillRule, RenderContext};
 
 const BOX_HEIGHT: f64 = 24.;
+const BACKGROUND_COLOR: Color = Color::rgb24(0x55_55_55);
+const SLIDER_COLOR: Color = Color::rgb24(0xf0_f0_ea);
 
 pub struct Slider {
     value: f64,
@@ -42,11 +44,8 @@ impl Slider {
 
 impl Widget for Slider {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
-        let background_color = 0x55_55_55_ff;
-        let slider_color = 0xf0f0eaff;
-
         //Paint the background
-        let brush = paint_ctx.render_ctx.solid_brush(background_color).unwrap();
+        let brush = paint_ctx.render_ctx.solid_brush(BACKGROUND_COLOR);
 
         let (x, y) = geom.pos;
         let (width, height) = geom.size;
@@ -60,7 +59,7 @@ impl Widget for Slider {
         paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
 
         //Paint the slider
-        let brush = paint_ctx.render_ctx.solid_brush(slider_color).unwrap();
+        let brush = paint_ctx.render_ctx.solid_brush(SLIDER_COLOR);
 
         let (width, height) = geom.size;
         let (width, height) = (width as f64, height as f64);

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -19,8 +19,8 @@ use crate::{
     BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, MouseEvent, PaintCtx, Ui,
 };
 
-use kurbo::Rect;
-use piet::{FillRule, RenderContext};
+use crate::kurbo::Rect;
+use crate::piet::{FillRule, RenderContext};
 
 const BOX_HEIGHT: f64 = 24.;
 

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -20,9 +20,10 @@ use crate::{
     MouseEvent, PaintCtx, Ui,
 };
 
-use kurbo::{Line, Rect};
-use piet::{FillRule, FontBuilder, RenderContext, Text, TextLayout, TextLayoutBuilder};
-use piet_common::Piet;
+use crate::kurbo::{Line, Rect};
+use crate::piet::{
+    FillRule, FontBuilder, Piet, RenderContext, Text, TextLayout, TextLayoutBuilder,
+};
 
 const BOX_HEIGHT: f32 = 24.;
 const BORDER_WIDTH: f32 = 2.;

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -22,8 +22,13 @@ use crate::{
 
 use crate::kurbo::{Line, Rect};
 use crate::piet::{
-    FillRule, FontBuilder, Piet, RenderContext, Text, TextLayout, TextLayoutBuilder,
+    Color, FillRule, FontBuilder, Piet, RenderContext, Text, TextLayout, TextLayoutBuilder,
 };
+
+const ACTIVE_BORDER_COLOR: Color = Color::rgb24(0xff_00_00);
+const INACTIVE_BORDER_COLOR: Color = Color::rgb24(0x55_55_55);
+const TEXT_COLOR: Color = Color::rgb24(0xf0_f0_ea);
+const CURSOR_COLOR: Color = Color::WHITE;
 
 const BOX_HEIGHT: f32 = 24.;
 const BORDER_WIDTH: f32 = 2.;
@@ -82,17 +87,12 @@ impl TextBox {
 impl Widget for TextBox {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
         let border_color = if paint_ctx.is_focused() {
-            // Create active color
-            0xff_00_00_ff
+            ACTIVE_BORDER_COLOR
         } else {
-            // Create inactive color
-            0x55_55_55_ff
+            INACTIVE_BORDER_COLOR
         };
-
-        let text_color = 0xf0f0eaff;
-
         // Paint the border
-        let brush = paint_ctx.render_ctx.solid_brush(border_color).unwrap();
+        let brush = paint_ctx.render_ctx.solid_brush(border_color);
 
         let (x, y) = geom.pos;
         let (width, height) = geom.size;
@@ -117,7 +117,7 @@ impl Widget for TextBox {
         // Paint the text
         let font_size = BOX_HEIGHT - 4.;
         let text_layout = self.get_layout(paint_ctx.render_ctx, font_size);
-        let brush = paint_ctx.render_ctx.solid_brush(text_color).unwrap();
+        let brush = paint_ctx.render_ctx.solid_brush(TEXT_COLOR);
 
         let pos = (geom.pos.0, geom.pos.1 + font_size);
 
@@ -132,7 +132,7 @@ impl Widget for TextBox {
 
                 // Paint the cursor if focused
                 if focused {
-                    let brush = rc.solid_brush(0xffffffff).unwrap();
+                    let brush = rc.solid_brush(CURSOR_COLOR);
 
                     let (x, y) = (
                         geom.pos.0 + text_layout.width() as f32 + 2.,


### PR DESCRIPTION
This fixes breakage from upstream changes, and takes advantage of the fact that `piet-common` now reexports `piet` and `kurbo`.

