### PR TITLE
Rename Widget traits

### DIFF
--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -15,7 +15,7 @@
 //! Simple calculator.
 
 use druid::shell::{runloop, WindowBuilder};
-use druid::{Data, LensWrap, UiMain, UiState, WidgetInner};
+use druid::{Data, LensWrap, UiMain, UiState, Widget};
 
 use druid::widget::{ActionWrapper, Button, Column, DynLabel, Padding, Row};
 
@@ -144,22 +144,22 @@ impl CalcState {
     }
 }
 
-fn pad<T: Data>(inner: impl WidgetInner<T> + 'static) -> impl WidgetInner<T> {
+fn pad<T: Data>(inner: impl Widget<T> + 'static) -> impl Widget<T> {
     Padding::uniform(5.0, inner)
 }
 
-fn op_button_label(op: char, label: String) -> impl WidgetInner<CalcState> {
+fn op_button_label(op: char, label: String) -> impl Widget<CalcState> {
     pad(ActionWrapper::new(
         Button::new(label),
         move |data: &mut CalcState, _env| data.op(op),
     ))
 }
 
-fn op_button(op: char) -> impl WidgetInner<CalcState> {
+fn op_button(op: char) -> impl Widget<CalcState> {
     op_button_label(op, op.to_string())
 }
 
-fn digit_button(digit: u8) -> impl WidgetInner<CalcState> {
+fn digit_button(digit: u8) -> impl Widget<CalcState> {
     pad(ActionWrapper::new(
         Button::new(format!("{}", digit)),
         move |data: &mut CalcState, _env| data.digit(digit),
@@ -167,11 +167,11 @@ fn digit_button(digit: u8) -> impl WidgetInner<CalcState> {
 }
 
 fn flex_row<T: Data>(
-    w1: impl WidgetInner<T> + 'static,
-    w2: impl WidgetInner<T> + 'static,
-    w3: impl WidgetInner<T> + 'static,
-    w4: impl WidgetInner<T> + 'static,
-) -> impl WidgetInner<T> {
+    w1: impl Widget<T> + 'static,
+    w2: impl Widget<T> + 'static,
+    w3: impl Widget<T> + 'static,
+    w4: impl Widget<T> + 'static,
+) -> impl Widget<T> {
     let mut row = Row::new();
     row.add_child(w1, 1.0);
     row.add_child(w2, 1.0);
@@ -180,7 +180,7 @@ fn flex_row<T: Data>(
     row
 }
 
-fn build_calc() -> impl WidgetInner<CalcState> {
+fn build_calc() -> impl Widget<CalcState> {
     let mut column = Column::new();
     let display = LensWrap::new(
         DynLabel::new(|data: &String, _env| data.clone()),

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 
 use crate::{
     Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Size,
-    UpdateCtx, WidgetInner,
+    UpdateCtx, Widget,
 };
 
 /// A lens is a datatype that gives access to a field within a larger
@@ -53,12 +53,12 @@ impl<U, L, W> LensWrap<U, L, W> {
     }
 }
 
-impl<T, U, L, W> WidgetInner<T> for LensWrap<U, L, W>
+impl<T, U, L, W> Widget<T> for LensWrap<U, L, W>
 where
     T: Data,
     U: Data,
     L: Lens<T, U>,
-    W: WidgetInner<U>,
+    W: Widget<U>,
 {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         self.inner

--- a/src/widget/action_wrapper.rs
+++ b/src/widget/action_wrapper.rs
@@ -16,17 +16,17 @@
 
 use crate::{
     Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
-    Rect, Size, UpdateCtx, WidgetInner,
+    Rect, Size, UpdateCtx, Widget,
 };
 
 pub struct ActionWrapper<T: Data, F: FnMut(&mut T, &Env)> {
-    child: Box<dyn WidgetInner<T>>,
+    child: Box<dyn Widget<T>>,
     closure: F,
 }
 
 impl<T: Data, F: FnMut(&mut T, &Env)> ActionWrapper<T, F> {
     /// Create widget with uniform padding.
-    pub fn new(child: impl WidgetInner<T> + 'static, closure: F) -> ActionWrapper<T, F> {
+    pub fn new(child: impl Widget<T> + 'static, closure: F) -> ActionWrapper<T, F> {
         ActionWrapper {
             child: Box::new(child),
             closure,
@@ -34,7 +34,7 @@ impl<T: Data, F: FnMut(&mut T, &Env)> ActionWrapper<T, F> {
     }
 }
 
-impl<T: Data, F: FnMut(&mut T, &Env)> WidgetInner<T> for ActionWrapper<T, F> {
+impl<T: Data, F: FnMut(&mut T, &Env)> Widget<T> for ActionWrapper<T, F> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         self.child.paint(paint_ctx, base_state, data, env);
     }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 
 use crate::{
     Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Size,
-    UpdateCtx, WidgetInner,
+    UpdateCtx, Widget,
 };
 
 use crate::piet::{Color, FillRule, FontBuilder, Text, TextLayoutBuilder};
@@ -44,7 +44,7 @@ pub struct DynLabel<T: Data, F: FnMut(&T, &Env) -> String> {
 
 impl Label {
     /// Discussion question: should this return Label or a wrapped
-    /// widget (with WidgetBase)?
+    /// widget (with WidgetPod)?
     pub fn new(text: impl Into<String>) -> Label {
         Label { text: text.into() }
     }
@@ -65,7 +65,7 @@ impl Label {
     }
 }
 
-impl<T: Data> WidgetInner<T> for Label {
+impl<T: Data> Widget<T> for Label {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, _data: &T, _env: &Env) {
         let font_size = 15.0;
         let text_layout = self.get_layout(paint_ctx.render_ctx, font_size);
@@ -106,7 +106,7 @@ impl Button {
     }
 }
 
-impl<T: Data> WidgetInner<T> for Button {
+impl<T: Data> Widget<T> for Button {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         let is_active = base_state.is_active();
         let is_hot = base_state.is_hot();
@@ -197,7 +197,7 @@ impl<T: Data, F: FnMut(&T, &Env) -> String> DynLabel<T, F> {
     }
 }
 
-impl<T: Data, F: FnMut(&T, &Env) -> String> WidgetInner<T> for DynLabel<T, F> {
+impl<T: Data, F: FnMut(&T, &Env) -> String> Widget<T> for DynLabel<T, F> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
         let font_size = 15.0;
         let text_layout = self.get_layout(paint_ctx.render_ctx, font_size, data, env);

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -18,7 +18,7 @@ use crate::kurbo::{Point, Rect, Size};
 
 use crate::{
     Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,
-    WidgetPod, Widget,
+    Widget, WidgetPod,
 };
 
 pub struct Row;

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -18,7 +18,7 @@ use crate::kurbo::{Point, Rect, Size};
 
 use crate::{
     Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,
-    WidgetBase, WidgetInner,
+    WidgetPod, Widget,
 };
 
 pub struct Row;
@@ -31,7 +31,7 @@ pub struct Flex<T: Data> {
 }
 
 struct ChildWidget<T: Data> {
-    widget: WidgetBase<T, Box<dyn WidgetInner<T>>>,
+    widget: WidgetPod<T, Box<dyn Widget<T>>>,
     params: Params,
 }
 
@@ -90,17 +90,17 @@ impl Column {
 
 impl<T: Data> Flex<T> {
     /// Add a child widget.
-    pub fn add_child(&mut self, child: impl WidgetInner<T> + 'static, flex: f64) {
+    pub fn add_child(&mut self, child: impl Widget<T> + 'static, flex: f64) {
         let params = Params { flex };
         let child = ChildWidget {
-            widget: WidgetBase::new(child).boxed(),
+            widget: WidgetPod::new(child).boxed(),
             params,
         };
         self.children.push(child);
     }
 }
 
-impl<T: Data> WidgetInner<T> for Flex<T> {
+impl<T: Data> Widget<T> for Flex<T> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         for child in &mut self.children {
             child.widget.paint_with_offset(paint_ctx, data, env);

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
-    Rect, Size, UpdateCtx, WidgetBase, WidgetInner,
+    Rect, Size, UpdateCtx, WidgetPod, Widget,
 };
 
 pub struct Padding<T: Data> {
@@ -25,23 +25,23 @@ pub struct Padding<T: Data> {
     top: f64,
     bottom: f64,
 
-    child: WidgetBase<T, Box<dyn WidgetInner<T>>>,
+    child: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
 impl<T: Data> Padding<T> {
     /// Create widget with uniform padding.
-    pub fn uniform(padding: f64, child: impl WidgetInner<T> + 'static) -> Padding<T> {
+    pub fn uniform(padding: f64, child: impl Widget<T> + 'static) -> Padding<T> {
         Padding {
             left: padding,
             right: padding,
             top: padding,
             bottom: padding,
-            child: WidgetBase::new(child).boxed(),
+            child: WidgetPod::new(child).boxed(),
         }
     }
 }
 
-impl<T: Data> WidgetInner<T> for Padding<T> {
+impl<T: Data> Widget<T> for Padding<T> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
         self.child.paint_with_offset(paint_ctx, data, env);
     }

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
-    Rect, Size, UpdateCtx, WidgetPod, Widget,
+    Rect, Size, UpdateCtx, Widget, WidgetPod,
 };
 
 pub struct Padding<T: Data> {


### PR DESCRIPTION
Renames `WidgetBase` to `WidgetPod` and `WidgetInner` to `Widget`, as
these are friendlier and more descriptive names.