### PR TITLE
Add text layout capability to widget contexts

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -649,14 +649,14 @@ impl IdleHandle {
     }
 }
 
-impl<'a> WinCtx for WinCtxImpl<'a> {
+impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
     fn invalidate(&mut self) {
         unsafe {
             let () = msg_send![*self.nsview.load(), setNeedsDisplay: YES];
         }
     }
 
-    fn text_factory<'b>(&'b mut self) -> &'b mut Text<'b> {
+    fn text_factory(&mut self) -> &mut Text<'a> {
         &mut self.text
     }
 }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -46,6 +46,13 @@ pub trait WinCtx {
     /// TODO: finer grained invalidation.
     fn invalidate(&mut self);
 
+    /// Get a reference to an object that can do text layout.
+    ///
+    /// TODO: the lifetime parameter on `Text` should probably be an
+    /// [existential lifetime]. There's a tracking issue for that in
+    /// Rust, but until then unsafe will probably be needed.
+    ///
+    /// [existential lifetime]: https://github.com/rust-lang/rust/issues/60670
     fn text_factory<'a>(&'a mut self) -> &'a mut Text<'a>;
 }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -21,6 +21,10 @@ pub use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::kurbo::{Point, Vec2};
 use crate::platform;
 
+// It's possible we'll want to make this type alias at a lower level,
+// see https://github.com/linebender/piet/pull/37 for more discussion.
+pub type Text<'a> = <piet_common::Piet<'a> as piet_common::RenderContext>::Text;
+
 // Handle to Window Level Utilities
 #[derive(Clone, Default)]
 pub struct WindowHandle {
@@ -41,6 +45,8 @@ pub trait WinCtx {
     ///
     /// TODO: finer grained invalidation.
     fn invalidate(&mut self);
+
+    fn text_factory<'a>(&'a mut self) -> &'a mut Text<'a>;
 }
 
 /// App behavior, supplied by the app.

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -40,20 +40,14 @@ impl Deref for WindowHandle {
 }
 
 /// A context supplied to most `WinHandler` methods.
-pub trait WinCtx {
+pub trait WinCtx<'a> {
     /// Invalidate the entire window.
     ///
     /// TODO: finer grained invalidation.
     fn invalidate(&mut self);
 
     /// Get a reference to an object that can do text layout.
-    ///
-    /// TODO: the lifetime parameter on `Text` should probably be an
-    /// [existential lifetime]. There's a tracking issue for that in
-    /// Rust, but until then unsafe will probably be needed.
-    ///
-    /// [existential lifetime]: https://github.com/rust-lang/rust/issues/60670
-    fn text_factory<'a>(&'a mut self) -> &'a mut Text<'a>;
+    fn text_factory(&mut self) -> &mut Text<'a>;
 }
 
 /// App behavior, supplied by the app.

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -1169,22 +1169,14 @@ impl IdleHandle {
 
 // Note: this has mostly methods moved from `WindowHandle`, so mostly forwards
 // to those. As a cleanup, some may be implemented more directly.
-impl<'a> WinCtx for WinCtxImpl<'a> {
+impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
     fn invalidate(&mut self) {
         self.handle.invalidate();
     }
 
     /// Get a reference to the text factory.
-    fn text_factory<'b>(&'b mut self) -> &'b mut Text<'b> {
-        // This unsafe transmute is to get around the lack of existential
-        // lifetimes. The statement we want to make is that the `Text`
-        // object will contain references with a lifetime at least as long
-        // as `'b` (the lifetime of `self`).
-        //
-        // But we can't express that (yet), so instead we assert that the
-        // lifetime is the same. This is safe for all uses, as we only
-        // pass a `WinCtx` down to app code.
-        unsafe { std::mem::transmute(&mut self.text) }
+    fn text_factory(&mut self) -> &mut Text<'a> {
+        &mut self.text
     }
 }
 

--- a/druid-shell/src/windows/win_main.rs
+++ b/druid-shell/src/windows/win_main.rs
@@ -36,7 +36,7 @@ struct RunLoopState {
 unsafe impl Send for Listener {}
 struct Listener {
     h: HANDLE,
-    callback: Box<FnMut()>,
+    callback: Box<dyn FnMut()>,
 }
 
 pub struct RunLoop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,9 @@ pub struct PaintCtx<'a, 'b: 'a> {
     pub render_ctx: &'a mut Piet<'b>,
 }
 
-pub struct LayoutCtx {}
+pub struct LayoutCtx<'a, 'b: 'a> {
+    text: &'a mut druid_shell::window::Text<'b>,
+}
 
 pub struct EventCtx<'a> {
     window: &'a WindowHandle,
