### PR TITLE
Add better hotkey support

### DIFF
--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -82,6 +82,12 @@ impl KeyEvent {
             Some(self.unmodified_text.as_str())
         }
     }
+
+    /// For creating `KeyEvent`s during testing.
+    #[doc(hidden)]
+    pub fn for_test(mods: impl Into<KeyModifiers>, text: &'static str, code: KeyCode) -> Self {
+        KeyEvent::new(code, false, mods.into(), text, text)
+    }
 }
 
 /// Keyboard modifier state, provided for events.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod widget;
 mod data;
 mod env;
 mod event;
+mod hotkey;
 mod lens;
 pub mod theme;
 
@@ -46,6 +47,7 @@ pub use druid_shell::window::{Cursor, MouseButton, MouseEvent, TimerToken};
 pub use data::Data;
 pub use env::{Env, Key, Value};
 pub use event::{Event, WheelEvent};
+pub use hotkey::{HotKey, RawMods, SysMods};
 pub use lens::{Lens, LensWrap};
 
 const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);


### PR DESCRIPTION
This is another attempt at improving the ergonomics of handling
keyboard events; as a bonus, this will also be useful for doing
menus.

closes #81

This spun off of some other work I was doing on commands, but I think it can stand alone. I'd be curious to get @futurepaul's opinion, in terms of whether this would improve the code in #117; in particular it offers a workaround for the "system command key". For example, with this, you can do:

```rust
let event: KeyEvent = ...;
match event {
    e if e == HotKey::new(SysMods::Cmd, "c") => self.copy(),
    e if e == HotKey::new(SysMods::Cmd, "v") => self.paste(),
    _ => (),
}
```
and it will work with 'Command' on macOS and 'Ctrl' elsewhere.