### PR TITLE
Fix TextBox panic due to selection going off-bounds on data string

### DIFF
--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -446,3 +446,32 @@ fn prev_grapheme(src: &str, from: usize) -> usize {
         0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that when data is mutated externally widget
+    /// can still be used to insert characters.
+    #[test]
+    fn data_can_be_changed_externally() {
+        let mut widget = TextBox::new(100.);
+        let mut data = "".to_string();
+
+        // First insert some chars
+        widget.insert(&mut data, "o");
+        widget.insert(&mut data, "n");
+        widget.insert(&mut data, "e");
+
+        assert_eq!("one", data);
+        assert_eq!(3, widget.selection.start);
+        assert_eq!(3, widget.selection.end);
+
+        // Modify data externally (e.g data was changed in the parent widget)
+        data = "".to_string();
+
+        // Insert again
+        widget.insert(&mut data, "a");
+    }
+
+}

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -92,7 +92,7 @@ impl Selection {
 
     /// Constrain selection to be not greater than input string
     pub fn constrain_to(mut self, s: &str) -> Self {
-        let s_len = s.chars().count();
+        let s_len = s.len();
         self.start = min(self.start, s_len);
         self.end = min(self.end, s_len);
         self


### PR DESCRIPTION
@futurepaul let me know if this is the right fix and in the right place.

* [x] <s>Should we replace all usages of `s.len()` with `s.chars().count()`?</s> No!