### PR TITLE
First draft of multiple window support

### DIFF
--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -14,8 +14,8 @@
 
 use std::any::Any;
 
-use piet_common::kurbo::{Line, Rect, Vec2};
-use piet_common::{Color, RenderContext};
+use druid_shell::kurbo::{Line, Rect, Vec2};
+use druid_shell::piet::{Color, RenderContext};
 
 use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -45,7 +45,6 @@ use winapi::shared::windef::*;
 use winapi::shared::winerror::*;
 use winapi::um::d2d1::*;
 use winapi::um::unknwnbase::*;
-use winapi::um::wingdi::*;
 use winapi::um::winnt::*;
 use winapi::um::winuser::*;
 use winapi::Interface;
@@ -780,27 +779,7 @@ impl WindowBuilder {
             // Maybe separate registration in build api? Probably only need to
             // register once even for multiple window creation.
 
-            // TODO: probably want configurable class name.
-            let class_name = "Xi Editor".to_wide();
-            let icon = LoadIconW(0 as HINSTANCE, IDI_APPLICATION);
-            let brush = CreateSolidBrush(0xffffff);
-            let wnd = WNDCLASSW {
-                style: 0,
-                lpfnWndProc: Some(win_proc_dispatch),
-                cbClsExtra: 0,
-                cbWndExtra: 0,
-                hInstance: 0 as HINSTANCE,
-                hIcon: icon,
-                hCursor: 0 as HCURSOR,
-                hbrBackground: brush,
-                lpszMenuName: 0 as LPCWSTR,
-                lpszClassName: class_name.as_ptr(),
-            };
-            let class_atom = RegisterClassW(&wnd);
-            if class_atom == 0 {
-                return Err(Error::Null);
-            }
-
+            let class_name = crate::util::CLASS_NAME.to_wide();
             let dwrite_factory = directwrite::Factory::new().unwrap();
             let dw_clone = clone_dwrite(&dwrite_factory);
             let wndproc = MyWndProc {

--- a/druid-shell/src/windows/util.rs
+++ b/druid-shell/src/windows/util.rs
@@ -36,12 +36,16 @@ use winapi::um::shellscalingapi::*;
 use winapi::um::unknwnbase::IUnknown;
 use winapi::um::winbase::*;
 use winapi::um::wincon::*;
+use winapi::um::wingdi::CreateSolidBrush;
 // This needs to be explicit, otherwise HRESULT will conflict
 use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+use winapi::um::winuser::{LoadIconW, RegisterClassW, IDI_APPLICATION, WNDCLASSW};
 
 use direct2d::enums::DrawTextOptions;
 
 use crate::Error;
+
+use crate::windows::win_proc_dispatch;
 
 pub fn as_result(hr: HRESULT) -> Result<(), Error> {
     if SUCCEEDED(hr) {
@@ -213,6 +217,8 @@ lazy_static! {
     pub static ref OPTIONAL_FUNCTIONS: OptionalFunctions = load_optional_functions();
 }
 
+pub(crate) const CLASS_NAME: &str = "druid";
+
 /// Initialize the app. At the moment, this is mostly needed for hi-dpi.
 pub fn init() {
     attach_console();
@@ -220,6 +226,28 @@ pub fn init() {
         // This function is only supported on windows 10
         unsafe {
             func(PROCESS_SYSTEM_DPI_AWARE); // TODO: per monitor (much harder)
+        }
+    }
+
+    unsafe {
+        let class_name = CLASS_NAME.to_wide();
+        let icon = LoadIconW(0 as HINSTANCE, IDI_APPLICATION);
+        let brush = CreateSolidBrush(0xffffff);
+        let wnd = WNDCLASSW {
+            style: 0,
+            lpfnWndProc: Some(win_proc_dispatch),
+            cbClsExtra: 0,
+            cbWndExtra: 0,
+            hInstance: 0 as HINSTANCE,
+            hIcon: icon,
+            hCursor: 0 as HCURSOR,
+            hbrBackground: brush,
+            lpszMenuName: 0 as LPCWSTR,
+            lpszClassName: class_name.as_ptr(),
+        };
+        let class_atom = RegisterClassW(&wnd);
+        if class_atom == 0 {
+            panic!("Error registering class");
         }
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -14,7 +14,7 @@
 
 use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{ActionWrapper, Align, Button, Column, Label, Padding};
-use druid::{LocalizedString, DruidHandler, SharedWindow, WindowId};
+use druid::{DruidHandler, LocalizedString, SharedWindow, WindowId};
 
 fn main() {
     druid::shell::init();

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -14,12 +14,13 @@
 
 use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{ActionWrapper, Align, Button, Column, Label, Padding};
-use druid::{LocalizedString, UiMain, UiState};
+use druid::{LocalizedString, DruidHandler, SharedWindow, WindowId};
 
 fn main() {
     druid::shell::init();
 
     let mut run_loop = runloop::RunLoop::new();
+    let id = WindowId::new();
     let mut builder = WindowBuilder::new();
     let mut col = Column::new();
     let text =
@@ -29,9 +30,10 @@ fn main() {
     col.add_child(Align::centered(Padding::uniform(5.0, label)), 1.0);
     col.add_child(Padding::uniform(5.0, button), 1.0);
     let root = ActionWrapper::new(col, |data: &mut u32, _env| *data += 1);
-    let state = UiState::new(root, 0u32);
+    let shared = SharedWindow::new(root, id);
+    let handler = DruidHandler::new(shared, 0u32, id);
     builder.set_title("Hello example");
-    builder.set_handler(Box::new(UiMain::new(state)));
+    builder.set_handler(Box::new(handler));
     let window = builder.build().unwrap();
     window.show();
     run_loop.run();

--- a/examples/multi_win.rs
+++ b/examples/multi_win.rs
@@ -1,0 +1,94 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use druid::shell::{runloop, WindowBuilder};
+use druid::widget::{ActionWrapper, Button, Column, DynLabel, Padding};
+
+use druid::{
+    Data, DruidHandler, Env, Event, EventCtxRoot, KeyCode, LayoutCtxRoot, PaintCtxRoot, RootWidget,
+    UpdateCtxRoot, Widget, WindowId, WindowSet,
+};
+
+pub struct SharedWindow<T: Data> {
+    windows: WindowSet<T>,
+}
+
+impl<T: Data> SharedWindow<T> {
+    pub fn new(root: impl Widget<T> + 'static, id: WindowId) -> SharedWindow<T> {
+        SharedWindow {
+            windows: WindowSet::new(root, id),
+        }
+    }
+}
+
+impl RootWidget<u32> for SharedWindow<u32> {
+    fn event(&mut self, event: &Event, ctx: &mut EventCtxRoot, data: &mut u32, env: &Env) {
+        match event {
+            Event::KeyDown(e) => {
+                // TODO: I know this is not the best practice to match
+                if e.mods.ctrl && e.key_code == KeyCode::KeyN {
+                    let mut builder = WindowBuilder::new();
+                    builder.set_title("Additional window");
+                    let (id, window_pod) = ctx.new_win(builder, make_ui());
+                    self.windows.add_window(id, window_pod);
+                    println!("new window {:?}", id);
+                }
+            }
+            _ => (),
+        }
+        self.windows.event(event, ctx, data, env);
+    }
+
+    /// Propagate a data update to all windows.
+    fn update(&mut self, ctx: &mut UpdateCtxRoot, data: &u32, env: &Env) {
+        self.windows.update(ctx, data, env);
+    }
+
+    /// Propagate layout to a child window.
+    ///
+    /// The case for this method is weak; it could be subsumed into the `paint` method.
+    fn layout(&mut self, ctx: &mut LayoutCtxRoot, data: &u32, env: &Env) {
+        self.windows.layout(ctx, data, env);
+    }
+
+    /// Paint a child window's appearance.
+    fn paint(&mut self, paint_ctx: &mut PaintCtxRoot, data: &u32, env: &Env) {
+        self.windows.paint(paint_ctx, data, env);
+    }
+}
+
+fn make_ui() -> impl Widget<u32> {
+    let mut col = Column::new();
+    let label = DynLabel::new(|data: &u32, _env| format!("value: {}", data));
+    let button = Button::new("increment");
+    col.add_child(Padding::uniform(5.0, label), 1.0);
+    col.add_child(Padding::uniform(5.0, button), 1.0);
+    ActionWrapper::new(col, |data: &mut u32, _env| *data += 1)
+}
+
+fn main() {
+    druid::shell::init();
+
+    let mut run_loop = runloop::RunLoop::new();
+    let id = WindowId::new();
+    let mut builder = WindowBuilder::new();
+    let root = make_ui();
+    let shared = SharedWindow::new(root, id);
+    let handler = DruidHandler::new(shared, 0u32, id);
+    builder.set_title("Hello example");
+    builder.set_handler(Box::new(handler));
+    let window = builder.build().unwrap();
+    window.show();
+    run_loop.run();
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,7 +14,7 @@
 
 //! Events.
 
-use crate::kurbo::{Rect, Shape, Vec2};
+use crate::kurbo::{Rect, Shape, Size, Vec2};
 
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::window::{MouseEvent, TimerToken};
@@ -44,6 +44,17 @@ use druid_shell::window::{MouseEvent, TimerToken};
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Debug, Clone)]
 pub enum Event {
+    /// Called on the root widget when the window size changes.
+    ///
+    /// Discussion: it's not obvious this should be propagated to user
+    /// widgets. It *is* propagated through the RootWidget and handled
+    /// in the WindowPod, but after that it might be considered better
+    /// to just handle it in `layout`.
+    ///
+    /// The propagation logic of "just the root" requires a little bit
+    /// of complexity and state in EventCtx, so if it's not useful it
+    /// should be removed.
+    Size(Size),
     /// Called when a mouse button is pressed.
     MouseDown(MouseEvent),
     /// Called when a mouse button is released.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,8 +350,8 @@ pub struct EventCtx<'a, 'b> {
 /// in the widget's appearance, to schedule a repaint.
 ///
 /// [`invalidate`]: #method.invalidate
-pub struct UpdateCtx<'a, 'b> {
-    text_factory: &'b mut Text<'b>,
+pub struct UpdateCtx<'a, 'b: 'a> {
+    text_factory: &'a mut Text<'b>,
     window: &'a WindowHandle,
     // Discussion: we probably want to propagate more fine-grained
     // invalidations, which would mean a structure very much like

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,8 @@ pub struct LayoutCtx<'a, 'b: 'a> {
 ///
 /// [`invalidate`]: #method.invalidate
 pub struct EventCtx<'a, 'b> {
+    // Note: there's a bunch of state that's just passed down, might
+    // want to group that into a single struct.
     win_ctx: &'a mut dyn WinCtx<'b>,
     cursor: &'a mut Option<Cursor>,
     window_id: WindowId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,8 @@ pub use event::{Event, WheelEvent};
 pub use lens::{Lens, LensWrap};
 pub use localization::LocalizedString;
 pub use window::{
-    EventCtxRoot, LayoutCtxRoot, PaintCtxRoot, RootWidget, UpdateCtxRoot, WindowId, WindowSet,
+    EventCtxRoot, LayoutCtxRoot, PaintCtxRoot, RootWidget, SharedWindow, UpdateCtxRoot, WindowId,
+    WindowSet,
 };
 
 const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub use env::{Env, Key, Value};
 pub use event::{Event, WheelEvent};
 pub use lens::{Lens, LensWrap};
 pub use localization::LocalizedString;
+pub use win_handler::DruidHandler;
 pub use window::{
     EventCtxRoot, LayoutCtxRoot, PaintCtxRoot, RootWidget, SharedWindow, UpdateCtxRoot, WindowId,
     WindowSet,
@@ -338,6 +339,7 @@ pub struct LayoutCtx<'a, 'b: 'a> {
 pub struct EventCtx<'a, 'b> {
     win_ctx: &'a mut dyn WinCtx<'b>,
     cursor: &'a mut Option<Cursor>,
+    window_id: WindowId,
     // TODO: migrate most usage of `WindowHandle` to `WinCtx` instead.
     window: &'a WindowHandle,
     base_state: &'a mut BaseState,
@@ -505,6 +507,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             win_ctx: ctx.win_ctx,
             cursor: ctx.cursor,
             window: &ctx.window,
+            window_id: ctx.window_id,
             base_state: &mut self.state,
             had_active,
             is_handled: false,
@@ -697,6 +700,7 @@ impl<T: Data> UiState<T> {
             win_ctx,
             cursor: &mut cursor,
             window: &self.handle,
+            window_id: Default::default(),
             base_state: &mut base_state,
             had_active: self.root.state.has_active,
             is_handled: false,
@@ -1055,6 +1059,11 @@ impl<'a, 'b> EventCtx<'a, 'b> {
         self.base_state.request_timer = true;
         self.win_ctx.request_timer(deadline)
     }
+
+    /// Get the window id.
+    pub fn window_id(&self) -> WindowId {
+        self.window_id
+    }
 }
 
 impl<'a, 'b> LayoutCtx<'a, 'b> {
@@ -1085,6 +1094,11 @@ impl<'a, 'b> UpdateCtx<'a, 'b> {
     /// it's shared across multiple windows.
     pub fn window(&self) -> &WindowHandle {
         &self.window
+    }
+
+    /// Get the window id.
+    pub fn window_id(&self) -> WindowId {
+        self.window_id
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -87,7 +87,7 @@ impl<T: Data> Widget<T> for Label<T> {
         _data: &T,
         env: &Env,
     ) -> Size {
-        let text_layout = self.get_layout(layout_ctx.text, env);
+        let text_layout = self.get_layout(layout_ctx.text(), env);
         bc.constrain((text_layout.width(), 17.0))
     }
 
@@ -220,7 +220,7 @@ impl<T: Data, F: FnMut(&T, &Env) -> String> Widget<T> for DynLabel<T, F> {
     ) -> Size {
         let font_name = env.get(theme::FONT_NAME);
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
-        let text_layout = self.get_layout(layout_ctx.text, font_name, font_size, data, env);
+        let text_layout = self.get_layout(layout_ctx.text(), font_name, font_size, data, env);
         bc.constrain((text_layout.width(), 17.0))
     }
 

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::Instant;
 
-use crate::kurbo::Vec2;
+use crate::kurbo::{Size, Vec2};
 
 use crate::piet::{Color, Piet, RenderContext};
 
@@ -70,7 +70,7 @@ impl<T: Data + 'static, R: RootWidget<T> + 'static> WinHandler for DruidHandler<
         self.app_state.borrow_mut().paint(self.window_id, piet, ctx)
     }
 
-    fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
+    fn size(&mut self, width: u32, height: u32, ctx: &mut dyn WinCtx) {
         let dpi = self
             .app_state
             .borrow()
@@ -80,8 +80,8 @@ impl<T: Data + 'static, R: RootWidget<T> + 'static> WinHandler for DruidHandler<
             .handle
             .get_dpi() as f64;
         let scale = 96.0 / dpi;
-        // TODO: this probably needs to be sent as an event
-        //self.state.size = Size::new(width as f64 * scale, height as f64 * scale);
+        let event = Event::Size(Size::new(width as f64 * scale, height as f64 * scale));
+        self.do_event(event, ctx);
     }
 
     fn mouse_down(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -1,0 +1,236 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The implementation of the WinHandler trait (druid-shell integration).
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::time::Instant;
+
+use crate::kurbo::Vec2;
+
+use crate::piet::{Color, Piet, RenderContext};
+
+use druid_shell::window::{Cursor, WinCtx, WinHandler, WindowHandle};
+
+use crate::{
+    Data, Env, Event, EventCtxRoot, KeyEvent, KeyModifiers, LayoutCtx, LayoutCtxRoot, MouseEvent,
+    PaintCtx, PaintCtxRoot, RootWidget, TimerToken, UpdateCtxRoot, WheelEvent, WindowId,
+};
+
+// TODO: this should come from the theme.
+const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
+
+/// The struct implements the druid-shell `WinHandler` trait
+struct DruidHandler<T: Data, R: RootWidget<T>> {
+    app_state: Rc<RefCell<AppState<T, R>>>,
+    window_id: WindowId,
+}
+
+/// State shared by all windows in the UI.
+struct AppState<T: Data, R: RootWidget<T>> {
+    window_state: HashMap<WindowId, WindowState>,
+    env: Env,
+    data: T,
+    root: R,
+}
+
+/// Per-window state not owned by user code.
+pub(crate) struct WindowState {
+    pub(crate) handle: WindowHandle,
+    prev_paint_time: Option<Instant>,
+}
+
+impl<T: Data + 'static, R: RootWidget<T> + 'static> WinHandler for DruidHandler<T, R> {
+    fn connect(&mut self, handle: &WindowHandle) {
+        let state = WindowState {
+            handle: handle.clone(),
+            prev_paint_time: None,
+        };
+        self.app_state
+            .borrow_mut()
+            .window_state
+            .insert(self.window_id, state);
+    }
+
+    fn paint(&mut self, piet: &mut Piet, ctx: &mut dyn WinCtx) -> bool {
+        self.app_state.borrow_mut().paint(self.window_id, piet, ctx)
+    }
+
+    fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
+        let dpi = self
+            .app_state
+            .borrow()
+            .window_state
+            .get(&self.window_id)
+            .unwrap()
+            .handle
+            .get_dpi() as f64;
+        let scale = 96.0 / dpi;
+        // TODO: this probably needs to be sent as an event
+        //self.state.size = Size::new(width as f64 * scale, height as f64 * scale);
+    }
+
+    fn mouse_down(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {
+        // TODO: double-click detection (or is this done in druid-shell?)
+        let event = Event::MouseDown(event.clone());
+        self.do_event(event, ctx);
+    }
+
+    fn mouse_up(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {
+        let event = Event::MouseUp(event.clone());
+        self.do_event(event, ctx);
+    }
+
+    fn mouse_move(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {
+        let event = Event::MouseMoved(event.clone());
+        self.do_event(event, ctx);
+    }
+
+    fn key_down(&mut self, event: KeyEvent, ctx: &mut dyn WinCtx) -> bool {
+        self.do_event(Event::KeyDown(event), ctx)
+    }
+
+    fn key_up(&mut self, event: KeyEvent, ctx: &mut dyn WinCtx) {
+        self.do_event(Event::KeyUp(event), ctx);
+    }
+
+    fn wheel(&mut self, delta: Vec2, mods: KeyModifiers, ctx: &mut dyn WinCtx) {
+        let event = Event::Wheel(WheelEvent { delta, mods });
+        self.do_event(event, ctx);
+    }
+
+    fn timer(&mut self, token: TimerToken, ctx: &mut dyn WinCtx) {
+        self.do_event(Event::Timer(token), ctx);
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl<T: Data, R: RootWidget<T>> DruidHandler<T, R> {
+    /// Send an event to the widget hierarchy.
+    ///
+    /// Returns `true` if the event produced an action.
+    ///
+    /// This is principally because in certain cases (such as keydown on Windows)
+    /// the OS needs to know if an event was handled.
+    fn do_event(&mut self, event: Event, win_ctx: &mut dyn WinCtx) -> bool {
+        let mut state = self.app_state.borrow_mut();
+        let (is_handled, dirty, anim) = state.do_event_inner(self.window_id, event, win_ctx);
+        if dirty || anim {
+            win_ctx.invalidate();
+        }
+        is_handled
+    }
+}
+
+impl<T: Data, R: RootWidget<T>> AppState<T, R> {
+    fn paint(&mut self, window_id: WindowId, piet: &mut Piet, ctx: &mut dyn WinCtx) -> bool {
+        // TODO: this calculation uses wall-clock time of the paint call, which
+        // potentially has jitter.
+        //
+        // See https://github.com/xi-editor/druid/issues/85 for discussion.
+        let this_paint_time = Instant::now();
+        let prev_paint_time = self.window_state.get(&window_id).unwrap().prev_paint_time;
+        let interval = if let Some(last) = prev_paint_time {
+            let duration = this_paint_time.duration_since(last);
+            1_000_000_000 * duration.as_secs() + (duration.subsec_nanos() as u64)
+        } else {
+            0
+        };
+        let anim_frame_event = Event::AnimFrame(interval);
+        let (_, _, request_anim) = self.do_event_inner(window_id, anim_frame_event, ctx);
+        let prev = if request_anim {
+            Some(this_paint_time)
+        } else {
+            None
+        };
+        self.window_state
+            .get_mut(&window_id)
+            .unwrap()
+            .prev_paint_time = prev;
+        let text_factory = piet.text();
+        let mut layout_ctx = LayoutCtxRoot(LayoutCtx {
+            text_factory,
+            window_id,
+        });
+        self.root.layout(&mut layout_ctx, &self.data, &self.env);
+        piet.clear(BACKGROUND_COLOR);
+        let mut paint_ctx = PaintCtxRoot(PaintCtx {
+            render_ctx: piet,
+            window_id,
+        });
+        self.root.paint(&mut paint_ctx, &self.data, &self.env);
+        request_anim
+    }
+}
+
+impl<T: Data, R: RootWidget<T>> AppState<T, R> {
+    /// Send an event to the widget hierarchy.
+    ///
+    /// Returns three flags. The first is true if the event was handled. The
+    /// second is true if invalidation is requested. The third is true if an
+    /// animation frame is requested.
+    fn do_event_inner(
+        &mut self,
+        window_id: WindowId,
+        event: Event,
+        win_ctx: &mut dyn WinCtx,
+    ) -> (bool, bool, bool) {
+        // should there be a root base state persisting in the ui state instead?
+        let mut cursor = match event {
+            Event::MouseMoved(..) => Some(Cursor::Arrow),
+            _ => None,
+        };
+        let mut ctx = EventCtxRoot {
+            win_ctx,
+            cursor: &mut cursor,
+            window: &self.window_state.get(&window_id).unwrap().handle,
+            base_state: Default::default(),
+            is_handled: false,
+            window_id,
+        };
+        self.root.event(&event, &mut ctx, &mut self.data, &self.env);
+
+        let is_handled = ctx.is_handled;
+        if ctx.base_state.request_focus {
+            let focus_event = Event::FocusChanged(true);
+            self.root
+                .event(&focus_event, &mut ctx, &mut self.data, &self.env);
+        }
+        let needs_inval = ctx.base_state.needs_inval;
+        let request_anim = ctx.base_state.request_anim;
+        if let Some(cursor) = cursor {
+            win_ctx.set_cursor(&cursor);
+        }
+
+        let mut update_ctx = UpdateCtxRoot {
+            text_factory: win_ctx.text_factory(),
+            window_state: &self.window_state,
+            originating_window: window_id,
+            needs_inval: false,
+        };
+        // Note: we probably want to aggregate updates so there's only one after
+        // a burst of events.
+        self.root.update(&mut update_ctx, &self.data, &self.env);
+        // TODO: process actions (maybe?)
+
+        let dirty = needs_inval || update_ctx.needs_inval;
+        (is_handled, dirty, request_anim)
+    }
+}

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -31,11 +31,16 @@ use crate::{
     PaintCtx, PaintCtxRoot, RootWidget, TimerToken, UpdateCtxRoot, WheelEvent, WindowId,
 };
 
+use crate::theme;
+
 // TODO: this should come from the theme.
 const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 
-/// The struct implements the druid-shell `WinHandler` trait
-struct DruidHandler<T: Data, R: RootWidget<T>> {
+/// The struct implements the druid-shell `WinHandler` trait.
+///
+/// This is something of an internal detail and possibly we don't want to surface
+/// it publicly.
+pub struct DruidHandler<T: Data, R: RootWidget<T>> {
     app_state: Rc<RefCell<AppState<T, R>>>,
     window_id: WindowId,
 }
@@ -123,6 +128,20 @@ impl<T: Data + 'static, R: RootWidget<T> + 'static> WinHandler for DruidHandler<
 }
 
 impl<T: Data, R: RootWidget<T>> DruidHandler<T, R> {
+    /// Create a new handler for the first window in the app.
+    pub fn new(root: R, data: T, window_id: WindowId) -> DruidHandler<T, R> {
+        let app_state = AppState {
+            root,
+            env: theme::init(),
+            data,
+            window_state: HashMap::new(),
+        };
+        DruidHandler {
+            app_state: Rc::new(RefCell::new(app_state)),
+            window_id,
+        }
+    }
+
     /// Send an event to the widget hierarchy.
     ///
     /// Returns `true` if the event produced an action.

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,0 +1,165 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Management of multiple windows.
+
+use std::collections::HashMap;
+
+use crate::kurbo::{Point, Rect, Size};
+
+use druid_shell::window::{Cursor, Text, WinCtx, WindowHandle};
+
+use crate::win_handler::WindowState;
+use crate::{
+    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
+    WidgetPod,
+};
+
+/// A unique identifier for a window.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+// TODO: Remove Default when we get it fully wired up
+#[derive(Default)]
+pub struct WindowId(u32);
+
+/// A container for a set of windows.
+pub struct WindowSet<T: Data> {
+    map: HashMap<WindowId, WindowPod<T>>,
+}
+
+// The state for a single window. Right now, access from user code is only through
+// `WindowSet`, but this struct is split out in case more flexibility is needed.
+struct WindowPod<T: Data> {
+    root: WidgetPod<T, Box<dyn Widget<T>>>,
+    size: Size,
+}
+
+/// A state and behavior object for the application logic holding the windows.
+///
+/// A main function of this object is to hold a `WindowSet`, but additional
+/// state and logic may be added.
+///
+/// All event flow is passed through this object, which then delegates it down
+/// the hierarchy.
+// TODO: consider rename?
+pub trait RootWidget<T> {
+    /// Propagate an event to a child window.
+    // Note: this signature is different from the widget trait in that it doesn't return an
+    // `Action`. We still have to think about this.
+    fn event(&mut self, event: &Event, ctx: &mut EventCtxRoot, data: &mut T, env: &Env);
+
+    /// Propagate a data update to all windows.
+    fn update(&mut self, ctx: &mut UpdateCtxRoot, data: &T, env: &Env);
+
+    /// Propagate layout to a child window.
+    ///
+    /// The case for this method is weak; it could be subsumed into the `paint` method.
+    fn layout(&mut self, ctx: &mut LayoutCtxRoot, data: &T, env: &Env);
+
+    /// Paint a child window's appearance.
+    fn paint(&mut self, paint_ctx: &mut PaintCtxRoot, data: &T, env: &Env);
+}
+
+pub struct EventCtxRoot<'a, 'b> {
+    pub(crate) win_ctx: &'a mut dyn WinCtx<'b>,
+    pub(crate) cursor: &'a mut Option<Cursor>,
+    // TODO: migrate most usage of `WindowHandle` to `WinCtx` instead.
+    pub(crate) window: &'a WindowHandle,
+    pub(crate) base_state: BaseState,
+    pub(crate) is_handled: bool,
+    pub(crate) window_id: WindowId,
+    // TODO: mutable access to the handle map, so we can add windows
+}
+
+pub struct UpdateCtxRoot<'a> {
+    pub(crate) window_state: &'a HashMap<WindowId, WindowState>,
+    pub(crate) text_factory: &'a mut Text<'a>,
+    pub(crate) originating_window: WindowId,
+    pub(crate) needs_inval: bool,
+}
+
+pub struct LayoutCtxRoot<'a, 'b>(pub(crate) LayoutCtx<'a, 'b>);
+
+pub struct PaintCtxRoot<'a, 'b>(pub(crate) PaintCtx<'a, 'b>);
+
+impl<T: Data> WindowSet<T> {
+    pub fn event(&mut self, event: &Event, event_ctx: &mut EventCtxRoot, data: &mut T, env: &Env) {
+        if let Some(root) = self.map.get_mut(&event_ctx.window_id) {
+            root.event(event, event_ctx, data, env);
+        }
+    }
+
+    pub fn update(&mut self, root_ctx: &mut UpdateCtxRoot, data: &mut T, env: &Env) {
+        for (window_id, root) in &mut self.map {
+            let mut update_ctx = UpdateCtx {
+                text_factory: root_ctx.text_factory,
+                window: &root_ctx.window_state.get(window_id).unwrap().handle,
+                needs_inval: false,
+                window_id: *window_id,
+            };
+            root.update(&mut update_ctx, data, env);
+            if *window_id == root_ctx.originating_window {
+                root_ctx.needs_inval = update_ctx.needs_inval;
+            } else {
+                update_ctx.window.invalidate();
+            }
+        }
+    }
+
+    pub fn layout(&mut self, layout_ctx: &mut LayoutCtxRoot, data: &T, env: &Env) {
+        if let Some(root) = self.map.get_mut(&layout_ctx.0.window_id) {
+            root.layout(layout_ctx, data, env);
+        }
+    }
+
+    pub fn paint(&mut self, paint_ctx: &mut PaintCtxRoot, data: &T, env: &Env) {
+        if let Some(root) = self.map.get_mut(&paint_ctx.0.window_id) {
+            root.paint(paint_ctx, data, env);
+        }
+    }
+}
+
+impl<T: Data> WindowPod<T> {
+    pub fn event(&mut self, event: &Event, root_ctx: &mut EventCtxRoot, data: &mut T, env: &Env) {
+        let mut base_state = Default::default();
+        let mut ctx = EventCtx {
+            win_ctx: root_ctx.win_ctx,
+            cursor: root_ctx.cursor,
+            window: root_ctx.window,
+            base_state: &mut base_state,
+            had_active: self.root.state.has_active,
+            is_handled: false,
+        };
+        let _action = self.root.event(event, &mut ctx, data, env);
+        root_ctx.is_handled = ctx.is_handled;
+
+        if let Some(cursor) = root_ctx.cursor {
+            root_ctx.win_ctx.set_cursor(&cursor);
+        }
+    }
+
+    pub fn update(&mut self, update_ctx: &mut UpdateCtx, data: &mut T, env: &Env) {
+        self.root.update(update_ctx, data, env);
+    }
+
+    pub fn layout(&mut self, layout_ctx: &mut LayoutCtxRoot, data: &T, env: &Env) {
+        let bc = BoxConstraints::tight(self.size);
+        let size = self.root.layout(&mut layout_ctx.0, &bc, data, env);
+        self.root
+            .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+    }
+
+    pub fn paint(&mut self, paint_ctx: &mut PaintCtxRoot, data: &T, env: &Env) {
+        self.root.paint(&mut paint_ctx.0, data, env);
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -81,9 +81,9 @@ pub struct EventCtxRoot<'a, 'b> {
     // TODO: mutable access to the handle map, so we can add windows
 }
 
-pub struct UpdateCtxRoot<'a> {
+pub struct UpdateCtxRoot<'a, 'b: 'a> {
     pub(crate) window_state: &'a HashMap<WindowId, WindowState>,
-    pub(crate) text_factory: &'a mut Text<'a>,
+    pub(crate) text_factory: &'a mut Text<'b>,
     pub(crate) originating_window: WindowId,
     pub(crate) needs_inval: bool,
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -131,6 +131,10 @@ impl<T: Data> WindowSet<T> {
 
 impl<T: Data> WindowPod<T> {
     pub fn event(&mut self, event: &Event, root_ctx: &mut EventCtxRoot, data: &mut T, env: &Env) {
+        match event {
+            Event::Size(size) => self.size = *size,
+            _ => (),
+        }
         let mut base_state = Default::default();
         let mut ctx = EventCtx {
             win_ctx: root_ctx.win_ctx,
@@ -139,6 +143,7 @@ impl<T: Data> WindowPod<T> {
             base_state: &mut base_state,
             had_active: self.root.state.has_active,
             is_handled: false,
+            is_root: true,
         };
         let _action = self.root.event(event, &mut ctx, data, env);
         root_ctx.is_handled = ctx.is_handled;

--- a/src/window.rs
+++ b/src/window.rs
@@ -99,7 +99,7 @@ impl<T: Data> WindowSet<T> {
         }
     }
 
-    pub fn update(&mut self, root_ctx: &mut UpdateCtxRoot, data: &mut T, env: &Env) {
+    pub fn update(&mut self, root_ctx: &mut UpdateCtxRoot, data: &T, env: &Env) {
         for (window_id, root) in &mut self.map {
             let mut update_ctx = UpdateCtx {
                 text_factory: root_ctx.text_factory,
@@ -153,7 +153,7 @@ impl<T: Data> WindowPod<T> {
         }
     }
 
-    pub fn update(&mut self, update_ctx: &mut UpdateCtx, data: &mut T, env: &Env) {
+    pub fn update(&mut self, update_ctx: &mut UpdateCtx, data: &T, env: &Env) {
         self.root.update(update_ctx, data, env);
     }
 
@@ -166,5 +166,33 @@ impl<T: Data> WindowPod<T> {
 
     pub fn paint(&mut self, paint_ctx: &mut PaintCtxRoot, data: &T, env: &Env) {
         self.root.paint(&mut paint_ctx.0, data, env);
+    }
+}
+
+/// A very simple window root that shares state with all windows
+pub struct SharedWindow<T: Data> {
+    windows: WindowSet<T>,
+}
+
+impl<T: Data> RootWidget<T> for SharedWindow<T> {
+    fn event(&mut self, event: &Event, ctx: &mut EventCtxRoot, data: &mut T, env: &Env) {
+        self.windows.event(event, ctx, data, env);
+    }
+
+    /// Propagate a data update to all windows.
+    fn update(&mut self, ctx: &mut UpdateCtxRoot, data: &T, env: &Env) {
+        self.windows.update(ctx, data, env);
+    }
+
+    /// Propagate layout to a child window.
+    ///
+    /// The case for this method is weak; it could be subsumed into the `paint` method.
+    fn layout(&mut self, ctx: &mut LayoutCtxRoot, data: &T, env: &Env) {
+        self.windows.layout(ctx, data, env);
+    }
+
+    /// Paint a child window's appearance.
+    fn paint(&mut self, paint_ctx: &mut PaintCtxRoot, data: &T, env: &Env) {
+        self.windows.paint(paint_ctx, data, env);
     }
 }


### PR DESCRIPTION
This isn't quite ready to merge, but I think is far enough along that it's worth reviewing. Open issues:

* There's no event flow for closing windows, so we're not cleaning up that state. The example still works though.

* The existing `UiMain` and `UiState` should be deleted, and examples moved to the new framework.

* It's *very* likely that the API can be cleaned up, especially exposing less of the internals of WindowId / WindowBuilder on first-window creation.

* The example should have both globally shared and window-local state; the latter is implemented basically as a map keyed off WindowId. This means making sure the window_id is exposed in all relevant contexts. We could also consider some kind of lens to make this more natural, so (a) you don't always have to access the map explicitly and (b) invalidations to window-local state don't propagate to other windows.

* Apparently it doesn't merge cleanly against master. I'll merge or rebase :/
