### PR TITLE
Expose setting the cursor

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -46,7 +46,7 @@ use piet_common::{Piet, RenderContext};
 use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::platform::dialog::{FileDialogOptions, FileDialogType};
 use crate::util::make_nsstring;
-use crate::window::{MouseButton, MouseEvent, WinHandler};
+use crate::window::{Cursor, MouseButton, MouseEvent, WinHandler};
 use crate::Error;
 
 use util::assert_main_thread;
@@ -482,6 +482,23 @@ impl WindowHandle {
                 // We could share impl with redraw, but we'd need to deal with nil.
                 let () = msg_send![*nsview.load(), setNeedsDisplay: YES];
             }
+        }
+    }
+
+    /// Set the current mouse cursor.
+    pub fn set_cursor(&self, cursor: &Cursor) {
+        unsafe {
+            let nscursor = class!(NSCursor);
+            let cursor: id = match cursor {
+                Cursor::Arrow => msg_send![nscursor, arrowCursor],
+                Cursor::IBeam => msg_send![nscursor, IBeamCursor],
+                Cursor::Crosshair => msg_send![nscursor, crosshairCursor],
+                Cursor::OpenHand => msg_send![nscursor, openHandCursor],
+                Cursor::NotAllowed => msg_send![nscursor, operationNotAllowedCursor],
+                Cursor::ResizeLeftRight => msg_send![nscursor, resizeLeftRightCursor],
+                Cursor::ResizeUpDown => msg_send![nscursor, ResizeUpDownCursor],
+            };
+            msg_send![cursor, set];
         }
     }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -140,8 +140,18 @@ pub enum MouseButton {
     X2,
 }
 
-/// Standard cursor types. This is only a subset, others can be added as needed.
+//NOTE: this currently only contains cursors that are included by default on
+//both Windows and macOS. We may want to provide polyfills for various additional cursors,
+//and we will also want to add some mechanism for adding custom cursors.
+/// Mouse cursors.
 pub enum Cursor {
+    /// The default arrow cursor.
     Arrow,
+    /// A vertical I-beam, for indicating insertion points in text.
     IBeam,
+    Crosshair,
+    OpenHand,
+    NotAllowed,
+    ResizeLeftRight,
+    ResizeUpDown,
 }

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -883,6 +883,11 @@ impl Cursor {
         match self {
             Cursor::Arrow => IDC_ARROW,
             Cursor::IBeam => IDC_IBEAM,
+            Cursor::Crosshair => IDC_CROSS,
+            Cursor::OpenHand => IDC_HAND,
+            Cursor::NotAllowed => IDC_NO,
+            Cursor::ResizeLeftRight => IDC_SIZEWE,
+            Cursor::ResizeUpDown => IDC_SIZENS,
         }
     }
 }
@@ -913,6 +918,14 @@ impl WindowHandle {
             unsafe {
                 InvalidateRect(hwnd, null(), FALSE);
             }
+        }
+    }
+
+    /// Set the current mouse cursor.
+    pub fn set_cursor(&self, cursor: &Cursor) {
+        unsafe {
+            let cursor = LoadCursorW(0 as HINSTANCE, cursor.get_lpcwstr());
+            SetCursor(cursor);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 pub use druid_shell::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 use druid_shell::platform::IdleHandle;
 use druid_shell::window::{self, WinHandler, WindowHandle};
-pub use druid_shell::window::{MouseButton, MouseEvent};
+pub use druid_shell::window::{Cursor, MouseButton, MouseEvent};
 
 pub use data::Data;
 pub use event::{Event, WheelEvent};
@@ -142,6 +142,7 @@ pub struct PaintCtx<'a, 'b: 'a> {
 pub struct LayoutCtx {}
 
 pub struct EventCtx<'a> {
+    window: &'a WindowHandle,
     base_state: &'a mut BaseState,
     had_active: bool,
 }
@@ -233,6 +234,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
         let had_active = self.state.has_active;
         let mut child_ctx = EventCtx {
+            window: &ctx.window,
             base_state: &mut self.state,
             had_active,
         };
@@ -344,6 +346,7 @@ impl<T: Data> UiState<T> {
         // should there be a root base state persisting in the ui state instead?
         let mut base_state = Default::default();
         let mut ctx = EventCtx {
+            window: &self.handle,
             base_state: &mut base_state,
             had_active: self.root.state.has_active,
         };
@@ -518,6 +521,11 @@ impl<'a> EventCtx<'a> {
     pub fn is_active(&self) -> bool {
         self.base_state.is_active
     }
+
+    /// Returns a reference to the current `WindowHandle`.
+    pub fn window(&self) -> &WindowHandle {
+        &self.window
+    }
 }
 
 impl UpdateCtx {
@@ -532,6 +540,11 @@ impl Action {
     /// Note: this is something of a placeholder and will change.
     pub fn from_str(s: impl Into<String>) -> Action {
         Action { text: s.into() }
+    }
+
+    /// Provides access to the action's string representation.
+    pub fn as_str(&self) -> &str {
+        self.text.as_str()
     }
 
     /// Merge two optional actions.


### PR DESCRIPTION
This adds support for the set of cursors shared between macOS
and Windows. It does not include support for custom cursors.