### PR TITLE
Use kurbo geometry types

### DIFF
--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -14,7 +14,7 @@
 
 //! Example of animation frames.
 
-use druid::kurbo::Line;
+use druid::kurbo::{Line, Rect, Size, Vec2};
 use druid::piet::{Color, RenderContext};
 
 use druid_shell::platform::WindowBuilder;
@@ -22,26 +22,22 @@ use druid_shell::win_main;
 
 use druid::widget::Widget;
 use druid::{
-    BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, MouseEvent, PaintCtx, Ui,
-    UiMain, UiState,
+    BoxConstraints, HandlerCtx, Id, LayoutCtx, LayoutResult, MouseEvent, PaintCtx, Ui, UiMain,
+    UiState,
 };
 
 const BG_COLOR: Color = Color::rgb24(0xfb_f8_ef);
 
 /// A custom widget with animations.
-struct AnimWidget(f32);
+struct AnimWidget(f64);
 
 impl Widget for AnimWidget {
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Rect) {
         let fg = paint_ctx.render_ctx.solid_brush(BG_COLOR);
-        let (x, y) = geom.pos;
         paint_ctx.render_ctx.stroke(
             Line::new(
-                (x as f64, y as f64),
-                (
-                    x as f64 + geom.size.0 as f64,
-                    y as f64 + self.0 as f64 * geom.size.1 as f64,
-                ),
+                geom.origin(),
+                geom.origin() + Vec2::new(geom.width(), self.0 * geom.height()),
             ),
             &fg,
             1.0,
@@ -53,17 +49,17 @@ impl Widget for AnimWidget {
         &mut self,
         bc: &BoxConstraints,
         _children: &[Id],
-        _size: Option<(f32, f32)>,
+        _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain((100.0, 100.0)))
+        LayoutResult::Size(bc.constrain(Size::new(100.0, 100.0)))
     }
 
     fn anim_frame(&mut self, interval: u64, ctx: &mut HandlerCtx) {
         println!("anim frame, interval={}", interval);
         if self.0 > 0.0 {
             ctx.request_anim_frame();
-            self.0 = (self.0 - 1e-9 * (interval as f32)).max(0.0);
+            self.0 = (self.0 - 1e-9 * (interval as f64)).max(0.0);
         }
         ctx.invalidate();
     }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -14,7 +14,7 @@
 
 //! Sample GUI app.
 
-use druid::kurbo::Rect;
+use druid::kurbo::{Point, Rect, Size};
 use druid::piet::{Color, FillRule, RenderContext};
 
 use druid_shell::platform::WindowBuilder;
@@ -22,29 +22,25 @@ use druid_shell::win_main;
 
 use druid::widget::{ScrollEvent, Widget};
 use druid::{
-    BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui, UiMain,
-    UiState,
+    BoxConstraints, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui, UiMain, UiState,
 };
 
 const BG_COLOR: Color = Color::rgb24(0xfb_f8_ef);
 const MOUSE_BOX_COLOR: Color = Color::rgb24(0xb8_32_5a);
 
 struct FooWidget {
-    pos: (f64, f64),
-    size: (f64, f64),
+    pos: Point,
+    size: Size,
 }
 
 impl Widget for FooWidget {
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Rect) {
         paint_ctx.render_ctx.clear(BG_COLOR);
 
         let fg = paint_ctx.render_ctx.solid_brush(MOUSE_BOX_COLOR);
-        let (x, y) = geom.pos;
-        let (x, y) = (x as f64, y as f64);
-        let (x, y) = (x + self.pos.0, y + self.pos.1);
-
+        let pos = self.pos + geom.origin().to_vec2();
         paint_ctx.render_ctx.fill(
-            Rect::new(x, y, x + self.size.0, y + self.size.1),
+            Rect::from_origin_size(pos, self.size),
             &fg,
             FillRule::NonZero,
         );
@@ -54,20 +50,20 @@ impl Widget for FooWidget {
         &mut self,
         bc: &BoxConstraints,
         _children: &[Id],
-        _size: Option<(f32, f32)>,
+        _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain((100.0, 100.0)))
+        LayoutResult::Size(bc.constrain(Size::new(100.0, 100.0)))
     }
 
     fn scroll(&mut self, event: &ScrollEvent, ctx: &mut HandlerCtx) {
-        self.size.0 += event.dx as f64;
-        self.size.1 += event.dy as f64;
+        self.size.width += event.dx as f64;
+        self.size.height += event.dy as f64;
         ctx.invalidate();
     }
 
-    fn mouse_moved(&mut self, x: f32, y: f32, ctx: &mut HandlerCtx) {
-        self.pos = (x as f64, y as f64);
+    fn mouse_moved(&mut self, pos: Point, ctx: &mut HandlerCtx) {
+        self.pos = pos;
         ctx.invalidate();
     }
 }
@@ -75,8 +71,8 @@ impl Widget for FooWidget {
 impl FooWidget {
     fn new() -> Self {
         Self {
-            pos: (10.0, 10.0),
-            size: (40.0, 40.0),
+            pos: Point::new(10.0, 10.0),
+            size: Size::new(40.0, 40.0),
         }
     }
 

--- a/examples/new-widgets.rs
+++ b/examples/new-widgets.rs
@@ -17,12 +17,8 @@
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
 
-use druid::widget::{
-    Column, EventForwarder, KeyListener, Label, Padding, ProgressBar, Row, Slider, TextBox,
-};
-use druid::{KeyEvent, KeyVariant, UiMain, UiState};
-
-use druid::Id;
+use druid::widget::{Column, Label, Padding, ProgressBar, Row, Slider, TextBox};
+use druid::{Id, UiMain, UiState};
 
 fn pad(widget: Id, state: &mut UiState) -> Id {
     Padding::uniform(5.0).ui(widget, state)

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -14,7 +14,7 @@
 
 //! Sample GUI app.
 
-use druid::kurbo::Line;
+use druid::kurbo::{Line, Rect, Size};
 use druid::piet::{Color, RenderContext};
 
 use druid_shell::keycodes::MenuKey;
@@ -24,8 +24,8 @@ use druid_shell::win_main;
 
 use druid::widget::{Button, Padding, Row, Widget};
 use druid::{
-    BoxConstraints, FileDialogOptions, FileDialogType, Geometry, Id, LayoutCtx, LayoutResult,
-    PaintCtx, Ui, UiMain, UiState,
+    BoxConstraints, FileDialogOptions, FileDialogType, Id, LayoutCtx, LayoutResult, PaintCtx, Ui,
+    UiMain, UiState,
 };
 
 const STROKECOLOR: Color = Color::rgb24(0xfb_f8_ef);
@@ -36,15 +36,10 @@ const COMMAND_OPEN: u32 = 0x101;
 struct FooWidget;
 
 impl Widget for FooWidget {
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Rect) {
         let fg = paint_ctx.render_ctx.solid_brush(STROKECOLOR);
-
-        let (x, y) = geom.pos;
         paint_ctx.render_ctx.stroke(
-            Line::new(
-                (x as f64, y as f64),
-                (x as f64 + geom.size.0 as f64, y as f64 + geom.size.1 as f64),
-            ),
+            Line::new(geom.origin(), geom.origin() + geom.size().to_vec2()),
             &fg,
             1.0,
             None,
@@ -55,10 +50,10 @@ impl Widget for FooWidget {
         &mut self,
         bc: &BoxConstraints,
         _children: &[Id],
-        _size: Option<(f32, f32)>,
+        _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain((100.0, 100.0)))
+        LayoutResult::Size(bc.constrain(Size::new(100.0, 100.0)))
     }
 }
 

--- a/examples/typing.rs
+++ b/examples/typing.rs
@@ -20,7 +20,7 @@ extern crate druid_shell;
 use druid_shell::platform::WindowBuilder;
 use druid_shell::win_main;
 
-use druid::widget::{Column, EventForwarder, KeyListener, Label, Padding, Row};
+use druid::widget::{Column, EventForwarder, KeyListener, Label, Padding};
 use druid::{KeyEvent, KeyVariant, UiMain, UiState};
 
 use druid::Id;
@@ -67,7 +67,7 @@ fn build_typing(ui: &mut UiState) {
     let display = Label::new("".to_string()).ui(ui);
     let row0 = pad(display, ui);
 
-    let mut column = Column::new();
+    let column = Column::new();
 
     let panel = column.ui(&[row0], ui);
     let key_listener = KeyListener::new().ui(panel, ui);

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -18,7 +18,8 @@ use std::any::Any;
 
 pub use druid_shell::window::{MouseButton, ScrollEvent};
 
-use crate::{BoxConstraints, Geometry, LayoutResult};
+use crate::kurbo::{Point, Rect, Size};
+use crate::{BoxConstraints, LayoutResult};
 use crate::{HandlerCtx, Id, LayoutCtx, PaintCtx};
 
 mod button;
@@ -55,7 +56,7 @@ pub trait Widget {
     /// The implementer is responsible for translating the coordinates as
     /// specified in the geometry.
     #[allow(unused)]
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {}
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Rect) {}
 
     /// Participate in the layout protocol.
     ///
@@ -67,12 +68,12 @@ pub trait Widget {
         &mut self,
         bc: &BoxConstraints,
         children: &[Id],
-        size: Option<(f32, f32)>,
+        size: Option<Size>,
         ctx: &mut LayoutCtx,
     ) -> LayoutResult {
         if let Some(size) = size {
             // Maybe this is not necessary, rely on default value.
-            ctx.position_child(children[0], (0.0, 0.0));
+            ctx.position_child(children[0], Point::ORIGIN);
             LayoutResult::Size(size)
         } else {
             LayoutResult::RequestChild(children[0], *bc)
@@ -91,7 +92,7 @@ pub trait Widget {
     /// Sent to the active or hot widget on mouse move events.
     // TODO: should mods be plumbed here?
     #[allow(unused)]
-    fn mouse_moved(&mut self, x: f32, y: f32, ctx: &mut HandlerCtx) {}
+    fn mouse_moved(&mut self, pos: Point, ctx: &mut HandlerCtx) {}
 
     /// Sent to the widget when its "hot" status changes.
     #[allow(unused)]
@@ -154,10 +155,8 @@ pub trait Widget {
 
 #[derive(Debug, Clone)]
 pub struct MouseEvent {
-    /// X coordinate in px units, relative to top left of widget.
-    pub x: f32,
-    /// Y coordinate in px units, relative to top left of widget.
-    pub y: f32,
+    /// The location of the event.
+    pub pos: Point,
     /// The modifiers, which have the same interpretation as the raw WM message.
     ///
     /// TODO: rationalize this with mouse mods.

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -14,21 +14,22 @@
 
 //! A widget that just adds padding during layout.
 
+use crate::kurbo::Size;
 use crate::widget::Widget;
 use crate::{BoxConstraints, LayoutResult};
 use crate::{Id, LayoutCtx, Ui};
 
 /// A padding widget. Is expected to have exactly one child.
 pub struct Padding {
-    left: f32,
-    right: f32,
-    top: f32,
-    bottom: f32,
+    left: f64,
+    right: f64,
+    top: f64,
+    bottom: f64,
 }
 
 impl Padding {
     /// Create widget with uniform padding.
-    pub fn uniform(padding: f32) -> Padding {
+    pub fn uniform(padding: f64) -> Padding {
         Padding {
             left: padding,
             right: padding,
@@ -47,23 +48,18 @@ impl Widget for Padding {
         &mut self,
         bc: &BoxConstraints,
         children: &[Id],
-        size: Option<(f32, f32)>,
+        size: Option<Size>,
         ctx: &mut LayoutCtx,
     ) -> LayoutResult {
+        let hpad = self.left + self.right;
+        let vpad = self.top + self.bottom;
         if let Some(size) = size {
             ctx.position_child(children[0], (self.left, self.top));
-            LayoutResult::Size((
-                size.0 + self.left + self.right,
-                size.1 + self.top + self.bottom,
-            ))
+            LayoutResult::Size(Size::new(size.width + hpad, size.height + vpad))
         } else {
-            let child_bc = BoxConstraints {
-                min_width: bc.min_width - (self.left + self.right),
-                max_width: bc.max_width - (self.left + self.right),
-                min_height: bc.min_height - (self.top + self.bottom),
-                max_height: bc.max_height - (self.top + self.bottom),
-            };
-            LayoutResult::RequestChild(children[0], child_bc)
+            let min = Size::new(bc.min.width - hpad, bc.min.height - hpad);
+            let max = Size::new(bc.max.width - hpad, bc.max.height - hpad);
+            LayoutResult::RequestChild(children[0], BoxConstraints::new(min, max))
         }
     }
 }

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -17,9 +17,9 @@
 use std::any::Any;
 
 use crate::widget::Widget;
-use crate::{BoxConstraints, Geometry, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui};
+use crate::{BoxConstraints, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui};
 
-use crate::kurbo::Rect;
+use crate::kurbo::{Rect, Size};
 use crate::piet::{Color, FillRule, RenderContext};
 
 const BOX_HEIGHT: f64 = 24.;
@@ -42,36 +42,18 @@ impl ProgressBar {
 }
 
 impl Widget for ProgressBar {
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Rect) {
         //Paint the background
         let brush = paint_ctx.render_ctx.solid_brush(BACKGROUND_COLOR);
 
-        let (x, y) = geom.pos;
-        let (width, height) = geom.size;
-        let rect = Rect::new(
-            x as f64,
-            y as f64,
-            x as f64 + width as f64,
-            y as f64 + height as f64,
-        );
-
-        paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
+        paint_ctx.render_ctx.fill(geom, &brush, FillRule::NonZero);
 
         //Paint the bar
         let brush = paint_ctx.render_ctx.solid_brush(BAR_COLOR);
 
-        let (width, height) = geom.size;
-        let (x, y) = geom.pos;
+        let calculated_bar_width = self.value * geom.width() as f64;
 
-        let calculated_bar_width = self.value * width as f64;
-
-        let rect = Rect::new(
-            x as f64,
-            y as f64,
-            x as f64 + calculated_bar_width,
-            y as f64 + height as f64,
-        );
-
+        let rect = geom.with_size(Size::new(calculated_bar_width, geom.height()));
         paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
     }
 
@@ -79,10 +61,10 @@ impl Widget for ProgressBar {
         &mut self,
         bc: &BoxConstraints,
         _children: &[Id],
-        _size: Option<(f32, f32)>,
+        _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain((bc.max_width, BOX_HEIGHT as f32)))
+        LayoutResult::Size(bc.constrain(Size::new(bc.max.width, BOX_HEIGHT as f64)))
     }
 
     fn poke(&mut self, payload: &mut Any, ctx: &mut HandlerCtx) -> bool {


### PR DESCRIPTION
This Replaces various custom geometry types with the `Point`,
`Size`, and `Rect` types from kurbo, and uses f64 instead
of f32 wherever possible.

In general I've tried to keep these changes in `druid`, and not
touch `druid-shell` much.