### PR TITLE
Improved set_cursor handling

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -551,23 +551,6 @@ impl WindowHandle {
         }
     }
 
-    /// Set the current mouse cursor.
-    pub fn set_cursor(&self, cursor: &Cursor) {
-        unsafe {
-            let nscursor = class!(NSCursor);
-            let cursor: id = match cursor {
-                Cursor::Arrow => msg_send![nscursor, arrowCursor],
-                Cursor::IBeam => msg_send![nscursor, IBeamCursor],
-                Cursor::Crosshair => msg_send![nscursor, crosshairCursor],
-                Cursor::OpenHand => msg_send![nscursor, openHandCursor],
-                Cursor::NotAllowed => msg_send![nscursor, operationNotAllowedCursor],
-                Cursor::ResizeLeftRight => msg_send![nscursor, resizeLeftRightCursor],
-                Cursor::ResizeUpDown => msg_send![nscursor, ResizeUpDownCursor],
-            };
-            msg_send![cursor, set];
-        }
-    }
-
     /// Get a handle that can be used to schedule an idle task.
     pub fn get_idle_handle(&self) -> Option<IdleHandle> {
         // TODO: maybe try harder to return None if window has been dropped.
@@ -658,6 +641,22 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
 
     fn text_factory(&mut self) -> &mut Text<'a> {
         &mut self.text
+    }
+
+    fn set_cursor(&mut self, cursor: &Cursor) {
+        unsafe {
+            let nscursor = class!(NSCursor);
+            let cursor: id = match cursor {
+                Cursor::Arrow => msg_send![nscursor, arrowCursor],
+                Cursor::IBeam => msg_send![nscursor, IBeamCursor],
+                Cursor::Crosshair => msg_send![nscursor, crosshairCursor],
+                Cursor::OpenHand => msg_send![nscursor, openHandCursor],
+                Cursor::NotAllowed => msg_send![nscursor, operationNotAllowedCursor],
+                Cursor::ResizeLeftRight => msg_send![nscursor, resizeLeftRightCursor],
+                Cursor::ResizeUpDown => msg_send![nscursor, ResizeUpDownCursor],
+            };
+            msg_send![cursor, set];
+        }
     }
 }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -48,6 +48,9 @@ pub trait WinCtx<'a> {
 
     /// Get a reference to an object that can do text layout.
     fn text_factory(&mut self) -> &mut Text<'a>;
+
+    /// Set the cursor icon.
+    fn set_cursor(&mut self, cursor: &Cursor);
 }
 
 /// App behavior, supplied by the app.
@@ -165,6 +168,7 @@ pub enum MouseButton {
 //both Windows and macOS. We may want to provide polyfills for various additional cursors,
 //and we will also want to add some mechanism for adding custom cursors.
 /// Mouse cursors.
+#[derive(Clone)]
 pub enum Cursor {
     /// The default arrow cursor.
     Arrow,

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -74,7 +74,6 @@ pub struct WindowBuilder {
     handler: Option<Box<dyn WinHandler>>,
     dwStyle: DWORD,
     title: String,
-    cursor: Cursor,
     menu: Option<Menu>,
     present_strategy: PresentStrategy,
 }
@@ -696,7 +695,6 @@ impl WindowBuilder {
             handler: None,
             dwStyle: WS_OVERLAPPEDWINDOW,
             title: String::new(),
-            cursor: Cursor::Arrow,
             menu: None,
             present_strategy: Default::default(),
         }
@@ -721,11 +719,6 @@ impl WindowBuilder {
         self.title = title.into();
     }
 
-    /// Set the default cursor for the window.
-    pub fn set_cursor(&mut self, cursor: Cursor) {
-        self.cursor = cursor;
-    }
-
     pub fn set_menu(&mut self, menu: Menu) {
         self.menu = Some(menu);
     }
@@ -742,7 +735,6 @@ impl WindowBuilder {
             // TODO: probably want configurable class name.
             let class_name = "Xi Editor".to_wide();
             let icon = LoadIconW(0 as HINSTANCE, IDI_APPLICATION);
-            let cursor = LoadCursorW(0 as HINSTANCE, self.cursor.get_lpcwstr());
             let brush = CreateSolidBrush(0xffffff);
             let wnd = WNDCLASSW {
                 style: 0,
@@ -751,7 +743,7 @@ impl WindowBuilder {
                 cbWndExtra: 0,
                 hInstance: 0 as HINSTANCE,
                 hIcon: icon,
-                hCursor: cursor,
+                hCursor: 0 as HCURSOR,
                 hbrBackground: brush,
                 lpszMenuName: 0 as LPCWSTR,
                 lpszClassName: class_name.as_ptr(),
@@ -1059,14 +1051,6 @@ impl WindowHandle {
         }
     }
 
-    /// Set the current mouse cursor.
-    pub fn set_cursor(&self, cursor: &Cursor) {
-        unsafe {
-            let cursor = LoadCursorW(0 as HINSTANCE, cursor.get_lpcwstr());
-            SetCursor(cursor);
-        }
-    }
-
     /// Get the raw HWND handle, for uses that are not wrapped in
     /// druid_win_shell.
     pub fn get_hwnd(&self) -> Option<HWND> {
@@ -1171,6 +1155,14 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
     /// Get a reference to the text factory.
     fn text_factory(&mut self) -> &mut Text<'a> {
         &mut self.text
+    }
+
+    /// Set the cursor icon.
+    fn set_cursor(&mut self, cursor: &Cursor) {
+        unsafe {
+            let cursor = LoadCursorW(0 as HINSTANCE, cursor.get_lpcwstr());
+            SetCursor(cursor);
+        }
     }
 }
 


### PR DESCRIPTION
Move druid-shell handling from WinHandle to WinCtx.

Add a `set_cursor` method to `EventCtx`. Previously you'd get a window
handle and call `set_cursor` on that, but it's been removed.

The `EventCtx::set_cursor` method doesn't immediately delegate it
to the WinCtx, but instead defers it to the end of event propagation.

Don't set a default cursor in the window class on Windows (this
doesn't work). Instead expect it to be set in the mouse move handler,
and set the default to arrow when dispatching the mouse move event.