### PR TITLE
Muggle mouse cleanup

### DIFF
--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -83,8 +83,12 @@ impl WinHandler for HelloState {
         println!("mouse_move {:?}", event);
     }
 
-    fn mouse(&self, event: &MouseEvent) {
-        println!("mouse {:?}", event);
+    fn mouse_down(&self, event: &MouseEvent) {
+        println!("mouse_down {:?}", event);
+    }
+
+    fn mouse_up(&self, event: &MouseEvent) {
+        println!("mouse_up {:?}", event);
     }
 
     fn size(&self, width: u32, height: u32) {

--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -84,7 +84,7 @@ impl KeyEvent {
     }
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, PartialEq)]
 pub struct KeyModifiers {
     pub shift: bool,
     /// Option on macOS.

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -40,6 +40,7 @@ use std::sync::{Arc, Mutex, Weak};
 
 use cairo::{Context, QuartzSurface};
 
+use crate::kurbo::Point;
 use piet_common::{Piet, RenderContext};
 
 use crate::keyboard::{KeyEvent, KeyModifiers};
@@ -284,12 +285,12 @@ fn mouse_event(nsevent: id, view: id, button: Option<MouseButton>) -> MouseEvent
         });
         let point = nsevent.locationInWindow();
         let view_point = view.convertPoint_fromView_(point, nil);
