### PR TITLE
Fail build on warnings

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -25,6 +25,14 @@ jobs:
         parameters:
           crate_path: '.'
 
+      - template: ci/build.yml
+        parameters:
+          crate_path: 'druid-shell'
+      
+      - template: ci/build.yml
+        parameters:
+          crate_path: '.'
+
       - template: ci/test.yml
         parameters:
           toolchain: stable

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,0 +1,5 @@
+steps:
+  - script: |
+        cargo rustc -- -D warnings
+    workingDirectory: '$(Build.SourcesDirectory)/${{parameters.crate_path}}'
+    displayName: Run cargo rustc, deny warnings

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -2,4 +2,4 @@ steps:
   - script: |
         cargo rustc -- -D warnings
     workingDirectory: '$(Build.SourcesDirectory)/${{parameters.crate_path}}'
-    displayName: Run cargo rustc, deny warnings
+    displayName: Run cargo rustc -- -D warnings on ${{parameters.crate_path}}


### PR DESCRIPTION
Run the build command for `druid` and `druid_shell`, failing on warnings.

fixes #139 