### PR TITLE
Impl deref for paintctx (#97)

### DIFF
--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -38,10 +38,8 @@ impl Widget<u32> for AnimWidget {
     ) {
         let center = Point::new(50.0, 50.0);
         let ambit = center + 45.0 * Vec2::from_angle((0.75 + self.t) * 2.0 * PI);
-        let brush = paint_ctx.render_ctx.solid_brush(Color::WHITE);
-        paint_ctx
-            .render_ctx
-            .stroke(Line::new(center, ambit), &brush, 1.0, None);
+        let brush = paint_ctx.solid_brush(Color::WHITE);
+        paint_ctx.stroke(Line::new(center, ambit), &brush, 1.0, None);
     }
 
     fn layout(

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -43,7 +43,7 @@ impl Widget<String> for CustomWidget {
     ) {
         // Let's draw a picture with Piet!
         // Clear the whole context with the color of your choice
-        paint_ctx.render_ctx.clear(Color::WHITE);
+        paint_ctx.clear(Color::WHITE);
 
         // Create an arbitrary bezier path
         // (base_state.size() returns the size of the layout rect we're painting in)
@@ -54,9 +54,9 @@ impl Widget<String> for CustomWidget {
             (base_state.size().width, base_state.size().height),
         );
         // Create a solid brush
-        let brush = paint_ctx.render_ctx.solid_brush(Color::rgb24(0x00_80_00));
+        let brush = paint_ctx.solid_brush(Color::rgb24(0x00_80_00));
         // Stroke the path with the brush, with thickness 1.0
-        paint_ctx.render_ctx.stroke(path, &brush, 1.0, None);
+        paint_ctx.stroke(path, &brush, 1.0, None);
 
         // Rectangles: the path for practical people
         let rect = Rect::from_origin_size((10., 10.), (100., 100.));
@@ -65,7 +65,7 @@ impl Widget<String> for CustomWidget {
             .render_ctx
             .solid_brush(Color::rgba32(0x00_00_00_7F));
         // A fill uses a brush, just like stroke, but it needs FillRule to be set
-        paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
+        paint_ctx.fill(rect, &brush, FillRule::NonZero);
 
         // Text is easy, if you ignore all these unwraps. Just pick a font and a size.
         let font = paint_ctx
@@ -103,7 +103,7 @@ impl Widget<String> for CustomWidget {
             .make_image(256, 256, &image_data, ImageFormat::RgbaSeparate)
             .unwrap();
         // The image is automatically scaled to fit the rect you pass to draw_image
-        paint_ctx.render_ctx.draw_image(
+        paint_ctx.draw_image(
             &image,
             Rect::from_origin_size(Point::ORIGIN, base_state.size()),
             InterpolationMode::Bilinear,

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -61,8 +61,7 @@ impl Widget<String> for CustomWidget {
         // Rectangles: the path for practical people
         let rect = Rect::from_origin_size((10., 10.), (100., 100.));
         // Note the Color:rgba32 which includes an alpha channel (7F in this case)
-        let brush = paint_ctx
-            .solid_brush(Color::rgba32(0x00_00_00_7F));
+        let brush = paint_ctx.solid_brush(Color::rgba32(0x00_00_00_7F));
         // A fill uses a brush, just like stroke, but it needs FillRule to be set
         paint_ctx.fill(rect, &brush, FillRule::NonZero);
 

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -62,14 +62,12 @@ impl Widget<String> for CustomWidget {
         let rect = Rect::from_origin_size((10., 10.), (100., 100.));
         // Note the Color:rgba32 which includes an alpha channel (7F in this case)
         let brush = paint_ctx
-            .render_ctx
             .solid_brush(Color::rgba32(0x00_00_00_7F));
         // A fill uses a brush, just like stroke, but it needs FillRule to be set
         paint_ctx.fill(rect, &brush, FillRule::NonZero);
 
         // Text is easy, if you ignore all these unwraps. Just pick a font and a size.
         let font = paint_ctx
-            .render_ctx
             .text()
             .new_font_by_name("Segoe UI", 24.0)
             .unwrap()
@@ -77,7 +75,6 @@ impl Widget<String> for CustomWidget {
             .unwrap();
         // Here's where we actually use the UI state
         let layout = paint_ctx
-            .render_ctx
             .text()
             .new_text_layout(&font, data)
             .unwrap()
@@ -86,7 +83,6 @@ impl Widget<String> for CustomWidget {
 
         // Let's rotate our text slightly. First we save our current (default) context:
         paint_ctx
-            .render_ctx
             .with_save(|rc| {
                 // Now we can rotate the context (or set a clip path, for instance):
                 rc.transform(Affine::rotate(0.1));
@@ -99,7 +95,6 @@ impl Widget<String> for CustomWidget {
         // Let's burn some CPU to make a (partially transparent) image buffer
         let image_data = make_image_data(256, 256);
         let image = paint_ctx
-            .render_ctx
             .make_image(256, 256, &image_data, ImageFormat::RgbaSeparate)
             .unwrap();
         // The image is automatically scaled to fit the rect you pass to draw_image

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,10 +302,10 @@ pub struct PaintCtx<'a, 'b: 'a> {
 }
 
 impl<'a, 'b: 'a> Deref for PaintCtx<'a, 'b> {
-    type Target = &'a mut Piet<'b>;
+    type Target = Piet<'b>;
 
     fn deref(&self) -> &Self::Target {
-        &self.render_ctx
+        self.render_ctx
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ pub struct Env {
 
 /// A context passed to paint methods of widgets.
 ///
-/// Widgets paint their appearance by calling methods on the 
+/// Widgets paint their appearance by calling methods on the
 /// `render_ctx`, which PaintCtx derefs to for convenience.
 /// This struct is expected to grow, for example to include the
 /// "damage region" indicating that only a subset of the entire
@@ -314,7 +314,6 @@ impl<'a, 'b: 'a> DerefMut for PaintCtx<'a, 'b> {
         &mut self.render_ctx
     }
 }
-
 
 /// A context provided to layout handling methods of widgets.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod lens;
 mod value;
 
 use std::any::Any;
+use std::ops::Deref;
 use std::ops::DerefMut;
 use std::time::Instant;
 
@@ -178,7 +179,8 @@ pub trait Widget<T> {
     /// Paint the widget appearance.
     ///
     /// The widget calls methods on the `render_ctx` field of the
-    /// `paint_ctx` in order to paint its appearance.
+    /// `paint_ctx` in order to paint its appearance. `paint_ctx` auto
+    /// derefs to `render_ctx` for convenience.
     ///
     /// Container widgets can paint a background before recursing to their
     /// children, or annotations (for example, scrollbars) by painting
@@ -289,14 +291,30 @@ pub struct Env {
 
 /// A context passed to paint methods of widgets.
 ///
-/// Widgets paint their appearance by calling methods on the
-/// `render_ctx`. This struct is expected to grow, for example to
-/// include the "damage region" indicating that only a subset of
-/// the entire widget hierarchy needs repainting.
+/// Widgets paint their appearance by calling methods on the 
+/// `render_ctx`, which PaintCtx derefs to for convenience.
+/// This struct is expected to grow, for example to include the
+/// "damage region" indicating that only a subset of the entire
+/// widget hierarchy needs repainting.
 pub struct PaintCtx<'a, 'b: 'a> {
     /// The render context for actually painting.
     pub render_ctx: &'a mut Piet<'b>,
 }
+
+impl<'a, 'b: 'a> Deref for PaintCtx<'a, 'b> {
+    type Target = &'a mut Piet<'b>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.render_ctx
+    }
+}
+
+impl<'a, 'b: 'a> DerefMut for PaintCtx<'a, 'b> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.render_ctx
+    }
+}
+
 
 /// A context provided to layout handling methods of widgets.
 ///
@@ -426,15 +444,13 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Paint the widget, translating it by the origin of its layout rectangle.
     // Discussion: should this be `paint` and the other `paint_raw`?
     pub fn paint_with_offset(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
-        if let Err(e) = paint_ctx.render_ctx.save() {
+        if let Err(e) = paint_ctx.save() {
             eprintln!("error saving render context: {:?}", e);
             return;
         }
-        paint_ctx
-            .render_ctx
-            .transform(Affine::translate(self.state.layout_rect.origin().to_vec2()));
+        paint_ctx.transform(Affine::translate(self.state.layout_rect.origin().to_vec2()));
         self.paint(paint_ctx, data, env);
-        if let Err(e) = paint_ctx.render_ctx.restore() {
+        if let Err(e) = paint_ctx.restore() {
             eprintln!("error restoring render context: {:?}", e);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ mod lens;
 mod value;
 
 use std::any::Any;
-use std::ops::Deref;
-use std::ops::DerefMut;
+use std::ops::{Deref, DerefMut};
+
 use std::time::Instant;
 
 use kurbo::{Affine, Point, Rect, Shape, Size, Vec2};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ impl<'a, 'b: 'a> Deref for PaintCtx<'a, 'b> {
 
 impl<'a, 'b: 'a> DerefMut for PaintCtx<'a, 'b> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.render_ctx
+        self.render_ctx
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -74,11 +74,9 @@ impl Label {
 impl<T: Data> Widget<T> for Label {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, _data: &T, _env: &Env) {
         let font_size = 15.0;
-        let text_layout = self.get_layout(paint_ctx.render_ctx, font_size);
-        let brush = paint_ctx.render_ctx.solid_brush(LABEL_TEXT_COLOR);
-        paint_ctx
-            .render_ctx
-            .draw_text(&text_layout, (0.0, font_size), &brush);
+        let text_layout = self.get_layout(paint_ctx, font_size);
+        let brush = paint_ctx.solid_brush(LABEL_TEXT_COLOR);
+        paint_ctx.draw_text(&text_layout, (0.0, font_size), &brush);
     }
 
     fn layout(
@@ -121,9 +119,9 @@ impl<T: Data> Widget<T> for Button {
             (false, true) => BUTTON_HOVER_COLOR,
             _ => BUTTON_BG_COLOR,
         };
-        let brush = paint_ctx.render_ctx.solid_brush(bg_color);
+        let brush = paint_ctx.solid_brush(bg_color);
         let rect = base_state.layout_rect.with_origin(Point::ORIGIN);
-        paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
+        paint_ctx.fill(rect, &brush, FillRule::NonZero);
 
         self.label.paint(paint_ctx, base_state, data, env);
     }
@@ -205,11 +203,9 @@ impl<T: Data, F: FnMut(&T, &Env) -> String> DynLabel<T, F> {
 impl<T: Data, F: FnMut(&T, &Env) -> String> Widget<T> for DynLabel<T, F> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
         let font_size = 15.0;
-        let text_layout = self.get_layout(paint_ctx.render_ctx, font_size, data, env);
-        let brush = paint_ctx.render_ctx.solid_brush(LABEL_TEXT_COLOR);
-        paint_ctx
-            .render_ctx
-            .draw_text(&text_layout, (0., font_size), &brush);
+        let text_layout = self.get_layout(paint_ctx, font_size, data, env);
+        let brush = paint_ctx.solid_brush(LABEL_TEXT_COLOR);
+        paint_ctx.draw_text(&text_layout, (0., font_size), &brush);
     }
 
     fn layout(

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -33,14 +33,14 @@ impl Widget<f64> for ProgressBar {
         let rect = Rect::from_origin_size(Point::ORIGIN, base_state.size());
 
         //Paint the background
-        let brush = paint_ctx.render_ctx.solid_brush(BACKGROUND_COLOR);
-        paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
+        let brush = paint_ctx.solid_brush(BACKGROUND_COLOR);
+        paint_ctx.fill(rect, &brush, FillRule::NonZero);
 
         //Paint the bar
-        let brush = paint_ctx.render_ctx.solid_brush(BAR_COLOR);
+        let brush = paint_ctx.solid_brush(BAR_COLOR);
         let calculated_bar_width = clamped * rect.width();
         let rect = rect.with_size(Size::new(calculated_bar_width, rect.height()));
-        paint_ctx.render_ctx.fill(rect, &brush, FillRule::NonZero);
+        paint_ctx.fill(rect, &brush, FillRule::NonZero);
     }
 
     fn layout(

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -65,17 +65,15 @@ impl<T: Data> Scroll<T> {
 
 impl<T: Data> Widget<T> for Scroll<T> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
-        if let Err(e) = paint_ctx.render_ctx.save() {
+        if let Err(e) = paint_ctx.save() {
             eprintln!("error saving render context: {:?}", e);
             return;
         }
         let viewport = Rect::from_origin_size(Point::ORIGIN, base_state.size());
-        paint_ctx.render_ctx.clip(viewport, FillRule::NonZero);
-        paint_ctx
-            .render_ctx
-            .transform(Affine::translate(-self.scroll_offset));
+        paint_ctx.clip(viewport, FillRule::NonZero);
+        paint_ctx.transform(Affine::translate(-self.scroll_offset));
         self.child.paint(paint_ctx, data, env);
-        if let Err(e) = paint_ctx.render_ctx.restore() {
+        if let Err(e) = paint_ctx.restore() {
             eprintln!("error restoring render context: {:?}", e);
         }
     }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -68,12 +68,10 @@ impl Widget<f64> for Slider {
             background_origin + Vec2::new(background_width, 0.),
         );
 
-        let brush = paint_ctx.render_ctx.solid_brush(BACKGROUND_COLOR);
+        let brush = paint_ctx.solid_brush(BACKGROUND_COLOR);
         let mut stroke = StrokeStyle::new();
         stroke.set_line_cap(LineCap::Round);
-        paint_ctx
-            .render_ctx
-            .stroke(background_line, &brush, BACKGROUND_THICKNESS, Some(&stroke));
+        paint_ctx.stroke(background_line, &brush, BACKGROUND_THICKNESS, Some(&stroke));
 
         //Paint the slider
         let is_active = base_state.is_active();
@@ -87,10 +85,8 @@ impl Widget<f64> for Slider {
         let knob_position = (self.width - KNOB_WIDTH) * clamped + KNOB_WIDTH / 2.;
         self.knob_pos = Point::new(knob_position, rect.height() / 2.);
         let knob_circle = Circle::new(self.knob_pos, KNOB_WIDTH / 2.);
-        let brush = paint_ctx.render_ctx.solid_brush(knob_color);
-        paint_ctx
-            .render_ctx
-            .fill(knob_circle, &brush, FillRule::NonZero);
+        let brush = paint_ctx.solid_brush(knob_color);
+        paint_ctx.fill(knob_circle, &brush, FillRule::NonZero);
     }
 
     fn layout(

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -80,8 +80,8 @@ impl Widget<String> for TextBox {
         };
 
         // Paint the border / background
-        let background_brush = paint_ctx.render_ctx.solid_brush(BACKGROUND_GREY_LIGHT);
-        let border_brush = paint_ctx.render_ctx.solid_brush(border_color);
+        let background_brush = paint_ctx.solid_brush(BACKGROUND_GREY_LIGHT);
+        let border_brush = paint_ctx.solid_brush(border_color);
 
         let clip_rect = RoundedRect::from_origin_size(
             Point::ORIGIN,
@@ -93,25 +93,20 @@ impl Widget<String> for TextBox {
             2.,
         );
 
-        paint_ctx
-            .render_ctx
-            .fill(clip_rect, &background_brush, FillRule::NonZero);
+        paint_ctx.fill(clip_rect, &background_brush, FillRule::NonZero);
 
-        paint_ctx
-            .render_ctx
-            .stroke(clip_rect, &border_brush, BORDER_WIDTH, None);
+        paint_ctx.stroke(clip_rect, &border_brush, BORDER_WIDTH, None);
 
         // Paint the text
-        let text = paint_ctx.render_ctx.text();
+        let text = paint_ctx.text();
         let text_layout = self.get_layout(text, FONT_SIZE, data);
-        let brush = paint_ctx.render_ctx.solid_brush(TEXT_COLOR);
+        let brush = paint_ctx.solid_brush(TEXT_COLOR);
 
         let text_height = FONT_SIZE * 0.8;
         let text_pos = Point::new(0.0 + PADDING_LEFT, text_height + PADDING_TOP);
 
         // Render text and cursor inside a clip
         paint_ctx
-            .render_ctx
             .with_save(|rc| {
                 rc.clip(clip_rect, FillRule::NonZero);
 


### PR DESCRIPTION
Fixes #97. 

I sort of banged on this until it compiled, so I'd appreciate a close look at the actual impl:

```rust
impl<'a, 'b: 'a> Deref for PaintCtx<'a, 'b> {
    type Target = &'a mut Piet<'b>;

    fn deref(&self) -> &Self::Target {
        &self.render_ctx
    }
}

impl<'a, 'b: 'a> DerefMut for PaintCtx<'a, 'b> {
    fn deref_mut(&mut self) -> &mut Self::Target {
        &mut self.render_ctx
    }
}
```

I ran all the examples in druid and druid-shell and everything works. I also tweaked the docs where appropriate as far as I could find.