### PR TITLE
A scroll container

### DIFF
--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -1,0 +1,36 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use druid::shell::{runloop, WindowBuilder};
+use druid::widget::{Button, Column, Padding, Scroll};
+use druid::{UiMain, UiState};
+
+fn main() {
+    druid::shell::init();
+
+    let mut run_loop = runloop::RunLoop::new();
+    let mut builder = WindowBuilder::new();
+    let mut col = Column::new();
+    for i in 0..30 {
+        let button = Button::new(format!("Button {}", i));
+        col.add_child(Padding::uniform(3.0, button), 0.0);
+    }
+    let scroll = Scroll::new(col);
+    let state = UiState::new(scroll, 0u32);
+    builder.set_title("Scroll example");
+    builder.set_handler(Box::new(UiMain::new(state)));
+    let window = builder.build().unwrap();
+    window.show();
+    run_loop.run();
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,7 +14,7 @@
 
 //! Events.
 
-use crate::kurbo::Vec2;
+use crate::kurbo::{Rect, Shape, Vec2};
 
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::window::MouseEvent;
@@ -46,6 +46,42 @@ pub struct WheelEvent {
 }
 
 impl Event {
+    /// Transform the event for the contents of a scrolling container.
+    pub fn transform_scroll(&self, offset: Vec2, viewport: Rect) -> Option<Event> {
+        // TODO: need to wire this up so that it always propagates mouse events
+        // if the widget is active.
+        match self {
+            Event::MouseDown(mouse_event) => {
+                if viewport.winding(mouse_event.pos) != 0 {
+                    let mut mouse_event = mouse_event.clone();
+                    mouse_event.pos += offset;
+                    Some(Event::MouseDown(mouse_event))
+                } else {
+                    None
+                }
+            }
+            Event::MouseUp(mouse_event) => {
+                if viewport.winding(mouse_event.pos) != 0 {
+                    let mut mouse_event = mouse_event.clone();
+                    mouse_event.pos += offset;
+                    Some(Event::MouseUp(mouse_event))
+                } else {
+                    None
+                }
+            }
+            Event::MouseMoved(mouse_event) => {
+                if viewport.winding(mouse_event.pos) != 0 {
+                    let mut mouse_event = mouse_event.clone();
+                    mouse_event.pos += offset;
+                    Some(Event::MouseMoved(mouse_event))
+                } else {
+                    None
+                }
+            }
+            _ => Some(self.clone())
+        }
+    }
+
     /// Whether the event should be propagated from parent to children.
     pub(crate) fn recurse(&self) -> bool {
         match self {

--- a/src/event.rs
+++ b/src/event.rs
@@ -78,7 +78,7 @@ impl Event {
                     None
                 }
             }
-            _ => Some(self.clone())
+            _ => Some(self.clone()),
         }
     }
 

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -173,8 +173,11 @@ impl<T: Data> Widget<T> for Flex<T> {
             child.widget.set_layout_rect(rect.with_origin(pos));
             major += self.direction.major(rect.size());
         }
+        if flex_sum > 0.0 {
+            major = total_major;
+        }
         // TODO: should be able to make this `into`
-        let (width, height) = self.direction.pack(total_major, minor);
+        let (width, height) = self.direction.pack(major, minor);
         Size::new(width, height)
     }
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -25,3 +25,6 @@ pub use crate::widget::flex::{Column, Flex, Row};
 
 mod padding;
 pub use crate::widget::padding::Padding;
+
+mod scroll;
+pub use crate::widget::scroll::Scroll;

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -1,0 +1,114 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A container that scrolls its contents.
+
+use std::f64::INFINITY;
+
+use crate::{
+    Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
+    Rect, Size, UpdateCtx, Vec2, Widget, WidgetPod,
+};
+
+use crate::piet::{FillRule, RenderContext};
+
+use crate::kurbo::Affine;
+
+pub struct Scroll<T: Data> {
+    child: WidgetPod<T, Box<dyn Widget<T>>>,
+    child_size: Size,
+    scroll_offset: Vec2,
+}
+
+impl<T: Data> Scroll<T> {
+    /// Create a new scroll container.
+    pub fn new(child: impl Widget<T> + 'static) -> Scroll<T> {
+        Scroll {
+            child: WidgetPod::new(child).boxed(),
+            child_size: Default::default(),
+            scroll_offset: Vec2::new(0.0, 0.0),
+        }
+    }
+
+    /// Update the scroll.
+    ///
+    /// Returns `true` if the scroll has been updated.
+    fn scroll(&mut self, delta: Vec2, size: Size) -> bool {
+        let mut offset = self.scroll_offset + delta;
+        offset.x = offset.x.min(self.child_size.width - size.width).max(0.0);
+        offset.y = offset.y.min(self.child_size.height - size.height).max(0.0);
+        if (offset - self.scroll_offset).hypot2() > 1e-12 {
+            self.scroll_offset = offset;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<T: Data> Widget<T> for Scroll<T> {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+        if let Err(e) = paint_ctx.render_ctx.save() {
+            eprintln!("error saving render context: {:?}", e);
+            return;
+        }
+        let viewport = Rect::from_origin_size(Point::ORIGIN, base_state.size());
+        paint_ctx.render_ctx.clip(viewport, FillRule::NonZero);
+        paint_ctx
+            .render_ctx
+            .transform(Affine::translate(-self.scroll_offset));
+        self.child.paint(paint_ctx, data, env);
+        if let Err(e) = paint_ctx.render_ctx.restore() {
+            eprintln!("error restoring render context: {:?}", e);
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        let child_bc = BoxConstraints::new(Size::ZERO, Size::new(INFINITY, INFINITY));
+        let size = self.child.layout(ctx, &child_bc, data, env);
+        self.child_size = size;
+        self.child
+            .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+        let self_size = bc.constrain(Size::new(100.0, 100.0));
+        let _ = self.scroll(Vec2::new(0.0, 0.0), self_size);
+        self_size
+    }
+
+    fn event(
+        &mut self,
+        event: &Event,
+        ctx: &mut EventCtx,
+        data: &mut T,
+        env: &Env,
+    ) -> Option<Action> {
+        let size = ctx.base_state.size();
+        let viewport = Rect::from_origin_size(Point::ORIGIN, size);
+        if let Event::Wheel(wheel) = event {
+            if self.scroll(wheel.delta, size) {
+                ctx.invalidate();
+            }
+        }
+        // TODO: cancellation logic
+        let child_event = event.transform_scroll(self.scroll_offset, viewport);
+        if let Some(child_event) = child_event {
+            self.child.event(&child_event, ctx, data, env)
+        } else {
+            None
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+        self.child.update(ctx, data, env);
+    }
+}

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -25,6 +25,12 @@ use crate::piet::{FillRule, RenderContext};
 
 use crate::kurbo::Affine;
 
+/// A container that scrolls its contents.
+///
+/// This container holds a single child, and uses the wheel to scroll it
+/// when the child's bounds are larger than the viewport.
+///
+/// The child is laid out with completely unconstrained layout bounds.
 pub struct Scroll<T: Data> {
     child: WidgetPod<T, Box<dyn Widget<T>>>,
     child_size: Size,


### PR DESCRIPTION
Adds a scrollable container. This implementation is quite basic as it
does not draw scroll bars or allow them to be dragged by mouse clicking,
but the fundamental scroll mechanics (with wheel) should be in place.

Scrolling is discussed in #5 among other things.