### PR TITLE
 Rely less on interior mutability in druid-shell

### DIFF
--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -24,7 +24,7 @@ use druid_shell::keycodes::MenuKey;
 use druid_shell::menu::Menu;
 use druid_shell::platform::WindowBuilder;
 use druid_shell::runloop;
-use druid_shell::window::{MouseEvent, WinHandler, WindowHandle};
+use druid_shell::window::{MouseEvent, WinCtx, WinHandler, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb24(0x27_28_22);
 const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
@@ -36,11 +36,11 @@ struct HelloState {
 }
 
 impl WinHandler for HelloState {
-    fn connect(&self, handle: &WindowHandle) {
+    fn connect(&mut self, handle: &WindowHandle) {
         *self.handle.borrow_mut() = handle.clone();
     }
 
-    fn paint(&self, rc: &mut piet_common::Piet) -> bool {
+    fn paint(&mut self, rc: &mut piet_common::Piet) -> bool {
         let bg = rc.solid_brush(BG_COLOR);
         let fg = rc.solid_brush(FG_COLOR);
         let (width, height) = *self.size.borrow();
@@ -50,7 +50,7 @@ impl WinHandler for HelloState {
         false
     }
 
-    fn command(&self, id: u32) {
+    fn command(&mut self, id: u32, _ctx: &mut dyn WinCtx) {
         match id {
             0x100 => self.handle.borrow().close(),
             0x101 => {
@@ -66,28 +66,28 @@ impl WinHandler for HelloState {
         }
     }
 
-    fn key_down(&self, event: KeyEvent) -> bool {
+    fn key_down(&mut self, event: KeyEvent, _ctx: &mut dyn WinCtx) -> bool {
         println!("keydown: {:?}", event);
         false
     }
 
-    fn wheel(&self, delta: Vec2, mods: KeyModifiers) {
+    fn wheel(&mut self, delta: Vec2, mods: KeyModifiers, _ctx: &mut dyn WinCtx) {
         println!("mouse_wheel {:?} {:?}", delta, mods);
     }
 
-    fn mouse_move(&self, event: &MouseEvent) {
+    fn mouse_move(&mut self, event: &MouseEvent, _ctx: &mut dyn WinCtx) {
         println!("mouse_move {:?}", event);
     }
 
-    fn mouse_down(&self, event: &MouseEvent) {
+    fn mouse_down(&mut self, event: &MouseEvent, _ctx: &mut dyn WinCtx) {
         println!("mouse_down {:?}", event);
     }
 
-    fn mouse_up(&self, event: &MouseEvent) {
+    fn mouse_up(&mut self, event: &MouseEvent, _ctx: &mut dyn WinCtx) {
         println!("mouse_up {:?}", event);
     }
 
-    fn size(&self, width: u32, height: u32) {
+    fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
         let dpi = self.handle.borrow().get_dpi();
         let dpi_scale = dpi as f64 / 96.0;
         let width_f = (width as f64) / dpi_scale;
@@ -95,11 +95,11 @@ impl WinHandler for HelloState {
         *self.size.borrow_mut() = (width_f, height_f);
     }
 
-    fn destroy(&self) {
+    fn destroy(&mut self, _ctx: &mut dyn WinCtx) {
         runloop::request_quit();
     }
 
-    fn as_any(&self) -> &dyn Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 }

--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::cell::RefCell;
 
 use piet_common::kurbo::{Line, Rect, Vec2};
 use piet_common::{Color, FillRule, RenderContext};
@@ -31,19 +30,19 @@ const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
 
 #[derive(Default)]
 struct HelloState {
-    size: RefCell<(f64, f64)>,
-    handle: RefCell<WindowHandle>,
+    size: (f64, f64),
+    handle: WindowHandle,
 }
 
 impl WinHandler for HelloState {
     fn connect(&mut self, handle: &WindowHandle) {
-        *self.handle.borrow_mut() = handle.clone();
+        self.handle = handle.clone();
     }
 
     fn paint(&mut self, rc: &mut piet_common::Piet) -> bool {
         let bg = rc.solid_brush(BG_COLOR);
         let fg = rc.solid_brush(FG_COLOR);
-        let (width, height) = *self.size.borrow();
+        let (width, height) = self.size;
         let rect = Rect::new(0.0, 0.0, width, height);
         rc.fill(rect, &bg, FillRule::NonZero);
         rc.stroke(Line::new((10.0, 50.0), (90.0, 90.0)), &fg, 1.0, None);
@@ -52,14 +51,11 @@ impl WinHandler for HelloState {
 
     fn command(&mut self, id: u32, _ctx: &mut dyn WinCtx) {
         match id {
-            0x100 => self.handle.borrow().close(),
+            0x100 => self.handle.close(),
             0x101 => {
                 let mut options = FileDialogOptions::default();
                 options.set_show_hidden();
-                let filename = self
-                    .handle
-                    .borrow()
-                    .file_dialog(FileDialogType::Open, options);
+                let filename = self.handle.file_dialog(FileDialogType::Open, options);
                 println!("result: {:?}", filename);
             }
             _ => println!("unexpected id {}", id),
@@ -88,11 +84,11 @@ impl WinHandler for HelloState {
     }
 
     fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
-        let dpi = self.handle.borrow().get_dpi();
+        let dpi = self.handle.get_dpi();
         let dpi_scale = dpi as f64 / 96.0;
         let width_f = (width as f64) / dpi_scale;
         let height_f = (height as f64) / dpi_scale;
-        *self.size.borrow_mut() = (width_f, height_f);
+        self.size = (width_f, height_f);
     }
 
     fn destroy(&mut self, _ctx: &mut dyn WinCtx) {

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::cell::RefCell;
 
 use time::get_time;
 
@@ -31,9 +30,7 @@ use druid_shell::window::{WinCtx, WinHandler, WindowHandle};
 const BG_COLOR: Color = Color::rgb24(0x27_28_22);
 const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
 
-struct PerfTest(RefCell<PerfState>);
-
-struct PerfState {
+struct PerfTest {
     handle: WindowHandle,
     size: (f64, f64),
     last_time: f64,
@@ -41,12 +38,11 @@ struct PerfState {
 
 impl WinHandler for PerfTest {
     fn connect(&mut self, handle: &WindowHandle) {
-        self.0.borrow_mut().handle = handle.clone();
+        self.handle = handle.clone();
     }
 
     fn paint(&mut self, rc: &mut Piet) -> bool {
-        let mut state = self.0.borrow_mut();
-        let (width, height) = state.size;
+        let (width, height) = self.size;
         let bg = rc.solid_brush(BG_COLOR);
         let fg = rc.solid_brush(FG_COLOR);
         let rect = Rect::new(0.0, 0.0, width, height);
@@ -73,8 +69,8 @@ impl WinHandler for PerfTest {
 
         let now = get_time();
         let now = now.sec as f64 + 1e-9 * now.nsec as f64;
-        let msg = format!("{:3.1}ms", 1e3 * (now - state.last_time));
-        state.last_time = now;
+        let msg = format!("{:3.1}ms", 1e3 * (now - self.last_time));
+        self.last_time = now;
         let layout = rc
             .text()
             .new_text_layout(&font, &msg)
@@ -103,7 +99,7 @@ impl WinHandler for PerfTest {
 
     fn command(&mut self, id: u32, _ctx: &mut dyn WinCtx) {
         match id {
-            0x100 => self.0.borrow().handle.close(),
+            0x100 => self.handle.close(),
             _ => println!("unexpected id {}", id),
         }
     }
@@ -114,12 +110,11 @@ impl WinHandler for PerfTest {
     }
 
     fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
-        let mut state = self.0.borrow_mut();
-        let dpi = state.handle.get_dpi();
+        let dpi = self.handle.get_dpi();
         let dpi_scale = dpi as f64 / 96.0;
         let width_f = (width as f64) / dpi_scale;
         let height_f = (height as f64) / dpi_scale;
-        state.size = (width_f, height_f);
+        self.size = (width_f, height_f);
     }
 
     fn destroy(&mut self, _ctx: &mut dyn WinCtx) {
@@ -136,12 +131,12 @@ fn main() {
 
     let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();
-    let perf_state = PerfState {
+    let perf_test = PerfTest {
         size: Default::default(),
         handle: Default::default(),
         last_time: 0.0,
     };
-    builder.set_handler(Box::new(PerfTest(RefCell::new(perf_state))));
+    builder.set_handler(Box::new(perf_test));
     builder.set_title("Performance tester");
 
     // Note: experiment with changing this

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -26,7 +26,7 @@ use druid_shell::platform::PresentStrategy;
 use druid_shell::keyboard::KeyEvent;
 use druid_shell::platform::WindowBuilder;
 use druid_shell::runloop;
-use druid_shell::window::{WinHandler, WindowHandle};
+use druid_shell::window::{WinCtx, WinHandler, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb24(0x27_28_22);
 const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
@@ -40,11 +40,11 @@ struct PerfState {
 }
 
 impl WinHandler for PerfTest {
-    fn connect(&self, handle: &WindowHandle) {
+    fn connect(&mut self, handle: &WindowHandle) {
         self.0.borrow_mut().handle = handle.clone();
     }
 
-    fn paint(&self, rc: &mut Piet) -> bool {
+    fn paint(&mut self, rc: &mut Piet) -> bool {
         let mut state = self.0.borrow_mut();
         let (width, height) = state.size;
         let bg = rc.solid_brush(BG_COLOR);
@@ -101,19 +101,19 @@ impl WinHandler for PerfTest {
         true
     }
 
-    fn command(&self, id: u32) {
+    fn command(&mut self, id: u32, _ctx: &mut dyn WinCtx) {
         match id {
             0x100 => self.0.borrow().handle.close(),
             _ => println!("unexpected id {}", id),
         }
     }
 
-    fn key_down(&self, event: KeyEvent) -> bool {
+    fn key_down(&mut self, event: KeyEvent, _ctx: &mut dyn WinCtx) -> bool {
         println!("keydown: {:?}", event);
         false
     }
 
-    fn size(&self, width: u32, height: u32) {
+    fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
         let mut state = self.0.borrow_mut();
         let dpi = state.handle.get_dpi();
         let dpi_scale = dpi as f64 / 96.0;
@@ -122,11 +122,11 @@ impl WinHandler for PerfTest {
         state.size = (width_f, height_f);
     }
 
-    fn destroy(&self) {
+    fn destroy(&mut self, _ctx: &mut dyn WinCtx) {
         runloop::request_quit();
     }
 
-    fn as_any(&self) -> &dyn Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 }

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -616,9 +616,9 @@ impl IdleHandle {
 
 impl<'a> WinCtx for WinCtxImpl<'a> {
     fn invalidate(&mut self) {
-            unsafe {
-                let () = msg_send![*self.nsview.load(), setNeedsDisplay: YES];
-            }
+        unsafe {
+            let () = msg_send![*self.nsview.load(), setNeedsDisplay: YES];
+        }
     }
 }
 

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -62,7 +62,7 @@ use dcomp::{D3D11Device, DCompositionDevice, DCompositionTarget, DCompositionVis
 use dialog::{get_file_dialog_path, FileDialogOptions, FileDialogType};
 
 use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
-use crate::window::{self, Cursor, MouseButton, MouseEvent, WinHandler};
+use crate::window::{self, Cursor, MouseButton, MouseEvent, WinCtx, WinHandler};
 
 extern "system" {
     pub fn DwmFlush();
@@ -107,6 +107,7 @@ pub enum PresentStrategy {
 
 #[derive(Default)]
 pub struct WindowHandle {
+    // Note: this clone of the dwrite factory might move into WinCtxImpl.
     dwrite_factory: Option<RefCell<directwrite::Factory>>,
     state: Weak<WindowState>,
 }
@@ -122,15 +123,17 @@ pub struct IdleHandle {
 }
 
 trait IdleCallback: Send {
-    fn call(self: Box<Self>, a: &dyn Any);
+    fn call(self: Box<Self>, a: &mut dyn Any);
 }
 
-impl<F: FnOnce(&dyn Any) + Send> IdleCallback for F {
-    fn call(self: Box<F>, a: &dyn Any) {
+impl<F: FnOnce(&mut dyn Any) + Send> IdleCallback for F {
+    fn call(self: Box<F>, a: &mut dyn Any) {
         (*self)(a)
     }
 }
 
+/// This is the low level window state. All mutable contents are protected
+/// by interior mutability, so we can handle reentrant calls.
 struct WindowState {
     hwnd: Cell<HWND>,
     dpi: Cell<f32>,
@@ -149,14 +152,15 @@ trait WndProc {
 // State and logic for the winapi window procedure entry point. Note that this level
 // implements policies such as the use of Direct2D for painting.
 struct MyWndProc {
-    handler: Box<dyn WinHandler>,
     handle: RefCell<WindowHandle>,
     d2d_factory: direct2d::Factory,
     dwrite_factory: directwrite::Factory,
     state: RefCell<Option<WndState>>,
 }
 
+/// The mutable state of the window.
 struct WndState {
+    handler: Box<dyn WinHandler>,
     render_target: Option<GenericRenderTarget>,
     dcomp_state: Option<DCompState>,
     dpi: f32,
@@ -167,6 +171,11 @@ struct WndState {
     /// a `WM_KEYUP` event.
     stashed_char: Option<char>,
     //TODO: track surrogate orphan
+}
+
+/// The Windows implementation of the context provided to WinHandler calls.
+struct WinCtxImpl<'a> {
+    handle: &'a WindowHandle,
 }
 
 /// State for DirectComposition. This is optional because it is only supported
@@ -210,27 +219,28 @@ fn get_mod_state() -> KeyModifiers {
     }
 }
 
-impl MyWndProc {
-    fn rebuild_render_target(&self) {
+impl WndState {
+    fn rebuild_render_target(&mut self, d2d: &direct2d::Factory) {
         unsafe {
-            let mut state = self.state.borrow_mut();
-            let s = state.as_mut().unwrap();
-            let swap_chain = s.dcomp_state.as_ref().unwrap().swap_chain;
-            let rt = paint::create_render_target_dxgi(&self.d2d_factory, swap_chain, s.dpi)
+            let swap_chain = self.dcomp_state.as_ref().unwrap().swap_chain;
+            let rt = paint::create_render_target_dxgi(d2d, swap_chain, self.dpi)
                 .map(|rt| rt.as_generic());
-            s.render_target = rt.ok();
+            self.render_target = rt.ok();
         }
     }
 
     // Renders but does not present.
-    fn render(&self) {
-        let mut state = self.state.borrow_mut();
-        let s = state.as_mut().unwrap();
-        let rt = s.render_target.as_mut().unwrap();
+    fn render(
+        &mut self,
+        d2d: &direct2d::Factory,
+        dw: &directwrite::Factory,
+        handle: &RefCell<WindowHandle>,
+    ) {
+        let rt = self.render_target.as_mut().unwrap();
         rt.begin_draw();
         let anim;
         {
-            let mut piet_ctx = Piet::new(&self.d2d_factory, &self.dwrite_factory, rt);
+            let mut piet_ctx = Piet::new(d2d, dw, rt);
             anim = self.handler.paint(&mut piet_ctx);
             if let Err(e) = piet_ctx.finish() {
                 // TODO: use proper log infrastructure
@@ -243,7 +253,7 @@ impl MyWndProc {
             println!("EndDraw error: {:?}", e);
         }
         if anim {
-            let handle = self.handle.borrow().get_idle_handle().unwrap();
+            let handle = handle.borrow().get_idle_handle().unwrap();
             // Note: maybe add WindowHandle as arg to idle handler so we don't need this.
             let handle2 = handle.clone();
             handle.add_idle(move |_| handle2.invalidate());
@@ -251,10 +261,23 @@ impl MyWndProc {
     }
 }
 
+impl MyWndProc {
+    /// Create debugging output for dropped messages due to wndproc reeentrancy.
+    ///
+    /// In the future, we choose to do something else other than logging and dropping,
+    /// such as queuing and replaying after the nested call returns.
+    fn log_dropped_msg(&self, hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) {
+        eprintln!(
+            "dropped message 0x{:x}, hwnd={:?}, wparam=0x{:x}, lparam=0x{:x}",
+            msg, hwnd, wparam, lparam
+        );
+    }
+}
+
 impl WndProc for MyWndProc {
-    fn connect(&self, handle: &WindowHandle, state: WndState) {
+    fn connect(&self, handle: &WindowHandle, mut state: WndState) {
         *self.handle.borrow_mut() = handle.clone();
-        self.handler.connect(&window::WindowHandle {
+        state.handler.connect(&window::WindowHandle {
             inner: handle.clone(),
         });
         *self.state.borrow_mut() = Some(state);
@@ -271,243 +294,298 @@ impl WndProc for MyWndProc {
         match msg {
             WM_ERASEBKGND => Some(0),
             WM_PAINT => unsafe {
-                if self
-                    .state
-                    .borrow()
-                    .as_ref()
-                    .unwrap()
-                    .render_target
-                    .is_none()
-                {
-                    let rt = paint::create_render_target(&self.d2d_factory, hwnd)
-                        .map(|rt| rt.as_generic());
-                    self.state.borrow_mut().as_mut().unwrap().render_target = rt.ok();
-                }
-                self.render();
-                let mut state = self.state.borrow_mut();
-                let s = state.as_mut().unwrap();
-                if let Some(ref mut ds) = s.dcomp_state {
-                    if !ds.sizing {
-                        (*ds.swap_chain).Present(1, 0);
-                        let _ = ds.dcomp_device.commit();
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    if s.render_target.is_none() {
+                        let rt = paint::create_render_target(&self.d2d_factory, hwnd)
+                            .map(|rt| rt.as_generic());
+                        s.render_target = rt.ok();
                     }
+                    s.render(&self.d2d_factory, &self.dwrite_factory, &self.handle);
+                    if let Some(ref mut ds) = s.dcomp_state {
+                        if !ds.sizing {
+                            (*ds.swap_chain).Present(1, 0);
+                            let _ = ds.dcomp_device.commit();
+                        }
+                    }
+                    ValidateRect(hwnd, null_mut());
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                 }
-                ValidateRect(hwnd, null_mut());
                 Some(0)
             },
             WM_ENTERSIZEMOVE => unsafe {
-                if self.state.borrow().as_ref().unwrap().dcomp_state.is_some() {
-                    let rt = paint::create_render_target(&self.d2d_factory, hwnd)
-                        .map(|rt| rt.as_generic());
-                    self.state.borrow_mut().as_mut().unwrap().render_target = rt.ok();
-                    self.handler.rebuild_resources();
-                    self.render();
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    if s.dcomp_state.is_some() {
+                        let rt = paint::create_render_target(&self.d2d_factory, hwnd)
+                            .map(|rt| rt.as_generic());
+                        s.render_target = rt.ok();
+                        let mut ctx = WinCtxImpl {
+                            handle: &self.handle.borrow(),
+                        };
+                        s.handler.rebuild_resources(&mut ctx);
+                        s.render(&self.d2d_factory, &self.dwrite_factory, &self.handle);
 
-                    let mut state = self.state.borrow_mut();
-                    let s = state.as_mut().unwrap();
-                    if let Some(ref mut ds) = s.dcomp_state {
-                        let _ = ds.dcomp_target.clear_root();
-                        let _ = ds.dcomp_device.commit();
-                        ds.sizing = true;
+                        if let Some(ref mut ds) = s.dcomp_state {
+                            let _ = ds.dcomp_target.clear_root();
+                            let _ = ds.dcomp_device.commit();
+                            ds.sizing = true;
+                        }
                     }
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                 }
                 None
             },
             WM_EXITSIZEMOVE => unsafe {
-                if self.state.borrow().as_ref().unwrap().dcomp_state.is_some() {
-                    let mut rect: RECT = mem::uninitialized();
-                    GetClientRect(hwnd, &mut rect);
-                    let width = (rect.right - rect.left) as u32;
-                    let height = (rect.bottom - rect.top) as u32;
-                    let res = (*self
-                        .state
-                        .borrow_mut()
-                        .as_mut()
-                        .unwrap()
-                        .dcomp_state
-                        .as_mut()
-                        .unwrap()
-                        .swap_chain)
-                        .ResizeBuffers(2, width, height, DXGI_FORMAT_UNKNOWN, 0);
-                    if SUCCEEDED(res) {
-                        self.handler.rebuild_resources();
-                        self.rebuild_render_target();
-                        self.render();
-                        let mut state = self.state.borrow_mut();
-                        let s = state.as_mut().unwrap();
-                        (*s.dcomp_state.as_ref().unwrap().swap_chain).Present(0, 0);
-                    } else {
-                        println!("ResizeBuffers failed: 0x{:x}", res);
-                    }
-
-                    // Flush to present flicker artifact (old swapchain composited)
-                    // It might actually be better to create a new swapchain here.
-                    DwmFlush();
-
-                    let mut state = self.state.borrow_mut();
-                    let s = state.as_mut().unwrap();
-                    if let Some(ref mut ds) = s.dcomp_state {
-                        let _ = ds.dcomp_target.set_root(&mut ds.swapchain_visual);
-                        let _ = ds.dcomp_device.commit();
-                        ds.sizing = false;
-                    }
-                }
-                None
-            },
-            WM_SIZE => unsafe {
-                let width = LOWORD(lparam as u32) as u32;
-                let height = HIWORD(lparam as u32) as u32;
-                self.handler.size(width, height);
-                let use_hwnd = if let Some(ref dcomp_state) =
-                    self.state.borrow().as_ref().unwrap().dcomp_state
-                {
-                    dcomp_state.sizing
-                } else {
-                    true
-                };
-                if use_hwnd {
-                    let mut state = self.state.borrow_mut();
-                    let s = state.as_mut().unwrap();
-                    if let Some(ref mut rt) = s.render_target {
-                        if let Some(hrt) = cast_to_hwnd(rt) {
-                            let width = LOWORD(lparam as u32) as u32;
-                            let height = HIWORD(lparam as u32) as u32;
-                            let size = SizeU(D2D1_SIZE_U { width, height });
-                            let _ = hrt.resize(size);
-                        }
-                    }
-                    InvalidateRect(hwnd, null_mut(), FALSE);
-                } else {
-                    let res;
-                    {
-                        let mut state = self.state.borrow_mut();
-                        let mut s = state.as_mut().unwrap();
-                        s.render_target = None;
-                        res = (*s.dcomp_state.as_mut().unwrap().swap_chain).ResizeBuffers(
-                            0,
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    if s.dcomp_state.is_some() {
+                        let mut rect: RECT = mem::uninitialized();
+                        GetClientRect(hwnd, &mut rect);
+                        let width = (rect.right - rect.left) as u32;
+                        let height = (rect.bottom - rect.top) as u32;
+                        let res = (*s.dcomp_state.as_mut().unwrap().swap_chain).ResizeBuffers(
+                            2,
                             width,
                             height,
                             DXGI_FORMAT_UNKNOWN,
                             0,
                         );
-                    }
-                    if SUCCEEDED(res) {
-                        self.rebuild_render_target();
-                        self.render();
-                        let mut state = self.state.borrow_mut();
-                        let s = state.as_mut().unwrap();
-                        if let Some(ref mut dcomp_state) = s.dcomp_state {
-                            (*dcomp_state.swap_chain).Present(0, 0);
-                            let _ = dcomp_state.dcomp_device.commit();
+                        if SUCCEEDED(res) {
+                            let mut ctx = WinCtxImpl {
+                                handle: &self.handle.borrow(),
+                            };
+                            s.handler.rebuild_resources(&mut ctx);
+                            s.rebuild_render_target(&self.d2d_factory);
+                            s.render(&self.d2d_factory, &self.dwrite_factory, &self.handle);
+                            (*s.dcomp_state.as_ref().unwrap().swap_chain).Present(0, 0);
+                        } else {
+                            println!("ResizeBuffers failed: 0x{:x}", res);
                         }
-                        ValidateRect(hwnd, null_mut());
-                    } else {
-                        println!("ResizeBuffers failed: 0x{:x}", res);
+
+                        // Flush to present flicker artifact (old swapchain composited)
+                        // It might actually be better to create a new swapchain here.
+                        DwmFlush();
+
+                        if let Some(ref mut ds) = s.dcomp_state {
+                            let _ = ds.dcomp_target.set_root(&mut ds.swapchain_visual);
+                            let _ = ds.dcomp_device.commit();
+                            ds.sizing = false;
+                        }
                     }
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
+                }
+                None
+            },
+            WM_SIZE => unsafe {
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let width = LOWORD(lparam as u32) as u32;
+                    let height = HIWORD(lparam as u32) as u32;
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    s.handler.size(width, height, &mut ctx);
+                    let use_hwnd = if let Some(ref dcomp_state) = s.dcomp_state {
+                        dcomp_state.sizing
+                    } else {
+                        true
+                    };
+                    if use_hwnd {
+                        if let Some(ref mut rt) = s.render_target {
+                            if let Some(hrt) = cast_to_hwnd(rt) {
+                                let width = LOWORD(lparam as u32) as u32;
+                                let height = HIWORD(lparam as u32) as u32;
+                                let size = SizeU(D2D1_SIZE_U { width, height });
+                                let _ = hrt.resize(size);
+                            }
+                        }
+                        InvalidateRect(hwnd, null_mut(), FALSE);
+                    } else {
+                        let res;
+                        {
+                            s.render_target = None;
+                            res = (*s.dcomp_state.as_mut().unwrap().swap_chain).ResizeBuffers(
+                                0,
+                                width,
+                                height,
+                                DXGI_FORMAT_UNKNOWN,
+                                0,
+                            );
+                        }
+                        if SUCCEEDED(res) {
+                            s.rebuild_render_target(&self.d2d_factory);
+                            s.render(&self.d2d_factory, &self.dwrite_factory, &self.handle);
+                            if let Some(ref mut dcomp_state) = s.dcomp_state {
+                                (*dcomp_state.swap_chain).Present(0, 0);
+                                let _ = dcomp_state.dcomp_device.commit();
+                            }
+                            ValidateRect(hwnd, null_mut());
+                        } else {
+                            println!("ResizeBuffers failed: 0x{:x}", res);
+                        }
+                    }
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                 }
                 Some(0)
             },
             WM_COMMAND => {
-                self.handler.command(LOWORD(wparam as u32) as u32);
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    s.handler.command(LOWORD(wparam as u32) as u32, &mut ctx);
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
+                }
                 Some(0)
             }
             WM_CHAR => {
-                let mut state = self.state.borrow_mut();
-                let mut s = state.as_mut().unwrap();
-                //FIXME: this can receive lone surrogate pairs?
-                let key_code = s.stashed_key_code;
-                s.stashed_char = std::char::from_u32(wparam as u32);
-                let text = match s.stashed_char {
-                    Some(c) => c,
-                    None => {
-                        eprintln!("failed to convert WM_CHAR to char: {:#X}", wparam);
-                        return None;
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    //FIXME: this can receive lone surrogate pairs?
+                    let key_code = s.stashed_key_code;
+                    s.stashed_char = std::char::from_u32(wparam as u32);
+                    let text = match s.stashed_char {
+                        Some(c) => c,
+                        None => {
+                            eprintln!("failed to convert WM_CHAR to char: {:#X}", wparam);
+                            return None;
+                        }
+                    };
+
+                    let modifiers = get_mod_state();
+                    let is_repeat = (lparam & 0xFFFF) > 0;
+                    let event = KeyEvent::new(key_code, is_repeat, modifiers, text, text);
+
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    if s.handler.key_down(event, &mut ctx) {
+                        Some(0)
+                    } else {
+                        None
                     }
-                };
-
-                let modifiers = get_mod_state();
-                let is_repeat = (lparam & 0xFFFF) > 0;
-                let event = KeyEvent::new(key_code, is_repeat, modifiers, text, text);
-
-                if self.handler.key_down(event) {
-                    Some(0)
                 } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                     None
                 }
             }
             WM_KEYDOWN | WM_SYSKEYDOWN => {
-                let mut state = self.state.borrow_mut();
-                let mut s = state.as_mut().unwrap();
-                let key_code: KeyCode = (wparam as i32).into();
-                s.stashed_key_code = key_code;
-                if key_code.is_printable() {
-                    //FIXME: this will fail to propogate key combinations such as alt+s
-                    return None;
-                }
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let key_code: KeyCode = (wparam as i32).into();
+                    s.stashed_key_code = key_code;
+                    if key_code.is_printable() {
+                        //FIXME: this will fail to propogate key combinations such as alt+s
+                        return None;
+                    }
 
-                let modifiers = get_mod_state();
-                // bits 0-15 of iparam are the repeat count:
-                // https://docs.microsoft.com/en-ca/windows/desktop/inputdev/wm-keydown
-                let is_repeat = (lparam & 0xFFFF) > 0;
-                let event = KeyEvent::new(key_code, is_repeat, modifiers, "", "");
+                    let modifiers = get_mod_state();
+                    // bits 0-15 of iparam are the repeat count:
+                    // https://docs.microsoft.com/en-ca/windows/desktop/inputdev/wm-keydown
+                    let is_repeat = (lparam & 0xFFFF) > 0;
+                    let event = KeyEvent::new(key_code, is_repeat, modifiers, "", "");
 
-                if self.handler.key_down(event) {
-                    Some(0)
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    if s.handler.key_down(event, &mut ctx) {
+                        Some(0)
+                    } else {
+                        None
+                    }
                 } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                     None
                 }
             }
             WM_KEYUP => {
-                let mut state = self.state.borrow_mut();
-                let s = state.as_mut().unwrap();
-                let key_code: KeyCode = (wparam as i32).into();
-                let modifiers = get_mod_state();
-                let is_repeat = false;
-                let text = s.stashed_char.take();
-                let event = KeyEvent::new(key_code, is_repeat, modifiers, text, text);
-                self.handler.key_up(event);
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let key_code: KeyCode = (wparam as i32).into();
+                    let modifiers = get_mod_state();
+                    let is_repeat = false;
+                    let text = s.stashed_char.take();
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    let event = KeyEvent::new(key_code, is_repeat, modifiers, text, text);
+                    s.handler.key_up(event, &mut ctx);
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
+                }
                 Some(0)
             }
             //TODO: WM_SYSCOMMAND
             WM_MOUSEWHEEL => {
                 // TODO: apply mouse sensitivity based on
                 // SPI_GETWHEELSCROLLLINES setting.
-                let delta_y = HIWORD(wparam as u32) as i16 as f64;
-                let delta = Vec2::new(0.0, -delta_y);
-                let mods = get_mod_state();
-                self.handler.wheel(delta, mods);
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let delta_y = HIWORD(wparam as u32) as i16 as f64;
+                    let delta = Vec2::new(0.0, -delta_y);
+                    let mods = get_mod_state();
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    s.handler.wheel(delta, mods, &mut ctx);
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
+                }
                 Some(0)
             }
             WM_MOUSEHWHEEL => {
-                let delta_x = HIWORD(wparam as u32) as i16 as f64;
-                let delta = Vec2::new(delta_x, 0.0);
-                let mods = get_mod_state();
-                self.handler.wheel(delta, mods);
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let delta_x = HIWORD(wparam as u32) as i16 as f64;
+                    let delta = Vec2::new(delta_x, 0.0);
+                    let mods = get_mod_state();
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    s.handler.wheel(delta, mods, &mut ctx);
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
+                }
                 Some(0)
             }
             WM_MOUSEMOVE => {
-                let x = LOWORD(lparam as u32) as i16 as i32;
-                let y = HIWORD(lparam as u32) as i16 as i32;
-                let (px, py) = self.handle.borrow().pixels_to_px_xy(x, y);
-                let pos = Point::new(px as f64, py as f64);
-                let mods = get_mod_state();
-                let button = match wparam {
-                    w if (w & 1) > 0 => MouseButton::Left,
-                    w if (w & 1 << 1) > 0 => MouseButton::Right,
-                    w if (w & 1 << 5) > 0 => MouseButton::Middle,
-                    w if (w & 1 << 6) > 0 => MouseButton::X1,
-                    w if (w & 1 << 7) > 0 => MouseButton::X2,
-                    //FIXME: I guess we probably do want `MouseButton::None`?
-                    //this feels bad, but also this gets discarded in druid anyway.
-                    _ => MouseButton::Left,
-                };
-                let event = MouseEvent {
-                    pos,
-                    mods,
-                    button,
-                    count: 0,
-                };
-                self.handler.mouse_move(&event);
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let x = LOWORD(lparam as u32) as i16 as i32;
+                    let y = HIWORD(lparam as u32) as i16 as i32;
+                    let (px, py) = self.handle.borrow().pixels_to_px_xy(x, y);
+                    let pos = Point::new(px as f64, py as f64);
+                    let mods = get_mod_state();
+                    let button = match wparam {
+                        w if (w & 1) > 0 => MouseButton::Left,
+                        w if (w & 1 << 1) > 0 => MouseButton::Right,
+                        w if (w & 1 << 5) > 0 => MouseButton::Middle,
+                        w if (w & 1 << 6) > 0 => MouseButton::X1,
+                        w if (w & 1 << 7) > 0 => MouseButton::X2,
+                        //FIXME: I guess we probably do want `MouseButton::None`?
+                        //this feels bad, but also this gets discarded in druid anyway.
+                        _ => MouseButton::Left,
+                    };
+                    let event = MouseEvent {
+                        pos,
+                        mods,
+                        button,
+                        count: 0,
+                    };
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    s.handler.mouse_move(&event, &mut ctx);
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
+                }
                 Some(0)
             }
             // TODO: not clear where double-click processing should happen. Currently disabled
@@ -515,56 +593,79 @@ impl WndProc for MyWndProc {
             WM_LBUTTONDBLCLK | WM_LBUTTONDOWN | WM_LBUTTONUP | WM_MBUTTONDBLCLK
             | WM_MBUTTONDOWN | WM_MBUTTONUP | WM_RBUTTONDBLCLK | WM_RBUTTONDOWN | WM_RBUTTONUP
             | WM_XBUTTONDBLCLK | WM_XBUTTONDOWN | WM_XBUTTONUP => {
-                let button = match msg {
-                    WM_LBUTTONDBLCLK | WM_LBUTTONDOWN | WM_LBUTTONUP => MouseButton::Left,
-                    WM_MBUTTONDBLCLK | WM_MBUTTONDOWN | WM_MBUTTONUP => MouseButton::Middle,
-                    WM_RBUTTONDBLCLK | WM_RBUTTONDOWN | WM_RBUTTONUP => MouseButton::Right,
-                    WM_XBUTTONDBLCLK | WM_XBUTTONDOWN | WM_XBUTTONUP => match HIWORD(wparam as u32)
-                    {
-                        1 => MouseButton::X1,
-                        2 => MouseButton::X2,
-                        _ => {
-                            println!("unexpected X button event");
-                            return None;
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let button = match msg {
+                        WM_LBUTTONDBLCLK | WM_LBUTTONDOWN | WM_LBUTTONUP => MouseButton::Left,
+                        WM_MBUTTONDBLCLK | WM_MBUTTONDOWN | WM_MBUTTONUP => MouseButton::Middle,
+                        WM_RBUTTONDBLCLK | WM_RBUTTONDOWN | WM_RBUTTONUP => MouseButton::Right,
+                        WM_XBUTTONDBLCLK | WM_XBUTTONDOWN | WM_XBUTTONUP => {
+                            match HIWORD(wparam as u32) {
+                                1 => MouseButton::X1,
+                                2 => MouseButton::X2,
+                                _ => {
+                                    println!("unexpected X button event");
+                                    return None;
+                                }
+                            }
                         }
-                    },
-                    _ => unreachable!(),
-                };
-                let count = match msg {
-                    WM_LBUTTONDOWN | WM_MBUTTONDOWN | WM_RBUTTONDOWN | WM_XBUTTONDOWN => 1,
-                    WM_LBUTTONDBLCLK | WM_MBUTTONDBLCLK | WM_RBUTTONDBLCLK | WM_XBUTTONDBLCLK => 2,
-                    WM_LBUTTONUP | WM_MBUTTONUP | WM_RBUTTONUP | WM_XBUTTONUP => 0,
-                    _ => unreachable!(),
-                };
-                let x = LOWORD(lparam as u32) as i16 as i32;
-                let y = HIWORD(lparam as u32) as i16 as i32;
-                let (px, py) = self.handle.borrow().pixels_to_px_xy(x, y);
-                let pos = Point::new(px as f64, py as f64);
-                let mods = get_mod_state();
-                let event = MouseEvent {
-                    pos,
-                    mods,
-                    button,
-                    count,
-                };
-                if count > 0 {
-                    self.handler.mouse_down(&event);
+                        _ => unreachable!(),
+                    };
+                    let count = match msg {
+                        WM_LBUTTONDOWN | WM_MBUTTONDOWN | WM_RBUTTONDOWN | WM_XBUTTONDOWN => 1,
+                        WM_LBUTTONDBLCLK | WM_MBUTTONDBLCLK | WM_RBUTTONDBLCLK
+                        | WM_XBUTTONDBLCLK => 2,
+                        WM_LBUTTONUP | WM_MBUTTONUP | WM_RBUTTONUP | WM_XBUTTONUP => 0,
+                        _ => unreachable!(),
+                    };
+                    let x = LOWORD(lparam as u32) as i16 as i32;
+                    let y = HIWORD(lparam as u32) as i16 as i32;
+                    let (px, py) = self.handle.borrow().pixels_to_px_xy(x, y);
+                    let pos = Point::new(px as f64, py as f64);
+                    let mods = get_mod_state();
+                    let event = MouseEvent {
+                        pos,
+                        mods,
+                        button,
+                        count,
+                    };
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    if count > 0 {
+                        s.handler.mouse_down(&event, &mut ctx);
+                    } else {
+                        s.handler.mouse_up(&event, &mut ctx);
+                    }
                 } else {
-                    self.handler.mouse_up(&event);
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                 }
                 Some(0)
             }
             WM_DESTROY => {
-                self.handler.destroy();
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let mut ctx = WinCtxImpl {
+                        handle: &self.handle.borrow(),
+                    };
+                    s.handler.destroy(&mut ctx);
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
+                }
                 None
             }
             XI_RUN_IDLE => {
-                let queue = self.handle.borrow().take_idle_queue();
-                let handler_as_any = self.handler.as_any();
-                for callback in queue {
-                    callback.call(handler_as_any);
+                if let Ok(mut s) = self.state.try_borrow_mut() {
+                    let s = s.as_mut().unwrap();
+                    let queue = self.handle.borrow().take_idle_queue();
+                    let handler_as_any = s.handler.as_any();
+                    for callback in queue {
+                        callback.call(handler_as_any);
+                    }
+                    Some(0)
+                } else {
+                    None
                 }
-                Some(0)
             }
             _ => None,
         }
@@ -648,7 +749,6 @@ impl WindowBuilder {
             (*dwrite_factory.get_raw()).AddRef();
             let dw_clone = directwrite::Factory::from_raw(dwrite_factory.get_raw());
             let wndproc = MyWndProc {
-                handler: self.handler.unwrap(),
                 handle: Default::default(),
                 d2d_factory: direct2d::Factory::new().unwrap(),
                 dwrite_factory: dw_clone,
@@ -713,6 +813,7 @@ impl WindowBuilder {
 
             win.hwnd.set(hwnd);
             let state = WndState {
+                handler: self.handler.unwrap(),
                 render_target: None,
                 dcomp_state,
                 dpi,
@@ -961,6 +1062,10 @@ impl WindowHandle {
         self.state.upgrade().map(|w| w.hwnd.get())
     }
 
+    /// Open a modal file dialog.
+    ///
+    /// Note: this method will be reworked to avoid reentrancy problems.
+    /// Currently, calling it may result in important messages being dropped.
     pub fn file_dialog(
         &self,
         ty: FileDialogType,
@@ -1017,6 +1122,11 @@ impl WindowHandle {
         ((x.into() as f32) * scale, (y.into() as f32) * scale)
     }
 
+    /// Get a reference to the text factory.
+    ///
+    /// Note: this is provisional, expected to move to WinCtxImpl, and at
+    /// that point the signature will probably change (getting rid of the
+    /// `RefCell`).
     pub fn get_text(&self) -> &RefCell<directwrite::Factory> {
         &self.dwrite_factory.as_ref().unwrap()
     }
@@ -1031,7 +1141,7 @@ impl IdleHandle {
     /// which means it won't be scheduled if the window is closed.
     pub fn add_idle<F>(&self, callback: F)
     where
-        F: FnOnce(&dyn Any) + Send + 'static,
+        F: FnOnce(&mut dyn Any) + Send + 'static,
     {
         let mut queue = self.queue.lock().unwrap();
         if queue.is_empty() {
@@ -1046,6 +1156,14 @@ impl IdleHandle {
         unsafe {
             InvalidateRect(self.hwnd, null(), FALSE);
         }
+    }
+}
+
+// Note: this has mostly methods moved from `WindowHandle`, so mostly forwards
+// to those. As a cleanup, some may be implemented more directly.
+impl<'a> WinCtx for WinCtxImpl<'a> {
+    fn invalidate(&mut self) {
+        self.handle.invalidate();
     }
 }
 

--- a/src/widget/action_wrapper.rs
+++ b/src/widget/action_wrapper.rs
@@ -15,8 +15,8 @@
 //! A widget that listens for events and invokes a closure.
 
 use crate::{
-    Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
-    Rect, Size, UpdateCtx, Widget,
+    Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Size,
+    UpdateCtx, Widget,
 };
 
 pub struct ActionWrapper<T: Data, F: FnMut(&mut T, &Env)> {

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -101,7 +101,7 @@ impl<T: Data> Flex<T> {
 }
 
 impl<T: Data> Widget<T> for Flex<T> {
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
         for child in &mut self.children {
             child.widget.paint_with_offset(paint_ctx, data, env);
         }


### PR DESCRIPTION
This makes methods on `WinHandler` mostly `&mut self`, and does `try_borrow_mut` for this state in the wndproc handler.

It's not complete, as there are more methods that should move from `WindowHandle` to `WinCtx`, including dpi calculation, but it does fix the panics in the attached bug. These further refinements should be possible without significant reorganization. And at some point I should be able to add text measurement in layout and event contexts.

Fixes #76