### PR TITLE
Add Checkbox widget

### DIFF
--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -13,8 +13,52 @@
 // limitations under the License.
 
 use druid::shell::{runloop, WindowBuilder};
-use druid::widget::{ActionWrapper, Align, Button, Column, DynLabel, Padding, ProgressBar, Slider};
-use druid::{UiMain, UiState};
+use druid::widget::{
+    ActionWrapper, Align, Button, Checkbox, Column, DynLabel, Label, Padding, ProgressBar, Row,
+    Slider,
+};
+use druid::{Data, LensWrap, UiMain, UiState};
+
+#[derive(Clone)]
+struct DemoState {
+    value: f64,
+    double: bool,
+}
+
+mod lenses {
+    pub mod demo_state {
+        use super::super::DemoState;
+        use druid::Lens;
+        pub struct Value;
+        pub struct Double;
+
+        impl Lens<DemoState, f64> for Value {
+            fn get<'a>(&self, data: &'a DemoState) -> &'a f64 {
+                &data.value
+            }
+
+            fn with_mut<V, F: FnOnce(&mut f64) -> V>(&self, data: &mut DemoState, f: F) -> V {
+                f(&mut data.value)
+            }
+        }
+
+        impl Lens<DemoState, bool> for Double {
+            fn get<'a>(&self, data: &'a DemoState) -> &'a bool {
+                &data.double
+            }
+
+            fn with_mut<V, F: FnOnce(&mut bool) -> V>(&self, data: &mut DemoState, f: F) -> V {
+                f(&mut data.double)
+            }
+        }
+    }
+}
+
+impl Data for DemoState {
+    fn same(&self, other: &Self) -> bool {
+        self.value.same(&other.value) && self.double.same(&other.double)
+    }
+}
 
 fn main() {
     druid_shell::init();
@@ -23,27 +67,45 @@ fn main() {
     let mut builder = WindowBuilder::new();
 
     let mut col = Column::new();
-    let label_1 = DynLabel::new(|data: &f64, _env| format!("actual value: {0:.2}", data));
-    let label_2 = DynLabel::new(|data: &f64, _env| format!("2x the value: {0:.2}", data * 2.0));
-    let bar = ProgressBar::new();
-    let slider = Slider::new();
+    let label = DynLabel::new(|data: &DemoState, _env| {
+        if data.double {
+            format!("2x the value: {0:.2}", data.value * 2.0)
+        } else {
+            format!("actual value: {0:.2}", data.value)
+        }
+    });
+    let mut row = Row::new();
+    let checkbox = LensWrap::new(Checkbox::new(), lenses::demo_state::Double);
+    let checkbox_label = Label::new("double the value");
+    row.add_child(checkbox, 0.0);
+    row.add_child(Padding::uniform(5.0, checkbox_label), 1.0);
+
+    let bar = LensWrap::new(ProgressBar::new(), lenses::demo_state::Value);
+    let slider = LensWrap::new(Slider::new(), lenses::demo_state::Value);
 
     let button_1 = ActionWrapper::new(
         Button::sized("increment ", 200.0, 100.0),
-        move |data: &mut f64, _env| *data += 0.1,
+        move |data: &mut DemoState, _env| data.value += 0.1,
     );
-    let button_2 = ActionWrapper::new(Button::new("decrement "), move |data: &mut f64, _env| {
-        *data -= 0.1
-    });
+    let button_2 = ActionWrapper::new(
+        Button::new("decrement "),
+        move |data: &mut DemoState, _env| data.value -= 0.1,
+    );
 
     col.add_child(Padding::uniform(5.0, bar), 1.0);
     col.add_child(Padding::uniform(5.0, slider), 1.0);
-    col.add_child(Padding::uniform(5.0, label_1), 1.0);
-    col.add_child(Padding::uniform(5.0, label_2), 1.0);
+    col.add_child(Padding::uniform(5.0, label), 1.0);
+    col.add_child(Padding::uniform(5.0, row), 1.0);
     col.add_child(Padding::uniform(5.0, Align::right(button_1)), 0.0);
     col.add_child(Padding::uniform(5.0, button_2), 1.0);
 
-    let state = UiState::new(col, 0.7f64);
+    let state = UiState::new(
+        col,
+        DemoState {
+            value: 0.7f64,
+            double: false,
+        },
+    );
     builder.set_title("Widget demo");
     builder.set_handler(Box::new(UiMain::new(state)));
     let window = builder.build().unwrap();

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -1,0 +1,128 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A checkbox widget.
+
+use crate::kurbo::{BezPath, Point, RoundedRect, Size};
+use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
+use crate::theme;
+use crate::widget::Align;
+use crate::{
+    Action, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
+};
+
+/// A checkbox that toogles a boolean
+#[derive(Debug, Clone)]
+pub struct Checkbox;
+
+impl Checkbox {
+    pub fn new() -> impl Widget<bool> {
+        Align::vertical(UnitPoint::CENTER, CheckboxRaw::default())
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CheckboxRaw;
+
+impl Widget<bool> for CheckboxRaw {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &bool, env: &Env) {
+        let size = env.get(theme::BASIC_WIDGET_HEIGHT);
+
+        let rect =
+            RoundedRect::from_origin_size(Point::ORIGIN, Size::new(size, size).to_vec2(), 2.);
+
+        //Paint the background
+        let background_gradient = LinearGradient::new(
+            UnitPoint::TOP,
+            UnitPoint::BOTTOM,
+            (
+                env.get(theme::BACKGROUND_LIGHT),
+                env.get(theme::BACKGROUND_DARK),
+            ),
+        );
+
+        paint_ctx.fill(rect, &background_gradient);
+
+        let border_color = if base_state.is_hot() {
+            env.get(theme::BORDER_LIGHT)
+        } else {
+            env.get(theme::BORDER)
+        };
+
+        paint_ctx.stroke(rect, &border_color, 1.);
+
+        if *data {
+            let mut path = BezPath::new();
+            path.move_to((4.0, 9.0));
+            path.line_to((8.0, 13.0));
+            path.line_to((14.0, 5.0));
+
+            let mut style = StrokeStyle::new();
+            style.set_line_cap(LineCap::Round);
+            style.set_line_join(LineJoin::Round);
+
+            paint_ctx.stroke_styled(path, &env.get(theme::LABEL_COLOR), 2., &style);
+        }
+    }
+
+    fn layout(
+        &mut self,
+        _layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _data: &bool,
+        env: &Env,
+    ) -> Size {
+        bc.constrain(Size::new(
+            env.get(theme::BASIC_WIDGET_HEIGHT),
+            env.get(theme::BASIC_WIDGET_HEIGHT),
+        ))
+    }
+
+    fn event(
+        &mut self,
+        event: &Event,
+        ctx: &mut EventCtx,
+        data: &mut bool,
+        _env: &Env,
+    ) -> Option<Action> {
+        match event {
+            Event::MouseDown(_) => {
+                ctx.set_active(true);
+                ctx.invalidate();
+            }
+            Event::MouseUp(_) => {
+                if ctx.is_active() {
+                    ctx.set_active(false);
+                    if ctx.is_hot() {
+                        if *data {
+                            *data = false;
+                        } else {
+                            *data = true;
+                        }
+                    }
+                    ctx.invalidate();
+                }
+            }
+            Event::MouseMoved(_) => {
+                ctx.invalidate();
+            }
+            _ => (),
+        }
+        None
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&bool>, _data: &bool, _env: &Env) {
+        ctx.invalidate();
+    }
+}

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -22,7 +22,7 @@ use crate::{
     Action, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
 };
 
-/// A checkbox that toogles a boolean
+/// A checkbox that toggles a boolean
 #[derive(Debug, Clone)]
 pub struct Checkbox;
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -43,3 +43,6 @@ pub use crate::widget::textbox::TextBox;
 
 mod sized_box;
 pub use crate::widget::sized_box::SizedBox;
+
+mod checkbox;
+pub use crate::widget::checkbox::Checkbox;


### PR DESCRIPTION
I believe this widget is straightforward in its implementation, but I'm curious if there's a better way to use it. I put it in the slider example, with the help of `Lens`. It felt pretty simple to use once I got past the setup boilerplate, but I'm sure there's another strategy I'm not thinking of.

I believe one possibility, which I did not explore, is to return a "toggle" action or something from `event` (like how the button returns "hit") and then handle it with an `ActionWrapper`.