### PR TITLE
Update for piet 0.0.6 (druid 0.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -29,7 +29,7 @@ name = "backtrace-sys"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -69,13 +69,13 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -171,7 +171,7 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -198,7 +198,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -209,7 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -267,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -381,24 +381,24 @@ dependencies = [
 
 [[package]]
 name = "piet"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-cairo"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-common"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -406,38 +406,38 @@ dependencies = [
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-cairo 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-direct2d 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-web 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-cairo 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-direct2d 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-web 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-direct2d"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -473,12 +473,12 @@ name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -511,7 +511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.40"
+version = "0.15.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -526,7 +526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -570,10 +570,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -593,7 +593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -610,10 +610,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -668,7 +668,7 @@ dependencies = [
 [metadata]
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
+"checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
@@ -676,7 +676,7 @@ dependencies = [
 "checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
 "checksum cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e05db47de3b0f09a222fa4bba2eab957d920d4243962a86b2d77ab401e4a359c"
 "checksum cairo-sys-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90a1ec04603a78c111886a385edcec396dbfbc57ea26b9e74aeea6a1fe55dcca"
-"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
+"checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -694,10 +694,10 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "da3ea71161651a4cd97d999b2da139109c537b15ab33abc8ae4ead38deac8a03"
-"checksum kurbo 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b839a66ac696e4b0e12cfcfef58c722f69856c2ed8398712b5fe3f5f7caef484"
+"checksum kurbo 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0caeb26248a62abf92dea93aad4f8244f54668e2f1060ed9cd9fd1d5545723"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
-"checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -710,23 +710,23 @@ dependencies = [
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
-"checksum piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5bf3e87499d52d7a805787b5728fda48f9a2bafd502c19ff1dbfafd5887b6e44"
-"checksum piet-cairo 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "27fd868970edd7b4e5d629c6357aae2eba563dd6044be94f43b39db956acbc3e"
-"checksum piet-common 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e35d47e80b4a36ba5869a8c2d14389a72951c0b65bc5729da2449b164ceca058"
-"checksum piet-direct2d 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a59576e5687b541e1b716cdb513862b42febb489e7d17d1f71d367e45d8da860"
-"checksum piet-web 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b05f4636aaea5836367c0a4fdcf26e4822a481a15dd40fb06e2f9f5f1df8d20e"
-"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "02e36470db0f6e8900c3f2d35ae137c96ebb726af2c070fc4369467ee57ab9bd"
+"checksum piet-cairo 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1afd8ad4a74d1ef1591e0bad7f860841c5a0cab6edeb347fc67e2e37422c01df"
+"checksum piet-common 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8e8cb78927118d65d350a677432e459d90ff72ea6fc875cf1ac1478d5570e196"
+"checksum piet-direct2d 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ccea047f88a367ad86b2a972302070f0bf4183b51376ad840b9eb298f3bdafc1"
+"checksum piet-web 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5f168f31a01eb3d0cc977258ae6b085f98d022f32b7e3edcdb4f565d912dcc60"
+"checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)" = "bc945221ccf4a7e8c31222b9d1fc77aefdd6638eb901a6ce457a3dc29d4c31e8"
+"checksum syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ee06ea4b620ab59a2267c6b48be16244a3389f8bfa0986bdd15c35b890b00af3"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"

--- a/druid-shell/Cargo.lock
+++ b/druid-shell/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -29,7 +29,7 @@ name = "backtrace-sys"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -69,13 +69,13 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -164,7 +164,7 @@ dependencies = [
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-common 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,7 +191,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -202,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -260,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -374,24 +374,24 @@ dependencies = [
 
 [[package]]
 name = "piet"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-cairo"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-common"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -399,38 +399,38 @@ dependencies = [
  "direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-cairo 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-direct2d 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet-web 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-cairo 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-direct2d 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-web 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-direct2d"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "piet-web"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -466,12 +466,12 @@ name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -504,7 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.40"
+version = "0.15.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -519,7 +519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -563,10 +563,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -586,7 +586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -603,10 +603,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -661,7 +661,7 @@ dependencies = [
 [metadata]
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
+"checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
@@ -669,7 +669,7 @@ dependencies = [
 "checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
 "checksum cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e05db47de3b0f09a222fa4bba2eab957d920d4243962a86b2d77ab401e4a359c"
 "checksum cairo-sys-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90a1ec04603a78c111886a385edcec396dbfbc57ea26b9e74aeea6a1fe55dcca"
-"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
+"checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -687,10 +687,10 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "da3ea71161651a4cd97d999b2da139109c537b15ab33abc8ae4ead38deac8a03"
-"checksum kurbo 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b839a66ac696e4b0e12cfcfef58c722f69856c2ed8398712b5fe3f5f7caef484"
+"checksum kurbo 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0caeb26248a62abf92dea93aad4f8244f54668e2f1060ed9cd9fd1d5545723"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
-"checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -703,23 +703,23 @@ dependencies = [
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
-"checksum piet 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5bf3e87499d52d7a805787b5728fda48f9a2bafd502c19ff1dbfafd5887b6e44"
-"checksum piet-cairo 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "27fd868970edd7b4e5d629c6357aae2eba563dd6044be94f43b39db956acbc3e"
-"checksum piet-common 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e35d47e80b4a36ba5869a8c2d14389a72951c0b65bc5729da2449b164ceca058"
-"checksum piet-direct2d 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a59576e5687b541e1b716cdb513862b42febb489e7d17d1f71d367e45d8da860"
-"checksum piet-web 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b05f4636aaea5836367c0a4fdcf26e4822a481a15dd40fb06e2f9f5f1df8d20e"
-"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum piet 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "02e36470db0f6e8900c3f2d35ae137c96ebb726af2c070fc4369467ee57ab9bd"
+"checksum piet-cairo 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1afd8ad4a74d1ef1591e0bad7f860841c5a0cab6edeb347fc67e2e37422c01df"
+"checksum piet-common 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8e8cb78927118d65d350a677432e459d90ff72ea6fc875cf1ac1478d5570e196"
+"checksum piet-direct2d 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ccea047f88a367ad86b2a972302070f0bf4183b51376ad840b9eb298f3bdafc1"
+"checksum piet-web 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5f168f31a01eb3d0cc977258ae6b085f98d022f32b7e3edcdb4f565d912dcc60"
+"checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)" = "bc945221ccf4a7e8c31222b9d1fc77aefdd6638eb901a6ce457a3dc29d4c31e8"
+"checksum syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ee06ea4b620ab59a2267c6b48be16244a3389f8bfa0986bdd15c35b890b00af3"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-piet-common = "0.0.5"
+piet-common = "0.0.6"
 
 lazy_static = "1.0"
 time = "0.1.39"

--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use piet_common::kurbo::{Line, Rect, Vec2};
-use piet_common::{Color, FillRule, RenderContext};
+use piet_common::{Color, RenderContext};
 
 use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
@@ -25,8 +25,8 @@ use druid_shell::platform::WindowBuilder;
 use druid_shell::runloop;
 use druid_shell::window::{Cursor, MouseEvent, TimerToken, WinCtx, WinHandler, WindowHandle};
 
-const BG_COLOR: Color = Color::rgb24(0x27_28_22);
-const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
+const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
+const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
 
 #[derive(Default)]
 struct HelloState {
@@ -40,12 +40,10 @@ impl WinHandler for HelloState {
     }
 
     fn paint(&mut self, piet: &mut piet_common::Piet, _ctx: &mut dyn WinCtx) -> bool {
-        let bg = piet.solid_brush(BG_COLOR);
-        let fg = piet.solid_brush(FG_COLOR);
         let (width, height) = self.size;
         let rect = Rect::new(0.0, 0.0, width, height);
-        piet.fill(rect, &bg, FillRule::NonZero);
-        piet.stroke(Line::new((10.0, 50.0), (90.0, 90.0)), &fg, 1.0, None);
+        piet.fill(rect, &BG_COLOR);
+        piet.stroke(Line::new((10.0, 50.0), (90.0, 90.0)), &FG_COLOR, 1.0);
         false
     }
 

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -17,7 +17,7 @@ use std::any::Any;
 use time::get_time;
 
 use piet_common::kurbo::{Line, Rect};
-use piet_common::{Color, FillRule, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
+use piet_common::{Color, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
 #[cfg(target_os = "windows")]
 use druid_shell::platform::PresentStrategy;
@@ -27,8 +27,8 @@ use druid_shell::platform::WindowBuilder;
 use druid_shell::runloop;
 use druid_shell::window::{WinCtx, WinHandler, WindowHandle};
 
-const BG_COLOR: Color = Color::rgb24(0x27_28_22);
-const FG_COLOR: Color = Color::rgb24(0xf0_f0_ea);
+const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
+const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
 
 struct PerfTest {
     handle: WindowHandle,
@@ -43,21 +43,18 @@ impl WinHandler for PerfTest {
 
     fn paint(&mut self, piet: &mut Piet, _ctx: &mut dyn WinCtx) -> bool {
         let (width, height) = self.size;
-        let bg = piet.solid_brush(BG_COLOR);
-        let fg = piet.solid_brush(FG_COLOR);
         let rect = Rect::new(0.0, 0.0, width, height);
-        piet.fill(rect, &bg, FillRule::NonZero);
+        piet.fill(rect, &BG_COLOR);
 
-        piet.stroke(Line::new((0.0, height), (width, 0.0)), &fg, 1.0, None);
+        piet.stroke(Line::new((0.0, height), (width, 0.0)), &FG_COLOR, 1.0);
 
         let th = ::std::f64::consts::PI * (get_time().nsec as f64) * 2e-9;
         let dx = 100.0 * th.sin();
         let dy = 100.0 * th.cos();
         piet.stroke(
             Line::new((100.0, 100.0), (100.0 + dx, 100.0 - dy)),
-            &fg,
+            &FG_COLOR,
             1.0,
-            None,
         );
 
         let font = piet
@@ -77,7 +74,7 @@ impl WinHandler for PerfTest {
             .unwrap()
             .build()
             .unwrap();
-        piet.draw_text(&layout, (10.0, 210.0), &fg);
+        piet.draw_text(&layout, (10.0, 210.0), &FG_COLOR);
 
         let msg = "Hello DWrite! This is a somewhat longer string of text intended to provoke slightly longer draw times.";
         let layout = piet
@@ -91,7 +88,7 @@ impl WinHandler for PerfTest {
         let y0 = 10.0;
         for i in 0..60 {
             let y = y0 + (i as f64) * dy;
-            piet.draw_text(&layout, (x0, y), &fg);
+            piet.draw_text(&layout, (x0, y), &FG_COLOR);
         }
 
         true

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -38,8 +38,7 @@ impl Widget<u32> for AnimWidget {
     ) {
         let center = Point::new(50.0, 50.0);
         let ambit = center + 45.0 * Vec2::from_angle((0.75 + self.t) * 2.0 * PI);
-        let brush = paint_ctx.solid_brush(Color::WHITE);
-        paint_ctx.stroke(Line::new(center, ambit), &brush, 1.0, None);
+        paint_ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);
     }
 
     fn layout(

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -17,8 +17,7 @@
 use druid::kurbo::{Affine, BezPath, Point, Rect, Size};
 
 use druid::piet::{
-    Color, FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text,
-    TextLayoutBuilder,
+    Color, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayoutBuilder,
 };
 
 use druid::shell::{runloop, WindowBuilder};
@@ -53,17 +52,16 @@ impl Widget<String> for CustomWidget {
             (80.0, 90.0),
             (base_state.size().width, base_state.size().height),
         );
-        // Create a solid brush
-        let brush = paint_ctx.solid_brush(Color::rgb24(0x00_80_00));
-        // Stroke the path with the brush, with thickness 1.0
-        paint_ctx.stroke(path, &brush, 1.0, None);
+        // Create a color
+        let stroke_color = Color::rgb8(0x00, 0x80, 0x00);
+        // Stroke the path with thickness 1.0
+        paint_ctx.stroke(path, &stroke_color, 1.0);
 
         // Rectangles: the path for practical people
         let rect = Rect::from_origin_size((10., 10.), (100., 100.));
-        // Note the Color:rgba32 which includes an alpha channel (7F in this case)
-        let brush = paint_ctx.solid_brush(Color::rgba32(0x00_00_00_7F));
-        // A fill uses a brush, just like stroke, but it needs FillRule to be set
-        paint_ctx.fill(rect, &brush, FillRule::NonZero);
+        // Note the Color:rgba8 which includes an alpha channel (7F in this case)
+        let fill_color = Color::rgba8(0x00, 0x00, 0x00, 0x7F);
+        paint_ctx.fill(rect, &fill_color);
 
         // Text is easy, if you ignore all these unwraps. Just pick a font and a size.
         let font = paint_ctx
@@ -85,7 +83,7 @@ impl Widget<String> for CustomWidget {
             .with_save(|rc| {
                 // Now we can rotate the context (or set a clip path, for instance):
                 rc.transform(Affine::rotate(0.1));
-                rc.draw_text(&layout, (80.0, 40.0), &brush);
+                rc.draw_text(&layout, (80.0, 40.0), &fill_color);
                 Ok(())
             })
             .unwrap();

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -39,8 +39,7 @@ impl Widget<u32> for TimerWidget {
         _env: &Env,
     ) {
         if self.on {
-            let brush = paint_ctx.solid_brush(Color::WHITE);
-            paint_ctx.stroke(Line::new((10.0, 10.0), (10.0, 50.0)), &brush, 1.0, None);
+            paint_ctx.stroke(Line::new((10.0, 10.0), (10.0, 50.0)), &Color::WHITE, 1.0);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use event::{Event, WheelEvent};
 pub use lens::{Lens, LensWrap};
 pub use value::{Delta, KeyPath, PathEl, PathFragment, Value};
 
-const BACKGROUND_COLOR: Color = Color::rgb24(0x27_28_22);
+const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 
 /// A struct representing the top-level root of the UI.
 ///

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -21,13 +21,13 @@ use crate::{
     UpdateCtx, Widget,
 };
 
-use crate::piet::{Color, FillRule, FontBuilder, Text, TextLayoutBuilder};
+use crate::piet::{Color, FontBuilder, Text, TextLayoutBuilder};
 use crate::{Piet, Point, RenderContext};
 
-const BUTTON_BG_COLOR: Color = Color::rgba32(0x40_40_48_ff);
-const BUTTON_HOVER_COLOR: Color = Color::rgba32(0x50_50_58_ff);
-const BUTTON_PRESSED_COLOR: Color = Color::rgba32(0x60_60_68_ff);
-const LABEL_TEXT_COLOR: Color = Color::rgba32(0xf0_f0_ea_ff);
+const BUTTON_BG_COLOR: Color = Color::rgb8(0x40, 0x40, 0x48);
+const BUTTON_HOVER_COLOR: Color = Color::rgb8(0x50, 0x50, 0x58);
+const BUTTON_PRESSED_COLOR: Color = Color::rgb8(0x60, 0x60, 0x68);
+const LABEL_TEXT_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
 
 /// A label with static text.
 pub struct Label {
@@ -75,8 +75,7 @@ impl<T: Data> Widget<T> for Label {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, _data: &T, _env: &Env) {
         let font_size = 15.0;
         let text_layout = self.get_layout(paint_ctx, font_size);
-        let brush = paint_ctx.solid_brush(LABEL_TEXT_COLOR);
-        paint_ctx.draw_text(&text_layout, (0.0, font_size), &brush);
+        paint_ctx.draw_text(&text_layout, (0.0, font_size), &LABEL_TEXT_COLOR);
     }
 
     fn layout(
@@ -119,9 +118,8 @@ impl<T: Data> Widget<T> for Button {
             (false, true) => BUTTON_HOVER_COLOR,
             _ => BUTTON_BG_COLOR,
         };
-        let brush = paint_ctx.solid_brush(bg_color);
         let rect = base_state.layout_rect.with_origin(Point::ORIGIN);
-        paint_ctx.fill(rect, &brush, FillRule::NonZero);
+        paint_ctx.fill(rect, &bg_color);
 
         self.label.paint(paint_ctx, base_state, data, env);
     }
@@ -204,8 +202,7 @@ impl<T: Data, F: FnMut(&T, &Env) -> String> Widget<T> for DynLabel<T, F> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
         let font_size = 15.0;
         let text_layout = self.get_layout(paint_ctx, font_size, data, env);
-        let brush = paint_ctx.solid_brush(LABEL_TEXT_COLOR);
-        paint_ctx.draw_text(&text_layout, (0., font_size), &brush);
+        paint_ctx.draw_text(&text_layout, (0., font_size), &LABEL_TEXT_COLOR);
     }
 
     fn layout(

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -15,13 +15,13 @@
 //! A progress bar widget.
 
 use crate::kurbo::{Point, Rect, Size};
-use crate::piet::{Color, FillRule, RenderContext};
+use crate::piet::{Color, RenderContext};
 use crate::{
     Action, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
 };
 
-const BACKGROUND_COLOR: Color = Color::rgb24(0x55_55_55);
-const BAR_COLOR: Color = Color::rgb24(0xf0_f0_ea);
+const BACKGROUND_COLOR: Color = Color::rgb8(0x55, 0x55, 0x55);
+const BAR_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
 
 /// A progress bar, displaying a numeric progress value.
 #[derive(Debug, Clone, Default)]
@@ -33,14 +33,12 @@ impl Widget<f64> for ProgressBar {
         let rect = Rect::from_origin_size(Point::ORIGIN, base_state.size());
 
         //Paint the background
-        let brush = paint_ctx.solid_brush(BACKGROUND_COLOR);
-        paint_ctx.fill(rect, &brush, FillRule::NonZero);
+        paint_ctx.fill(rect, &BACKGROUND_COLOR);
 
         //Paint the bar
-        let brush = paint_ctx.solid_brush(BAR_COLOR);
         let calculated_bar_width = clamped * rect.width();
         let rect = rect.with_size(Size::new(calculated_bar_width, rect.height()));
-        paint_ctx.fill(rect, &brush, FillRule::NonZero);
+        paint_ctx.fill(rect, &BAR_COLOR);
     }
 
     fn layout(

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -21,7 +21,7 @@ use crate::{
     Rect, Size, UpdateCtx, Vec2, Widget, WidgetPod,
 };
 
-use crate::piet::{FillRule, RenderContext};
+use crate::piet::RenderContext;
 
 use crate::kurbo::Affine;
 
@@ -70,7 +70,7 @@ impl<T: Data> Widget<T> for Scroll<T> {
             return;
         }
         let viewport = Rect::from_origin_size(Point::ORIGIN, base_state.size());
-        paint_ctx.clip(viewport, FillRule::NonZero);
+        paint_ctx.clip(viewport);
         paint_ctx.transform(Affine::translate(-self.scroll_offset));
         self.child.paint(paint_ctx, data, env);
         if let Err(e) = paint_ctx.restore() {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -15,17 +15,17 @@
 //! A slider widget.
 
 use crate::kurbo::{Circle, Line, Point, Rect, Size, Vec2};
-use crate::piet::{Color, FillRule, LineCap, RenderContext, StrokeStyle};
+use crate::piet::{Color, LineCap, RenderContext, StrokeStyle};
 use crate::{
     Action, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
 };
 
 const KNOB_WIDTH: f64 = 24.;
 const BACKGROUND_THICKNESS: f64 = 4.;
-const BACKGROUND_COLOR: Color = Color::rgb24(0x55_55_55);
-const KNOB_COLOR: Color = Color::rgb24(0xf0_f0_e5);
-const KNOB_HOVER_COLOR: Color = Color::rgb24(0xa0_a0_a5);
-const KNOB_PRESSED_COLOR: Color = Color::rgb24(0x75_75_75);
+const BACKGROUND_COLOR: Color = Color::rgb8(0x55, 0x55, 0x55);
+const KNOB_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xe5);
+const KNOB_HOVER_COLOR: Color = Color::rgb8(0xa0, 0xa0, 0xa5);
+const KNOB_PRESSED_COLOR: Color = Color::rgb8(0x75, 0x75, 0x75);
 
 /// A slider, allowing interactive update of a numeric value.
 #[derive(Debug, Clone, Default)]
@@ -68,10 +68,14 @@ impl Widget<f64> for Slider {
             background_origin + Vec2::new(background_width, 0.),
         );
 
-        let brush = paint_ctx.solid_brush(BACKGROUND_COLOR);
         let mut stroke = StrokeStyle::new();
         stroke.set_line_cap(LineCap::Round);
-        paint_ctx.stroke(background_line, &brush, BACKGROUND_THICKNESS, Some(&stroke));
+        paint_ctx.stroke_styled(
+            background_line,
+            &BACKGROUND_COLOR,
+            BACKGROUND_THICKNESS,
+            &stroke,
+        );
 
         //Paint the slider
         let is_active = base_state.is_active();
@@ -85,8 +89,7 @@ impl Widget<f64> for Slider {
         let knob_position = (self.width - KNOB_WIDTH) * clamped + KNOB_WIDTH / 2.;
         self.knob_pos = Point::new(knob_position, rect.height() / 2.);
         let knob_circle = Circle::new(self.knob_pos, KNOB_WIDTH / 2.);
-        let brush = paint_ctx.solid_brush(knob_color);
-        paint_ctx.fill(knob_circle, &brush, FillRule::NonZero);
+        paint_ctx.fill(knob_circle, &knob_color);
     }
 
     fn layout(

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -20,15 +20,13 @@ use crate::{
 };
 
 use crate::kurbo::{Affine, Line, Point, RoundedRect, Size, Vec2};
-use crate::piet::{
-    Color, FillRule, FontBuilder, Piet, RenderContext, Text, TextLayout, TextLayoutBuilder,
-};
+use crate::piet::{Color, FontBuilder, Piet, RenderContext, Text, TextLayout, TextLayoutBuilder};
 
-const BACKGROUND_GREY_LIGHT: Color = Color::rgba32(0x3a_3a_3a_ff);
-const BORDER_GREY: Color = Color::rgba32(0x5a_5a_5a_ff);
-const PRIMARY_LIGHT: Color = Color::rgba32(0x5c_c4_ff_ff);
+const BACKGROUND_GREY_LIGHT: Color = Color::rgba8(0x3a, 0x3a, 0x3a, 0xff);
+const BORDER_GREY: Color = Color::rgba8(0x5a, 0x5a, 0x5a, 0xff);
+const PRIMARY_LIGHT: Color = Color::rgba8(0x5c, 0xc4, 0xff, 0xff);
 
-const TEXT_COLOR: Color = Color::rgb24(0xf0_f0_ea);
+const TEXT_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xEA);
 const CURSOR_COLOR: Color = Color::WHITE;
 
 const BOX_HEIGHT: f64 = 24.;
@@ -80,8 +78,6 @@ impl Widget<String> for TextBox {
         };
 
         // Paint the border / background
-        let background_brush = paint_ctx.solid_brush(BACKGROUND_GREY_LIGHT);
-        let border_brush = paint_ctx.solid_brush(border_color);
 
         let clip_rect = RoundedRect::from_origin_size(
             Point::ORIGIN,
@@ -93,14 +89,12 @@ impl Widget<String> for TextBox {
             2.,
         );
 
-        paint_ctx.fill(clip_rect, &background_brush, FillRule::NonZero);
-
-        paint_ctx.stroke(clip_rect, &border_brush, BORDER_WIDTH, None);
+        paint_ctx.fill(clip_rect, &BACKGROUND_GREY_LIGHT);
+        paint_ctx.stroke(clip_rect, &border_color, BORDER_WIDTH);
 
         // Paint the text
         let text = paint_ctx.text();
         let text_layout = self.get_layout(text, FONT_SIZE, data);
-        let brush = paint_ctx.solid_brush(TEXT_COLOR);
 
         let text_height = FONT_SIZE * 0.8;
         let text_pos = Point::new(0.0 + PADDING_LEFT, text_height + PADDING_TOP);
@@ -108,24 +102,22 @@ impl Widget<String> for TextBox {
         // Render text and cursor inside a clip
         paint_ctx
             .with_save(|rc| {
-                rc.clip(clip_rect, FillRule::NonZero);
+                rc.clip(clip_rect);
 
                 // If overflowing, shift the text
                 if text_layout.width() + (PADDING_LEFT * 2.) > self.width {
                     let offset = text_layout.width() - self.width + (PADDING_LEFT * 2.) + 1.;
                     rc.transform(Affine::translate(Vec2::new(-offset, 0.)));
                 }
-                rc.draw_text(&text_layout, text_pos, &brush);
+                rc.draw_text(&text_layout, text_pos, &TEXT_COLOR);
 
                 // Paint the cursor if focused
                 if has_focus {
-                    let brush = rc.solid_brush(CURSOR_COLOR);
-
                     let xy = text_pos + Vec2::new(text_layout.width() + 1., 2. - FONT_SIZE);
                     let x2y2 = xy + Vec2::new(0., FONT_SIZE + 2.);
                     let line = Line::new(xy, x2y2);
 
-                    rc.stroke(line, &brush, 1., None);
+                    rc.stroke(line, &CURSOR_COLOR, 1.);
                 }
                 Ok(())
             })


### PR DESCRIPTION
This fixes breakage and adopts new idioms where possible.

Looking at this, we probably don't need a version bump since we haven't published since 0.1.1 😨