### PR TITLE
Druid v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,14 +173,14 @@ dependencies = [
 
 [[package]]
 name = "druid"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "druid-shell 0.2.0",
+ "druid-shell 0.3.0",
 ]
 
 [[package]]
 name = "druid-shell"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -189,7 +189,7 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,24 +424,24 @@ dependencies = [
 
 [[package]]
 name = "piet"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-cairo"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-common"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -449,31 +449,31 @@ dependencies = [
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-cairo 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-direct2d 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-web 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-direct2d"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -829,7 +829,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9987e7c13a91d9cf0efe59cca48a3a7a70e2b11695d5a4640f85ae71e28f5e73"
-"checksum kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "74a2af7a4e1995cf3711d494b399128b80fc8fa9789220c2bdbf640f6708c037"
+"checksum kurbo 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f6ca71ed1844d21b35cad6cbada491ca594dfa3de39f3f17c969538229c6f7c"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -846,11 +846,11 @@ dependencies = [
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
-"checksum piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b55f39da64b1490af57af1defbfbeaf91cf382e3e0d2eec598c31f606e449cf"
-"checksum piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "02c69f1195c0ba740dc67303d71e163a8f0b2f2a82a289bd4ef668f30961996a"
-"checksum piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e5f3a5c27ac4758f7a15927ffb81b0b191242623121b9938a14389f01e1692aa"
-"checksum piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb67f6a62271ae8b28ab0b22b197974949c5f6d6bbb3524136bc48a58dff863"
-"checksum piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f5a9493fd33f9ec3cd1c81aff029fe3c005cef0d5f41645dd9c3c41b813765f"
+"checksum piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e7615303690d378835a7d5ee9344e27df1088f8b4fa321f1714ef022019fd2f4"
+"checksum piet-cairo 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ad708c80e4546e14b6260ea7b87c719e26340127c633df09fa426e1d947f0d3"
+"checksum piet-common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee265553e0105f569cdb89c1ffae54b36abc6ee5a1f3df8134cc0c6ef6abe6ab"
+"checksum piet-direct2d 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5d45be70a9942aab4a7dba139665d4aa4670050a15381b37b0d2f2c3b2fac03"
+"checksum piet-web 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "30e14d2a367752e0e15826fb395de219c5f314698f9aca30cce323334b8f4950"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Data-oriented Rust UI design toolkit."
@@ -17,4 +17,4 @@ travis-ci = { repository = "xi-editor/druid" }
 
 [dependencies.druid-shell]
 path = "druid-shell"
-version = "0.2.0"
+version = "0.3.0"

--- a/druid-shell/Cargo.lock
+++ b/druid-shell/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "druid-shell"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -182,7 +182,7 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -417,24 +417,24 @@ dependencies = [
 
 [[package]]
 name = "piet"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-cairo"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-common"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -442,31 +442,31 @@ dependencies = [
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-cairo 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-direct2d 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-web 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-direct2d"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -822,7 +822,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9987e7c13a91d9cf0efe59cca48a3a7a70e2b11695d5a4640f85ae71e28f5e73"
-"checksum kurbo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "74a2af7a4e1995cf3711d494b399128b80fc8fa9789220c2bdbf640f6708c037"
+"checksum kurbo 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f6ca71ed1844d21b35cad6cbada491ca594dfa3de39f3f17c969538229c6f7c"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -839,11 +839,11 @@ dependencies = [
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
-"checksum piet 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b55f39da64b1490af57af1defbfbeaf91cf382e3e0d2eec598c31f606e449cf"
-"checksum piet-cairo 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "02c69f1195c0ba740dc67303d71e163a8f0b2f2a82a289bd4ef668f30961996a"
-"checksum piet-common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e5f3a5c27ac4758f7a15927ffb81b0b191242623121b9938a14389f01e1692aa"
-"checksum piet-direct2d 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb67f6a62271ae8b28ab0b22b197974949c5f6d6bbb3524136bc48a58dff863"
-"checksum piet-web 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f5a9493fd33f9ec3cd1c81aff029fe3c005cef0d5f41645dd9c3c41b813765f"
+"checksum piet 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e7615303690d378835a7d5ee9344e27df1088f8b4fa321f1714ef022019fd2f4"
+"checksum piet-cairo 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ad708c80e4546e14b6260ea7b87c719e26340127c633df09fa426e1d947f0d3"
+"checksum piet-common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee265553e0105f569cdb89c1ffae54b36abc6ee5a1f3df8134cc0c6ef6abe6ab"
+"checksum piet-direct2d 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5d45be70a9942aab4a7dba139665d4aa4670050a15381b37b0d2f2c3b2fac03"
+"checksum piet-web 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "30e14d2a367752e0e15826fb395de219c5f314698f9aca30cce323334b8f4950"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-shell"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Platform abstracting application shell used for druid toolkit."
@@ -12,7 +12,7 @@ edition = "2018"
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-piet-common = "0.0.3"
+piet-common = "0.0.4"
 
 lazy_static = "1.0"
 time = "0.1.39"

--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -23,7 +23,7 @@ use druid_shell::keyboard::KeyEvent;
 use druid_shell::keycodes::MenuKey;
 use druid_shell::menu::Menu;
 use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
+use druid_shell::runloop;
 use druid_shell::window::{MouseEvent, WinHandler, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb24(0x27_28_22);
@@ -96,7 +96,7 @@ impl WinHandler for HelloState {
     }
 
     fn destroy(&self) {
-        win_main::request_quit();
+        runloop::request_quit();
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -113,7 +113,7 @@ fn main() {
     let mut menubar = Menu::new();
     menubar.add_dropdown(file_menu, "&File");
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -25,7 +25,7 @@ use druid_shell::platform::PresentStrategy;
 
 use druid_shell::keyboard::KeyEvent;
 use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
+use druid_shell::runloop;
 use druid_shell::window::{WinHandler, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb24(0x27_28_22);
@@ -94,7 +94,7 @@ impl WinHandler for PerfTest {
         let x0 = 210.0;
         let y0 = 10.0;
         for i in 0..60 {
-            let y = y0 + (i as f32) * dy;
+            let y = y0 + (i as f64) * dy;
             rc.draw_text(&layout, (x0, y), &fg);
         }
 
@@ -123,7 +123,7 @@ impl WinHandler for PerfTest {
     }
 
     fn destroy(&self) {
-        win_main::request_quit();
+        runloop::request_quit();
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -134,7 +134,7 @@ impl WinHandler for PerfTest {
 fn main() {
     druid_shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let perf_state = PerfState {
         size: Default::default(),

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -51,5 +51,6 @@ pub use platform::application;
 pub use platform::dialog;
 pub use platform::menu;
 pub use platform::util;
-pub use platform::win_main; // TODO: rename to "runloop"
+pub use platform::win_main as runloop; // TODO: rename to "runloop"
+pub use platform::WindowBuilder;
 pub use util::init;

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -164,9 +164,9 @@ pub enum Cursor {
 #[derive(Debug)]
 pub struct ScrollEvent {
     /// The scroll wheel’s horizontal delta.
-    pub dx: f32,
+    pub dx: f64,
     /// The scroll wheel’s vertical delta.
-    pub dy: f32,
+    pub dy: f64,
     /// Modifiers, as in raw WM message
     pub mods: u32,
 }

--- a/druid-shell/src/windows/application.rs
+++ b/druid-shell/src/windows/application.rs
@@ -18,6 +18,6 @@ pub struct Application;
 
 impl Application {
     pub fn quit() {
-        crate::win_main::request_quit();
+        crate::runloop::request_quit();
     }
 }

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -16,9 +16,7 @@
 
 use druid::kurbo::{Line, Rect, Size, Vec2};
 use druid::piet::{Color, RenderContext};
-
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
+use druid::shell::{runloop, WindowBuilder};
 
 use druid::widget::Widget;
 use druid::{
@@ -52,7 +50,7 @@ impl Widget for AnimWidget {
         _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain(Size::new(100.0, 100.0)))
+        LayoutResult::Size(bc.constrain((100.0, 100.0)))
     }
 
     fn anim_frame(&mut self, interval: u64, ctx: &mut HandlerCtx) {
@@ -80,9 +78,9 @@ impl AnimWidget {
 }
 
 fn main() {
-    druid_shell::init();
+    druid::shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
     let anim = AnimWidget(1.0).ui(&mut state);

--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -14,16 +14,9 @@
 
 //! Simple calculator.
 
-extern crate druid;
-extern crate druid_shell;
-
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
-
+use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{Button, Column, EventForwarder, KeyListener, Label, Padding, Row};
-use druid::{KeyCode, KeyEvent, UiMain, UiState};
-
-use druid::Id;
+use druid::{Id, KeyCode, KeyEvent, UiMain, UiState};
 
 struct CalcState {
     /// The number displayed. Generally a valid float.
@@ -267,7 +260,7 @@ fn action_for_key(event: &KeyEvent) -> Option<CalcAction> {
 fn main() {
     druid_shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
     build_calc(&mut state);

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -14,13 +14,9 @@
 
 //! An example of dynamic graph mutation.
 
-extern crate druid;
-extern crate druid_shell;
-
 use std::collections::BTreeMap;
 
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
+use druid::shell::{runloop, WindowBuilder};
 
 use druid::widget::{Button, Column, EventForwarder, Label, Padding, Row};
 use druid::{Id, UiMain, UiState};
@@ -41,9 +37,9 @@ enum Action {
 }
 
 fn main() {
-    druid_shell::init();
+    druid::shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
     let label = Label::new("Selection: None").ui(&mut state);

--- a/examples/ext_event.rs
+++ b/examples/ext_event.rs
@@ -14,21 +14,16 @@
 
 //! Example of sending external events to the UI.
 
-extern crate druid;
-extern crate druid_shell;
-
 use std::{thread, time};
 
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
-
+use druid::shell::{runloop, WindowBuilder};
 use druid::widget::Label;
 use druid::{UiMain, UiState};
 
 fn main() {
-    druid_shell::init();
+    druid::shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
     let label = Label::new("Initial state").ui(&mut state);

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -17,9 +17,7 @@
 use druid::kurbo::{Point, Rect, Size};
 use druid::piet::{Color, FillRule, RenderContext};
 
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
-
+use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{ScrollEvent, Widget};
 use druid::{
     BoxConstraints, HandlerCtx, Id, LayoutCtx, LayoutResult, PaintCtx, Ui, UiMain, UiState,
@@ -53,7 +51,7 @@ impl Widget for FooWidget {
         _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain(Size::new(100.0, 100.0)))
+        LayoutResult::Size(bc.constrain((100.0, 100.0)))
     }
 
     fn scroll(&mut self, event: &ScrollEvent, ctx: &mut HandlerCtx) {
@@ -84,7 +82,7 @@ impl FooWidget {
 fn main() {
     druid_shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
     let foo = FooWidget::new().ui(&mut state);

--- a/examples/new-widgets.rs
+++ b/examples/new-widgets.rs
@@ -14,8 +14,7 @@
 
 //! Simple textbox example.
 
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
+use druid::shell::{runloop, WindowBuilder};
 
 use druid::widget::{Column, Label, Padding, ProgressBar, Row, Slider, TextBox};
 use druid::{Id, KeyEvent, UiMain, UiState};
@@ -25,9 +24,9 @@ fn pad(widget: Id, state: &mut UiState) -> Id {
 }
 
 fn main() {
-    druid_shell::init();
+    druid::shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
 

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -17,10 +17,9 @@
 use druid::kurbo::{Line, Rect, Size};
 use druid::piet::{Color, RenderContext};
 
-use druid_shell::keycodes::MenuKey;
-use druid_shell::menu::Menu;
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
+use druid::shell::keycodes::MenuKey;
+use druid::shell::menu::Menu;
+use druid::shell::{runloop, WindowBuilder};
 
 use druid::widget::{Button, Padding, Row, Widget};
 use druid::{
@@ -53,7 +52,7 @@ impl Widget for FooWidget {
         _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain(Size::new(100.0, 100.0)))
+        LayoutResult::Size(bc.constrain((100.0, 100.0)))
     }
 }
 
@@ -72,7 +71,7 @@ fn main() {
     let mut menubar = Menu::new();
     menubar.add_dropdown(file_menu, "&File");
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
     let foo1 = FooWidget.ui(&mut state);

--- a/examples/typing.rs
+++ b/examples/typing.rs
@@ -17,8 +17,7 @@
 extern crate druid;
 extern crate druid_shell;
 
-use druid_shell::platform::WindowBuilder;
-use druid_shell::win_main;
+use druid::shell::{runloop, WindowBuilder};
 
 use druid::widget::{Column, EventForwarder, KeyListener, Label, Padding};
 use druid::{KeyCode, KeyEvent, UiMain, UiState};
@@ -102,7 +101,7 @@ fn action_for_key(event: &KeyEvent) -> Option<TypingAction> {
 fn main() {
     druid_shell::init();
 
-    let mut run_loop = win_main::RunLoop::new();
+    let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = UiState::new();
     build_typing(&mut state);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Simple entity-component-system based GUI.
 
-pub use druid_shell::{kurbo, piet};
+pub use druid_shell::{self as shell, kurbo, piet};
 
 use std::any::Any;
 use std::cell::RefCell;
@@ -958,7 +958,7 @@ impl WinHandler for UiMain {
         let mut state = self.state.borrow_mut();
         state.handle_scroll(&window::ScrollEvent {
             dx: 0.0,
-            dy: dy as f32,
+            dy: dy as f64,
             mods,
         });
     }
@@ -966,7 +966,7 @@ impl WinHandler for UiMain {
     fn mouse_hwheel(&self, dx: i32, mods: u32) {
         let mut state = self.state.borrow_mut();
         state.handle_scroll(&window::ScrollEvent {
-            dx: dx as f32,
+            dx: dx as f64,
             dy: 0.0,
             mods,
         });

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -49,7 +49,7 @@ impl Label {
         ctx.add(self, &[])
     }
 
-    fn get_layout(&self, rt: &mut Piet, font_size: f32) -> <Piet as RenderContext>::TextLayout {
+    fn get_layout(&self, rt: &mut Piet, font_size: f64) -> <Piet as RenderContext>::TextLayout {
         // TODO: caching of both the format and the layout
         let font = rt
             .text()
@@ -71,10 +71,8 @@ impl Widget for Label {
         let text_layout = self.get_layout(paint_ctx.render_ctx, font_size);
         let brush = paint_ctx.render_ctx.solid_brush(LABEL_TEXT_COLOR);
 
-        let pos = Point::new(geom.origin().x, geom.origin().y + font_size as f64);
-        paint_ctx
-            .render_ctx
-            .draw_text(&text_layout, pos.to_vec2(), &brush);
+        let pos = Point::new(geom.origin().x, geom.origin().y + font_size);
+        paint_ctx.render_ctx.draw_text(&text_layout, pos, &brush);
     }
 
     fn layout(
@@ -85,7 +83,7 @@ impl Widget for Label {
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
         // TODO: measure text properly
-        LayoutResult::Size(bc.constrain(Size::new(100.0, 17.0)))
+        LayoutResult::Size(bc.constrain((100.0, 17.0)))
     }
 
     fn poke(&mut self, payload: &mut dyn Any, ctx: &mut HandlerCtx) -> bool {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -165,11 +165,3 @@ pub struct MouseEvent {
     /// Count of multiple clicks, is 0 for mouse up event.
     pub count: u32,
 }
-
-#[derive(Debug, Clone)]
-pub enum KeyVariant {
-    /// A virtual-key code, same as WM_KEYDOWN message.
-    Vkey(i32),
-    /// A Unicode character.
-    Char(char),
-}

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -51,7 +51,7 @@ impl Widget for ProgressBar {
         //Paint the bar
         let brush = paint_ctx.render_ctx.solid_brush(BAR_COLOR);
 
-        let calculated_bar_width = self.value * geom.width() as f64;
+        let calculated_bar_width = self.value * geom.width();
 
         let rect = geom.with_size(Size::new(calculated_bar_width, geom.height()));
         paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
@@ -64,7 +64,7 @@ impl Widget for ProgressBar {
         _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain(Size::new(bc.max.width, BOX_HEIGHT as f64)))
+        LayoutResult::Size(bc.constrain((bc.max.width, BOX_HEIGHT)))
     }
 
     fn poke(&mut self, payload: &mut dyn Any, ctx: &mut HandlerCtx) -> bool {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -60,9 +60,9 @@ impl Widget for Slider {
             position = geom.width() - full_box;
         }
 
-        let knob_orig = Point::new(geom.origin().x + position, geom.origin().y);
+        let knob_origin = Point::new(geom.origin().x + position, geom.origin().y);
         let knob_size = Size::new(full_box, geom.height());
-        let knob_rect = Rect::from_origin_size(knob_orig, knob_size);
+        let knob_rect = Rect::from((knob_origin, knob_size));
 
         paint_ctx
             .render_ctx
@@ -76,7 +76,7 @@ impl Widget for Slider {
         _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain(Size::new(bc.max.width, BOX_HEIGHT)))
+        LayoutResult::Size(bc.constrain((bc.max.width, BOX_HEIGHT)))
     }
 
     fn mouse(&mut self, event: &MouseEvent, ctx: &mut HandlerCtx) -> bool {

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -54,7 +54,7 @@ impl TextBox {
     fn load_font(&mut self, rt: &mut Piet, font_size: f64) {
         let font = rt
             .text()
-            .new_font_by_name("Segoe UI", font_size as f32)
+            .new_font_by_name("Segoe UI", font_size)
             .unwrap()
             .build()
             .unwrap();
@@ -114,13 +114,13 @@ impl Widget for TextBox {
             .render_ctx
             .with_save(|rc| {
                 rc.clip(clip_rect, FillRule::NonZero);
-                rc.draw_text(&text_layout, pos.to_vec2(), &brush);
+                rc.draw_text(&text_layout, pos, &brush);
 
                 // Paint the cursor if focused
                 if focused {
                     let brush = rc.solid_brush(CURSOR_COLOR);
 
-                    let xy = geom.origin() + Vec2::new(text_layout.width() as f64 + 2., 2.);
+                    let xy = geom.origin() + Vec2::new(text_layout.width() + 2., 2.);
                     let x2y2 = xy + height_delta;
                     let line = Line::new(xy, x2y2);
 
@@ -138,7 +138,7 @@ impl Widget for TextBox {
         _size: Option<Size>,
         _ctx: &mut LayoutCtx,
     ) -> LayoutResult {
-        LayoutResult::Size(bc.constrain(Size::new(self.width, BOX_HEIGHT)))
+        LayoutResult::Size(bc.constrain((self.width, BOX_HEIGHT)))
     }
 
     fn mouse(&mut self, event: &MouseEvent, ctx: &mut HandlerCtx) -> bool {


### PR DESCRIPTION
- reexport druid_shell as 'shell'
- Update for removal of Coord & Point from piet
- make expose updated kurbo
- update examples


Before publishing, I'd like to discuss which bits of druid_shell should be exported directly. My gut feeling is that it's more or less 'all of it'; consumers of druid shouldn't need to reach into `shell` for anything? What am I missing?