### PR TITLE
Polish mouse handling

### DIFF
--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -19,7 +19,7 @@ use piet_common::kurbo::{Line, Rect};
 use piet_common::{Color, FillRule, RenderContext};
 
 use druid_shell::dialog::{FileDialogOptions, FileDialogType};
-use druid_shell::keyboard::KeyEvent;
+use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::keycodes::MenuKey;
 use druid_shell::menu::Menu;
 use druid_shell::platform::WindowBuilder;
@@ -71,16 +71,16 @@ impl WinHandler for HelloState {
         false
     }
 
-    fn mouse_wheel(&self, delta: i32, mods: u32) {
-        println!("mouse_wheel {} {:02x}", delta, mods);
+    fn mouse_wheel(&self, delta: i32, mods: KeyModifiers) {
+        println!("mouse_wheel {} {:?}", delta, mods);
     }
 
-    fn mouse_hwheel(&self, delta: i32, mods: u32) {
-        println!("mouse_hwheel {} {:02x}", delta, mods);
+    fn mouse_hwheel(&self, delta: i32, mods: KeyModifiers) {
+        println!("mouse_hwheel {} {:?}", delta, mods);
     }
 
-    fn mouse_move(&self, x: i32, y: i32, mods: u32) {
-        println!("mouse_move ({}, {}) {:02x}", x, y, mods);
+    fn mouse_move(&self, event: &MouseEvent) {
+        println!("mouse_move {:?}", event);
     }
 
     fn mouse(&self, event: &MouseEvent) {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -17,7 +17,7 @@
 use std::any::Any;
 use std::ops::Deref;
 
-use crate::keyboard::KeyEvent;
+use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::platform;
 
 // Handle to Window Level Utilities
@@ -81,7 +81,7 @@ pub trait WinHandler {
     ///
     /// The modifiers are the same as WM_MOUSEWHEEL.
     #[allow(unused_variables)]
-    fn mouse_wheel(&self, delta: i32, mods: u32) {}
+    fn mouse_wheel(&self, delta: i32, mods: KeyModifiers) {}
 
     /// Called on a mouse horizontal wheel event. This corresponds to a
     /// [WM_MOUSEHWHEEL](https://msdn.microsoft.com/en-us/library/windows/desktop/ms645614(v=vs.85).aspx)
@@ -89,14 +89,14 @@ pub trait WinHandler {
     ///
     /// The modifiers are the same as WM_MOUSEHWHEEL.
     #[allow(unused_variables)]
-    fn mouse_hwheel(&self, delta: i32, mods: u32) {}
+    fn mouse_hwheel(&self, delta: i32, mods: KeyModifiers) {}
 
     /// Called when the mouse moves. Note that the x, y coordinates are
     /// in absolute pixels.
     ///
     /// TODO: should we reuse the MouseEvent struct for this method as well?
     #[allow(unused_variables)]
-    fn mouse_move(&self, x: i32, y: i32, mods: u32) {}
+    fn mouse_move(&self, event: &MouseEvent) {}
 
     /// Called on mouse button up or down. Note that the x, y
     /// coordinates are in absolute pixels.
@@ -112,7 +112,7 @@ pub trait WinHandler {
     fn as_any(&self) -> &dyn Any;
 }
 
-/// A mouse button press or release event.
+/// The state of the mouse for a click, mouse-up, or move event.
 #[derive(Debug)]
 pub struct MouseEvent {
     /// X coordinate in absolute pixels.
@@ -120,11 +120,13 @@ pub struct MouseEvent {
     /// Y coordinate in absolute pixels.
     pub y: i32,
     /// Modifiers, as in raw WM message
-    pub mods: u32,
-    /// Which button was pressed or released.
-    pub which: MouseButton,
-    /// Type of event.
-    pub ty: MouseType,
+    pub mods: KeyModifiers,
+    /// The number of mouse clicks associated with this event. This will always
+    /// be `0` for a mouse-up event.
+    pub count: u32,
+    /// The currently pressed button in the case of a move or click event,
+    /// or the released button in the case of a mouse-up event.
+    pub button: MouseButton,
 }
 
 /// An indicator of which mouse button was pressed.
@@ -142,18 +144,6 @@ pub enum MouseButton {
     X2,
 }
 
-/// An indicator of the state change of a mouse button.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub enum MouseType {
-    /// Mouse down event.
-    Down,
-    /// Note: DoubleClick is currently disabled, as we don't use the
-    /// Windows processing.
-    DoubleClick,
-    /// Mouse up event.
-    Up,
-}
-
 /// Standard cursor types. This is only a subset, others can be added as needed.
 pub enum Cursor {
     Arrow,
@@ -168,5 +158,5 @@ pub struct ScrollEvent {
     /// The scroll wheel’s vertical delta.
     pub dy: f32,
     /// Modifiers, as in raw WM message
-    pub mods: u32,
+    pub mods: KeyModifiers,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use druid_shell::application::Application;
 pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 pub use druid_shell::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 use druid_shell::platform::IdleHandle;
-use druid_shell::window::{self, MouseType, WinHandler, WindowHandle};
+use druid_shell::window::{self, WinHandler, WindowHandle};
 
 mod graph;
 pub mod widget;
@@ -253,16 +253,11 @@ impl UiState {
             raw_event: &window::MouseEvent,
             ctx: &mut HandlerCtx,
         ) -> bool {
-            let count = if raw_event.ty == MouseType::Down {
-                1
-            } else {
-                0
-            };
             let event = MouseEvent {
                 pos,
                 mods: raw_event.mods,
-                which: raw_event.which,
-                count,
+                button: raw_event.button,
+                count: raw_event.count,
             };
             widgets[node].mouse(&event, ctx)
         }
@@ -954,7 +949,7 @@ impl WinHandler for UiMain {
         state.handle_key_up(&event);
     }
 
-    fn mouse_wheel(&self, dy: i32, mods: u32) {
+    fn mouse_wheel(&self, dy: i32, mods: KeyModifiers) {
         let mut state = self.state.borrow_mut();
         state.handle_scroll(&window::ScrollEvent {
             dx: 0.0,
@@ -963,7 +958,7 @@ impl WinHandler for UiMain {
         });
     }
 
-    fn mouse_hwheel(&self, dx: i32, mods: u32) {
+    fn mouse_hwheel(&self, dx: i32, mods: KeyModifiers) {
         let mut state = self.state.borrow_mut();
         state.handle_scroll(&window::ScrollEvent {
             dx: dx as f32,
@@ -972,9 +967,9 @@ impl WinHandler for UiMain {
         });
     }
 
-    fn mouse_move(&self, x: i32, y: i32, _mods: u32) {
+    fn mouse_move(&self, event: &window::MouseEvent) {
         let mut state = self.state.borrow_mut();
-        let (x, y) = state.layout_ctx.handle.pixels_to_px_xy(x, y);
+        let (x, y) = state.layout_ctx.handle.pixels_to_px_xy(event.x, event.y);
         let pos = Point::new(x as f64, y as f64);
         state.mouse_move(pos);
     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -153,16 +153,20 @@ pub trait Widget {
 }
 
 #[derive(Debug, Clone)]
+/// The state of the mouse for a click, mouse-up, or move event.
 pub struct MouseEvent {
-    /// The location of the event.
+    /// The location of the mouse.
     pub pos: Point,
-    /// The modifiers, which have the same interpretation as the raw WM message.
-    ///
-    /// TODO: rationalize this with mouse mods.
-    pub mods: u32,
-    /// Which mouse button was pressed.
-    pub which: MouseButton,
+    /// The currently active modifiers.
+    pub mods: KeyModifiers,
+    /// Which mouse button was pressed or released.
+    pub button: MouseButton,
     /// Count of multiple clicks, is 0 for mouse up event.
+    ///
+    /// This is something that is handled by the operating system, based on the
+    /// user's settings. It is possible (such as on macOS) for you to receive
+    /// multiple events for a double-click; it will arrive first as a single-click
+    /// and then again as a double-click.
     pub count: u32,
 }
 


### PR DESCRIPTION
- Use `KeyModifiers` for mouse events
- use `count` instead of `MouseType`; this is motivated by reusing
`MouseEvent` for mouse_moved, and making `druid_shell::MouseEvent`
closer to `druid::MouseEvent`
- thread modifiers through during mouse events