@@ -374,7 +376,8 @@ impl<T: Data> UiState<T> {
     fn paint(&mut self, piet: &mut Piet) -> bool {
         let bc = BoxConstraints::tight(self.size);
         let env = self.root_env();
-        let mut layout_ctx = LayoutCtx {};
+        let text = piet.text();
+        let mut layout_ctx = LayoutCtx { text };
         let size = self.root.layout(&mut layout_ctx, &bc, &self.data, &env);
         self.root.state.layout_rect = Rect::from_origin_size(Point::ORIGIN, size);
         piet.clear(BACKGROUND_COLOR);
@@ -534,6 +537,12 @@ impl<'a> EventCtx<'a> {
     /// Determine whether the event has been handled by some other widget.
     pub fn is_handled(&self) -> bool {
         self.is_handled
+    }
+}
+
+impl<'a, 'b> LayoutCtx<'a, 'b> {
+    pub fn text(&mut self) -> &mut druid_shell::window::Text<'b> {
+        &mut self.text
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 pub use druid_shell::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 #[allow(unused)]
 use druid_shell::platform::IdleHandle;
-use druid_shell::window::{self, WinCtx, WinHandler, WindowHandle};
+use druid_shell::window::{self, Text, WinCtx, WinHandler, WindowHandle};
 pub use druid_shell::window::{Cursor, MouseButton, MouseEvent};
 
 pub use data::Data;
@@ -140,10 +140,13 @@ pub struct PaintCtx<'a, 'b: 'a> {
 }
 
 pub struct LayoutCtx<'a, 'b: 'a> {
-    text: &'a mut druid_shell::window::Text<'b>,
+    text: &'a mut Text<'b>,
 }
 
-pub struct EventCtx<'a> {
+/// A mutable context provided to event handling methods of widgets.
+pub struct EventCtx<'a, 'b> {
+    win_ctx: &'a mut dyn WinCtx<'b>,
+    // TODO: migrate most usage of `WindowHandle` to `WinCtx` instead.
     window: &'a WindowHandle,
     base_state: &'a mut BaseState,
     had_active: bool,
@@ -238,6 +241,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
         let had_active = self.state.has_active;
         let mut child_ctx = EventCtx {
+            win_ctx: ctx.win_ctx,
             window: &ctx.window,
             base_state: &mut self.state,
             had_active,
@@ -352,6 +356,7 @@ impl<T: Data> UiState<T> {
         // should there be a root base state persisting in the ui state instead?
         let mut base_state = Default::default();
         let mut ctx = EventCtx {
+            win_ctx,
             window: &self.handle,
             base_state: &mut base_state,
             had_active: self.root.state.has_active,
@@ -367,7 +372,7 @@ impl<T: Data> UiState<T> {
         // a burst of events.
         self.root.update(&mut update_ctx, &self.data, &env);
         if ctx.base_state.needs_inval || update_ctx.needs_inval {
-            win_ctx.invalidate();
+            ctx.win_ctx.invalidate();
         }
         // TODO: process actions
         ctx.is_handled()
@@ -501,29 +506,58 @@ impl Env {
     }
 }
 
-impl<'a> EventCtx<'a> {
+impl<'a, 'b> EventCtx<'a, 'b> {
     /// Invalidate.
     ///
     /// Right now, it just invalidates the entire window, but we'll want
     /// finer grained invalidation before long.
     pub fn invalidate(&mut self) {
+        // Note: for the current functionality, we could shortcut and just
+        // request an invalidate on the window. But when we do fine-grained
+        // invalidation, we'll want to compute the invalidation region, and
+        // that needs to be propagated (with, likely, special handling for
+        // scrolling).
         self.base_state.needs_inval = true;
     }
 
+    /// Get an object which can create text layouts.
+    pub fn text(&mut self) -> &mut Text<'b> {
+        self.win_ctx.text_factory()
+    }
+
+    /// Set the "active" state of the widget.
+    ///
+    /// The active state basically captures a mouse press inside the widget.
+    /// Thus, a button should set this to true on mouse down and false on
+    /// mouse up.
+    ///
+    /// While a widget is active, all mouse events are routed to it.
     pub fn set_active(&mut self, active: bool) {
         self.base_state.is_active = active;
         // TODO: plumb mouse grab through to platform (through druid-shell)
     }
 
+    /// Query the "hot" state of the widget.
+    ///
+    /// A widget is hot when the mouse is hovering.
     pub fn is_hot(&self) -> bool {
         self.base_state.is_hot
     }
 
+    /// Query the "active" state of the widget.
+    ///
+    /// This is the same state set by [`set_active`](#method.set_active) and
+    /// is provided as a convenience.
     pub fn is_active(&self) -> bool {
         self.base_state.is_active
     }
 
     /// Returns a reference to the current `WindowHandle`.
+    ///
+    /// Note: we're in the process of migrating towards providing functionality
+    /// provided by the window handle in mutable contexts instead. If you're
+    /// considering a new use of this method, try adding it to `WinCtx` and
+    /// plumbing it through instead.
     pub fn window(&self) -> &WindowHandle {
         &self.window
     }
@@ -541,7 +575,8 @@ impl<'a> EventCtx<'a> {
 }
 
 impl<'a, 'b> LayoutCtx<'a, 'b> {
-    pub fn text(&mut self) -> &mut druid_shell::window::Text<'b> {
+    /// Get an object which can create text layouts.
+    pub fn text(&mut self) -> &mut Text<'b> {
         &mut self.text
     }
 }


### PR DESCRIPTION
With this patch, the event, update, and layout contexts all have a `text` method which allows the creation of text layout objects. There's also a bit of documentation and other cleanup.

This patch is part of a general migration of functionality into methods on mutable contexts which are passed down. This pattern is flexible and robust than the previous pattern of stashing a shared reference to a "window handle" and using interior mutability.

Thanks to @SimonSapin for helping with some particularly tricky borrow checker issues.