### PR TITLE
Rename KeyEvent.modifers -> .mods (for consistency)

### DIFF
--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -24,7 +24,7 @@ pub struct KeyEvent {
     /// Whether or not this event is a repeat (the key was held down)
     pub is_repeat: bool,
     /// The modifiers for this event.
-    pub modifiers: KeyModifiers,
+    pub mods: KeyModifiers,
     // these are exposed via methods, below. The rationale for this approach is
     // that a key might produce more than a single 'char' of input, but we don't
     // want to need a heap allocation in the trivial case. This gives us 15 bytes
@@ -42,7 +42,7 @@ impl KeyEvent {
     pub(crate) fn new(
         key_code: impl Into<KeyCode>,
         is_repeat: bool,
-        modifiers: KeyModifiers,
+        mods: KeyModifiers,
         text: impl Into<StrOrChar>,
         unmodified_text: impl Into<StrOrChar>,
     ) -> Self {
@@ -58,7 +58,7 @@ impl KeyEvent {
         KeyEvent {
             key_code: key_code.into(),
             is_repeat,
-            modifiers,
+            mods,
             text,
             unmodified_text,
         }

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -420,7 +420,7 @@ extern "C" fn key_down(this: &mut Object, _: Sel, nsevent: id) {
         nsview: &(*view_state).nsview,
     };
     (*view_state).handler.key_down(event, &mut ctx);
-    view_state.last_mods = event.modifiers;
+    view_state.last_mods = event.mods;
 }
 
 extern "C" fn key_up(this: &mut Object, _: Sel, nsevent: id) {
@@ -433,7 +433,7 @@ extern "C" fn key_up(this: &mut Object, _: Sel, nsevent: id) {
         nsview: &(*view_state).nsview,
     };
     (*view_state).handler.key_up(event, &mut ctx);
-    view_state.last_mods = event.modifiers;
+    view_state.last_mods = event.mods;
 }
 
 extern "C" fn mods_changed(this: &mut Object, _: Sel, nsevent: id) {
@@ -442,7 +442,7 @@ extern "C" fn mods_changed(this: &mut Object, _: Sel, nsevent: id) {
         &mut *(view_state as *mut ViewState)
     };
     let (down, event) = mods_changed_key_event(view_state.last_mods, nsevent);
-    view_state.last_mods = event.modifiers;
+    view_state.last_mods = event.mods;
     let mut ctx = WinCtxImpl {
         nsview: &(*view_state).nsview,
     };


### PR DESCRIPTION
This is `mods` in `MouseEvent` and `WheelEvent`. 🤷‍♂ 