### PR TITLE
Add width and height factors to Align

### DIFF
--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use druid::shell::{runloop, WindowBuilder};
-use druid::widget::{ActionWrapper, Button, Column, DynLabel, Padding, ProgressBar, Slider};
+use druid::widget::{ActionWrapper, Align, Button, Column, DynLabel, Padding, ProgressBar, Slider};
 use druid::{UiMain, UiState};
 
 fn main() {
@@ -40,7 +40,7 @@ fn main() {
     col.add_child(Padding::uniform(5.0, slider), 1.0);
     col.add_child(Padding::uniform(5.0, label_1), 1.0);
     col.add_child(Padding::uniform(5.0, label_2), 1.0);
-    col.add_child(Padding::uniform(5.0, button_1), 0.0);
+    col.add_child(Padding::uniform(5.0, Align::right(button_1)), 0.0);
     col.add_child(Padding::uniform(5.0, button_2), 1.0);
 
     let state = UiState::new(col, 0.7f64);

--- a/src/widget/align.rs
+++ b/src/widget/align.rs
@@ -25,6 +25,8 @@ use crate::piet::UnitPoint;
 pub struct Align<T: Data> {
     align: UnitPoint,
     child: WidgetPod<T, Box<dyn Widget<T>>>,
+    width_factor: Option<f64>,
+    height_factor: Option<f64>,
 }
 
 impl<T: Data> Align<T> {
@@ -37,12 +39,44 @@ impl<T: Data> Align<T> {
         Align {
             align,
             child: WidgetPod::new(child).boxed(),
+            width_factor: None,
+            height_factor: None,
         }
     }
 
     /// Create centered widget.
     pub fn centered(child: impl Widget<T> + 'static) -> Align<T> {
         Align::new(UnitPoint::CENTER, child)
+    }
+
+    /// Create right-aligned widget.
+    pub fn right(child: impl Widget<T> + 'static) -> Align<T> {
+        Align::new(UnitPoint::RIGHT, child)
+    }
+
+    /// Create left-aligned widget.
+    pub fn left(child: impl Widget<T> + 'static) -> Align<T> {
+        Align::new(UnitPoint::LEFT, child)
+    }
+
+    /// Align only in the horizontal axis, keeping the child's size in the vertical.
+    pub fn horizontal(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+        Align {
+            align,
+            child: WidgetPod::new(child).boxed(),
+            width_factor: None,
+            height_factor: Some(1.0),
+        }
+    }
+
+    /// Align only in the vertical axis, keeping the child's size in the horizontal.
+    pub fn vertical(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+        Align {
+            align,
+            child: WidgetPod::new(child).boxed(),
+            width_factor: Some(1.0),
+            height_factor: None,
+        }
     }
 }
 
@@ -66,6 +100,14 @@ impl<T: Data> Widget<T> for Align<T> {
         if bc.is_height_bounded() {
             my_size.height = bc.max().height;
         }
+
+        if let Some(width) = self.width_factor {
+            my_size.width = size.width * width;
+        }
+        if let Some(height) = self.height_factor {
+            my_size.height = size.height * height;
+        }
+
         my_size = bc.constrain(my_size);
         let extra_width = (my_size.width - size.width).max(0.);
         let extra_height = (my_size.height - size.height).max(0.);

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -148,8 +148,8 @@ impl<T: Data + 'static> Button<T> {
     }
 
     pub fn sized(text: impl Into<LabelText<T>>, width: f64, height: f64) -> impl Widget<T> {
-        Align::new(
-            UnitPoint::LEFT,
+        Align::vertical(
+            UnitPoint::CENTER,
             SizedBox::new(Button {
                 label: Label::aligned(text, UnitPoint::CENTER),
             })

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -28,7 +28,7 @@ pub struct ProgressBar;
 
 impl ProgressBar {
     pub fn new() -> impl Widget<f64> {
-        Align::new(UnitPoint::LEFT, ProgressBarRaw::default())
+        Align::vertical(UnitPoint::CENTER, ProgressBarRaw::default())
     }
 }
 

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -28,7 +28,7 @@ pub struct Slider;
 
 impl Slider {
     pub fn new() -> impl Widget<f64> {
-        Align::new(UnitPoint::LEFT, SliderRaw::default())
+        Align::vertical(UnitPoint::CENTER, SliderRaw::default())
     }
 }
 

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -99,7 +99,7 @@ pub struct TextBox;
 
 impl TextBox {
     pub fn new() -> impl Widget<String> {
-        Align::new(UnitPoint::LEFT, TextBoxRaw::new())
+        Align::vertical(UnitPoint::CENTER, TextBoxRaw::new())
     }
 }
 


### PR DESCRIPTION
The motivation for this can be seen in the slider example. Adding a right-align to the sized button now moves the button to the right. Before, `Align::new(UnitPoint::RIGHT)` would do nothing because the button is already wrapped in an Align widget and Align widgets take up bc.max() in both dimensions by default.

Adding `width_factor` and `height_factor` matches [Flutter's design](https://api.flutter.dev/flutter/widgets/Align-class.html).  I took the liberty of only exposing this via `Align::vertical` and `Align::horizontal` methods because I don't really have a motivating use for bespoke width / height factors right now.

I also added `Align::right` and `Align::left` methods to save the need for importing `UnitPoint` in those cases.