+        let pos = Point::new(view_point.x as f64, view_point.y as f64);
         let modifiers = nsevent.modifierFlags();
         let modifiers = make_modifiers(modifiers);
         let count = nsevent.clickCount() as u32;
         MouseEvent {
-            x: view_point.x as i32,
-            y: view_point.y as i32,
+            pos,
             mods: modifiers,
             count,
             button,

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -276,7 +276,7 @@ extern "C" fn set_frame_size(this: &mut Object, _: Sel, size: NSSize) {
 
 // NOTE: If we know the button (because of the origin call) we pass it through,
 // otherwise we get it from the event itself.
-fn mouse_event(nsevent: id, view: id, down: bool, button: Option<MouseButton>) -> MouseEvent {
+fn mouse_event(nsevent: id, view: id, button: Option<MouseButton>) -> MouseEvent {
     unsafe {
         let button = button.unwrap_or_else(|| {
             let button = NSEvent::pressedMouseButtons(nsevent);
@@ -286,7 +286,7 @@ fn mouse_event(nsevent: id, view: id, down: bool, button: Option<MouseButton>) -
         let view_point = view.convertPoint_fromView_(point, nil);
         let modifiers = nsevent.modifierFlags();
         let modifiers = make_modifiers(modifiers);
-        let count = if down { nsevent.clickCount() as u32 } else { 0 };
+        let count = nsevent.clickCount() as u32;
         MouseEvent {
             x: view_point.x as i32,
             y: view_point.y as i32,
@@ -325,8 +325,8 @@ fn mouse_down(this: &mut Object, nsevent: id, button: MouseButton) {
     unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
-        let event = mouse_event(nsevent, this as id, true, Some(button));
-        (*view_state).handler.mouse(&event);
+        let event = mouse_event(nsevent, this as id, Some(button));
+        (*view_state).handler.mouse_down(&event);
     }
 }
 
@@ -342,8 +342,8 @@ fn mouse_up(this: &mut Object, nsevent: id, button: MouseButton) {
     unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
-        let event = mouse_event(nsevent, this as id, false, Some(button));
-        (*view_state).handler.mouse(&event);
+        let event = mouse_event(nsevent, this as id, Some(button));
+        (*view_state).handler.mouse_up(&event);
     }
 }
 
@@ -351,7 +351,7 @@ extern "C" fn mouse_move(this: &mut Object, _: Sel, nsevent: id) {
     unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
-        let event = mouse_event(nsevent, this as id, false, None);
+        let event = mouse_event(nsevent, this as id, None);
         (*view_state).handler.mouse_move(&event);
     }
 }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -18,6 +18,7 @@ use std::any::Any;
 use std::ops::Deref;
 
 use crate::keyboard::{KeyEvent, KeyModifiers};
+use crate::kurbo::Point;
 use crate::platform;
 
 // Handle to Window Level Utilities
@@ -91,20 +92,15 @@ pub trait WinHandler {
     #[allow(unused_variables)]
     fn mouse_hwheel(&self, delta: i32, mods: KeyModifiers) {}
 
-    /// Called when the mouse moves. Note that the x, y coordinates are
-    /// in absolute pixels.
-    ///
-    /// TODO: should we reuse the MouseEvent struct for this method as well?
+    /// Called when the mouse moves.
     #[allow(unused_variables)]
     fn mouse_move(&self, event: &MouseEvent) {}
 
-    /// Called on mouse button down. Note that the x, y
-    /// coordinates are in absolute pixels.
+    /// Called on mouse button down.
     #[allow(unused_variables)]
     fn mouse_down(&self, event: &MouseEvent) {}
 
-    /// Called on mouse button up. Note that the x, y
-    /// coordinates are in absolute pixels.
+    /// Called on mouse button up.
     #[allow(unused_variables)]
     fn mouse_up(&self, event: &MouseEvent) {}
 
@@ -118,12 +114,12 @@ pub trait WinHandler {
 }
 
 /// The state of the mouse for a click, mouse-up, or move event.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MouseEvent {
-    /// X coordinate in absolute pixels.
-    pub x: i32,
-    /// Y coordinate in absolute pixels.
-    pub y: i32,
+    /// The location of the mouse in the current window.
+    ///
+    /// This is in px units, that is, adjusted for hDPI.
+    pub pos: Point,
     /// Modifiers, as in raw WM message
     pub mods: KeyModifiers,
     /// The number of mouse clicks associated with this event. This will always

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -98,10 +98,15 @@ pub trait WinHandler {
     #[allow(unused_variables)]
     fn mouse_move(&self, event: &MouseEvent) {}
 
-    /// Called on mouse button up or down. Note that the x, y
+    /// Called on mouse button down. Note that the x, y
     /// coordinates are in absolute pixels.
     #[allow(unused_variables)]
-    fn mouse(&self, event: &MouseEvent) {}
+    fn mouse_down(&self, event: &MouseEvent) {}
+
+    /// Called on mouse button up. Note that the x, y
+    /// coordinates are in absolute pixels.
+    #[allow(unused_variables)]
+    fn mouse_up(&self, event: &MouseEvent) {}
 
     /// Called when the window is being destroyed. Note that this happens
     /// earlier in the sequence than drop (at WM_DESTROY, while the latter is

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -537,7 +537,11 @@ impl WndProc for MyWndProc {
                     button,
                     count,
                 };
-                self.handler.mouse(&event);
+                if count > 0 {
+                    self.handler.mouse_down(&event);
+                } else {
+                    self.handler.mouse_up(&event);
+                }
                 Some(0)
             }
             WM_DESTROY => {

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -54,6 +54,7 @@ use direct2d::render_target::{GenericRenderTarget, HwndRenderTarget, RenderTarge
 
 use piet_common::{Piet, RenderContext};
 
+use crate::kurbo::Point;
 use crate::menu::Menu;
 use crate::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 use crate::Error;
@@ -480,6 +481,8 @@ impl WndProc for MyWndProc {
             WM_MOUSEMOVE => {
                 let x = LOWORD(lparam as u32) as i16 as i32;
                 let y = HIWORD(lparam as u32) as i16 as i32;
+                let (px, py) = self.handle.borrow().pixels_to_px_xy(x, y);
+                let pos = Point::new(px as f64, py as f64);
                 let mods = get_mod_state();
                 let button = match wparam {
                     w if (w & 1) > 0 => MouseButton::Left,
@@ -492,8 +495,7 @@ impl WndProc for MyWndProc {
                     _ => MouseButton::Left,
                 };
                 let event = MouseEvent {
-                    x,
-                    y,
+                    pos,
                     mods,
                     button,
                     count: 0,
@@ -529,10 +531,11 @@ impl WndProc for MyWndProc {
                 };
                 let x = LOWORD(lparam as u32) as i16 as i32;
                 let y = HIWORD(lparam as u32) as i16 as i32;
+                let (px, py) = self.handle.borrow().pixels_to_px_xy(x, y);
+                let pos = Point::new(px as f64, py as f64);
                 let mods = get_mod_state();
                 let event = MouseEvent {
-                    x,
-                    y,
+                    pos,
                     mods,
                     button,
                     count,

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,31 +14,17 @@
 
 //! Events.
 
-use crate::Point;
-
-use druid_shell::keyboard::{KeyEvent, KeyModifiers};
-use druid_shell::window::MouseButton;
+use druid_shell::keyboard::KeyEvent;
+use druid_shell::window::MouseEvent;
 
 #[derive(Debug, Clone)]
 pub enum Event {
     MouseDown(MouseEvent),
     MouseUp(MouseEvent),
-    MouseMoved(Point),
+    MouseMoved(MouseEvent),
     KeyDown(KeyEvent),
     KeyUp(KeyEvent),
     HotChanged(bool),
-}
-
-#[derive(Debug, Clone)]
-pub struct MouseEvent {
-    /// The location of the event.
-    pub pos: Point,
-    /// The modifiers, which have the same interpretation as the raw WM message.
-    pub mods: KeyModifiers,
-    /// Which mouse button was pressed.
-    pub button: MouseButton,
-    /// Count of multiple clicks, is 0 for mouse up event.
-    pub count: u32,
 }
 
 impl Event {

--- a/src/event.rs
+++ b/src/event.rs
@@ -21,7 +21,8 @@ use druid_shell::window::MouseButton;
 
 #[derive(Debug, Clone)]
 pub enum Event {
-    Mouse(MouseEvent),
+    MouseDown(MouseEvent),
+    MouseUp(MouseEvent),
     MouseMoved(Point),
     KeyDown(KeyEvent),
     KeyUp(KeyEvent),

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 use crate::piet::{Color, FillRule, FontBuilder, Text, TextLayoutBuilder};
-use crate::{Piet, Point, RenderContext, Vec2};
+use crate::{Piet, Point, RenderContext};
 
 const BUTTON_BG_COLOR: Color = Color::rgba32(0x40_40_48_ff);
 const BUTTON_HOVER_COLOR: Color = Color::rgba32(0x50_50_58_ff);
@@ -87,15 +87,15 @@ impl<T: Data> WidgetInner<T> for Label {
 
     fn event(
         &mut self,
-        event: &Event,
-        ctx: &mut EventCtx,
+        _event: &Event,
+        _ctx: &mut EventCtx,
         _data: &mut T,
-        env: &Env,
+        _env: &Env,
     ) -> Option<Action> {
         None
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {}
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {}
 }
 
 impl Button {
@@ -141,11 +141,11 @@ impl<T: Data> WidgetInner<T> for Button {
     ) -> Option<Action> {
         let mut result = None;
         match event {
-            Event::MouseDown(mouse_event) => {
+            Event::MouseDown(_) => {
                 ctx.set_active(true);
                 ctx.invalidate();
             }
-            Event::MouseUp(mouse_event) => {
+            Event::MouseUp(_) => {
                 if ctx.is_active() {
                     ctx.set_active(false);
                     ctx.invalidate();
@@ -163,7 +163,7 @@ impl<T: Data> WidgetInner<T> for Button {
         result
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {}
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {}
 }
 
 impl<T: Data, F: FnMut(&T, &Env) -> String> DynLabel<T, F> {
@@ -219,15 +219,15 @@ impl<T: Data, F: FnMut(&T, &Env) -> String> WidgetInner<T> for DynLabel<T, F> {
 
     fn event(
         &mut self,
-        event: &Event,
-        ctx: &mut EventCtx,
+        _event: &Event,
+        _ctx: &mut EventCtx,
         _data: &mut T,
-        env: &Env,
+        _env: &Env,
     ) -> Option<Action> {
         None
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {
         ctx.invalidate();
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -141,17 +141,16 @@ impl<T: Data> WidgetInner<T> for Button {
     ) -> Option<Action> {
         let mut result = None;
         match event {
-            Event::Mouse(mouse_event) => {
-                if mouse_event.count > 0 {
-                    ctx.set_active(true);
+            Event::MouseDown(mouse_event) => {
+                ctx.set_active(true);
+                ctx.invalidate();
+            }
+            Event::MouseUp(mouse_event) => {
+                if ctx.is_active() {
+                    ctx.set_active(false);
                     ctx.invalidate();
-                } else {
-                    if ctx.is_active() {
-                        ctx.set_active(false);
-                        ctx.invalidate();
-                        if ctx.is_hot() {
-                            result = Some(Action::from_str("hit"));
-                        }
+                    if ctx.is_hot() {
+                        result = Some(Action::from_str("hit"));
                     }
                 }
             }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -25,18 +25,3 @@ pub use crate::widget::flex::{Column, Flex, Row};
 
 mod padding;
 pub use crate::widget::padding::Padding;
-
-/*
-
-// The widget trait should probably at least get its own file. When it does,
-// the following methods should probably go into it:
-
-#[derive(Debug, Clone)]
-pub enum KeyVariant {
-    /// A virtual-key code, same as WM_KEYDOWN message.
-    Vkey(i32),
-    /// A Unicode character.
-    Char(char),
-}
-
-*/


### PR DESCRIPTION
This separates `mouse` into `mouse_down` and `mouse_up`, and unifies the `MouseEvent` types from `druid_shell` and `druid`.