### PR TITLE
Dispatch Cocoa menu events via the responder chain

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -261,6 +261,10 @@ lazy_static! {
             sel!(handleTimer:),
             handle_timer as extern "C" fn(&mut Object, Sel, id),
         );
+        decl.add_method(
+            sel!(handleMenuItem:),
+            handle_menu_item as extern "C" fn(&mut Object, Sel, id),
+        );
         ViewClass(decl.register())
     };
 }
@@ -545,6 +549,19 @@ extern "C" fn handle_timer(this: &mut Object, _: Sel, timer: id) {
     (*view_state)
         .handler
         .timer(TimerToken::new(token), &mut ctx);
+}
+
+extern "C" fn handle_menu_item(this: &mut Object, _: Sel, item: id) {
+    unsafe {
+        let tag: isize = msg_send![item, tag];
+        let view_state: *mut c_void = *this.get_ivar("viewState");
+        let view_state = &mut *(view_state as *mut ViewState);
+        let mut ctx = WinCtxImpl {
+            nsview: &(*view_state).nsview,
+            text: Text::new(),
+        };
+        (*view_state).handler.command(tag as u32, &mut ctx);
+    }
 }
 
 impl WindowHandle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,6 +763,10 @@ impl<T: Data + 'static> WinHandler for UiMain<T> {
         self.state.paint(piet, ctx)
     }
 
+    fn command(&mut self, id: u32, ctx: &mut dyn WinCtx) {
+        eprintln!("got command {}", id);
+    }
+
     fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
         let dpi = self.state.handle.get_dpi() as f64;
         let scale = 96.0 / dpi;


### PR DESCRIPTION
This changes how we route menu events on mac. Instead of having
a custom proxy class that we instantiate for each menu, we set
the menu's 'tag' property to the command number, and set the
'action' to be an action we define on our custom view class.

This also stubs out the `command` fn in druid to receive these events.