### PR TITLE
CI: Test on stable before installing nightly

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,13 +26,15 @@ jobs:
 
       - template: ci/test.yml
         parameters:
-          toolchain: nightly
-          crate_path: 'druid-shell'
+          toolchain: stable
+          crate_path: '.'
+
+      - template: ci/install-nightly.yml
 
       - template: ci/test.yml
         parameters:
-          toolchain: stable
-          crate_path: '.'
+          toolchain: nightly
+          crate_path: 'druid-shell'
 
       - template: ci/test.yml
         parameters:

--- a/ci/install-nightly.yml
+++ b/ci/install-nightly.yml
@@ -1,0 +1,8 @@
+steps:
+  - script: |
+        rustup install nightly
+    displayName: Install nightly
+
+  - script: |
+        rustup component add rustfmt --toolchain nightly
+    displayName: Install rustfmt (nightly)

--- a/ci/install-rust.yml
+++ b/ci/install-rust.yml
@@ -23,15 +23,10 @@ steps:
 
   # All platforms.
   - script: |
+        rustup component add rustfmt
+    displayName: Install rustfmt (stable)
+
+  - script: |
         rustc -Vv
         cargo -V
     displayName: Query rust and cargo versions
-
-  - script: |
-        rustup install nightly
-    displayName: Install nightly
-
-  - script: |
-        rustup component add rustfmt
-        rustup component add rustfmt --toolchain nightly
-    displayName: Install rustfmt


### PR DESCRIPTION
This shaves a few minutes off the iteration cycle in the case where a build fails on stable.