### PR TITLE
Move hotkey.rs into druid-shell

### DIFF
--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -14,7 +14,9 @@
 
 //! Hotkeys and helpers for parsing keyboard shortcuts.
 
-use crate::{KeyCode, KeyEvent, KeyModifiers};
+use std::borrow::Borrow;
+
+use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 
 /// A description of a keyboard shortcut.
 ///
@@ -26,7 +28,8 @@ use crate::{KeyCode, KeyEvent, KeyModifiers};
 /// [`SysMods`] matches the Command key on macOS and Ctrl elsewhere:
 ///
 /// ```
-/// use druid::{HotKey, KeyEvent, RawMods, SysMods, KeyCode};
+/// use druid_shell::hotkey::{HotKey, RawMods, SysMods};
+/// use druid_shell::keyboard::{KeyEvent, KeyCode};
 ///
 /// let hotkey = HotKey::new(SysMods::Cmd, "a");
 ///
@@ -40,7 +43,8 @@ use crate::{KeyCode, KeyEvent, KeyModifiers};
 /// `None` matches only the key without modifiers:
 ///
 /// ```
-/// use druid::{HotKey, KeyEvent, RawMods, SysMods, KeyCode};
+/// use druid_shell::hotkey::{HotKey, RawMods, SysMods};
+/// use druid_shell::keyboard::{KeyEvent, KeyCode};
 ///
 /// let hotkey = HotKey::new(None, KeyCode::ArrowLeft);
 ///
@@ -79,7 +83,8 @@ impl HotKey {
     ///
     /// # Examples
     /// ```
-    /// use druid::{HotKey, KeyEvent, RawMods, SysMods, KeyCode};
+    /// use druid_shell::hotkey::{HotKey, RawMods, SysMods};
+    /// use druid_shell::keyboard::{KeyEvent, KeyCode};
     ///
     /// let select_all = HotKey::new(SysMods::Cmd, "a");
     /// let esc = HotKey::new(None, KeyCode::Escape);
@@ -126,8 +131,6 @@ impl HotKey {
             }
     }
 }
-
-use std::borrow::Borrow;
 
 /// A platform-agnostic representation of keyboard modifiers, for command handling.
 ///

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -29,6 +29,7 @@ extern crate objc;
 extern crate lazy_static;
 
 pub mod error;
+pub mod hotkey;
 pub mod keyboard;
 pub mod keycodes;
 pub mod window;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ pub mod widget;
 mod data;
 mod env;
 mod event;
-mod hotkey;
 mod lens;
 pub mod theme;
 
@@ -45,11 +44,11 @@ pub use druid_shell::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 use druid_shell::platform::IdleHandle;
 use druid_shell::window::{self, Text, WinCtx, WinHandler, WindowHandle};
 pub use druid_shell::window::{Cursor, MouseButton, MouseEvent, TimerToken};
+pub use shell::hotkey::{HotKey, RawMods, SysMods};
 
 pub use data::Data;
 pub use env::{Env, Key, Value};
 pub use event::{Event, WheelEvent};
-pub use hotkey::{HotKey, RawMods, SysMods};
 pub use lens::{Lens, LensWrap};
 
 const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);


### PR DESCRIPTION
We should only have one way of describing a hotkey, and if we're going to use it in APIs in druid-shell then the types should also live in druid-shell. 🤷‍♂ 

`HotKey` is going to expand to replace most of the stuff in `keycodes.rs`.