### PR TITLE
Add set_title to WindowHandle

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -597,6 +597,17 @@ impl WindowHandle {
         }
     }
 
+    /// Set the title for this menu.
+    pub fn set_title(&self, title: &str) {
+        if let Some(ref nsview) = self.nsview {
+            unsafe {
+                let window: id = msg_send![*nsview.load(), window];
+                let title = make_nsstring(title);
+                window.setTitle_(title);
+            }
+        }
+    }
+
     /// Get a handle that can be used to schedule an idle task.
     pub fn get_idle_handle(&self) -> Option<IdleHandle> {
         // TODO: maybe try harder to return None if window has been dropped.

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -1103,6 +1103,18 @@ impl WindowHandle {
         }
     }
 
+    /// Set the title for this menu.
+    pub fn set_title(&self, title: &str) {
+        if let Some(w) = self.state.upgrade() {
+            let hwnd = w.hwnd.get();
+            unsafe {
+                if SetWindowTextW(hwnd, title.to_wide().as_ptr()) == FALSE {
+                    warn!("failed to set window title '{}'", title);
+                }
+            }
+        }
+    }
+
     /// Get the raw HWND handle, for uses that are not wrapped in
     /// druid_win_shell.
     pub fn get_hwnd(&self) -> Option<HWND> {


### PR DESCRIPTION
This allows the title of a window to be changed at runtime.

Breaking this out of some other work.

One question this raises: as we add more and more backends, it would be nice to have some way to ensure that various backends implement the expected API. One possible way to do this is to describe the interfaces for the various backend types as traits; we could then either add stub impls there that print warnings, or less have compilation (and CI) fail when those methods aren't implemented.

The only other solution that comes to mind is that we are rigorous about using each API method in some test or example; this is more fragile but maybe more ergonomic in practice (don't need to always import the traits?)