### PR TITLE
Add app.rs & AppLauncher

### DIFF
--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -18,11 +18,10 @@ use std::f64::consts::PI;
 
 use druid::kurbo::{Line, Point, Size, Vec2};
 use druid::piet::{Color, RenderContext};
-use druid::shell::{runloop, WindowBuilder};
 use druid::{
-    Action, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
+    Action, AppLauncher, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx,
+    UpdateCtx, Widget, WindowDesc,
 };
-use druid::{UiMain, UiState};
 
 struct AnimWidget {
     t: f64,
@@ -81,15 +80,8 @@ impl Widget<u32> for AnimWidget {
 }
 
 fn main() {
-    druid::shell::init();
-
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
-    let root = AnimWidget { t: 0.0 };
-    let state = UiState::new(root, 0u32);
-    builder.set_title("Animation example");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    let window = WindowDesc::new(|| AnimWidget { t: 0.0 });
+    AppLauncher::with_window(window)
+        .launch(0)
+        .expect("launch failed");
 }

--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -14,8 +14,7 @@
 
 //! Simple calculator.
 
-use druid::shell::{runloop, WindowBuilder};
-use druid::{Data, LensWrap, UiMain, UiState, Widget};
+use druid::{AppLauncher, Data, LensWrap, Widget, WindowDesc};
 
 use druid::widget::{ActionWrapper, Button, Column, DynLabel, Padding, Row};
 
@@ -237,21 +236,14 @@ fn build_calc() -> impl Widget<CalcState> {
 
 fn main() {
     simple_logger::init().unwrap();
-    druid_shell::init();
-
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
-    let root = build_calc();
+    let window = WindowDesc::new(build_calc);
     let calc_state = CalcState {
         value: "0".to_string(),
         operand: 0.0,
         operator: 'C',
         in_num: false,
     };
-    let state = UiState::new(root, calc_state);
-    builder.set_title("Calculator");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    AppLauncher::with_window(window)
+        .launch(calc_state)
+        .expect("launch failed");
 }

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -20,11 +20,9 @@ use druid::piet::{
     Color, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayoutBuilder,
 };
 
-use druid::shell::{runloop, WindowBuilder};
-
 use druid::{
-    Action, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UiMain, UiState,
-    UpdateCtx, Widget,
+    Action, AppLauncher, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx,
+    UpdateCtx, Widget, WindowDesc,
 };
 
 struct CustomWidget;
@@ -136,19 +134,10 @@ impl Widget<String> for CustomWidget {
 
 fn main() {
     simple_logger::init().unwrap();
-    druid::shell::init();
-
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
-    let root = CustomWidget {};
-
-    let state = UiState::new(root, "Druid + Piet".to_string());
-
-    builder.set_title("Custom widget example");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    let window = WindowDesc::new(|| CustomWidget {});
+    AppLauncher::with_window(window)
+        .launch("Druid + Piet".to_string())
+        .expect("launch failed");
 }
 
 fn make_image_data(width: usize, height: usize) -> Vec<u8> {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -12,28 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{ActionWrapper, Align, Button, Column, Label, Padding};
-use druid::{LocalizedString, UiMain, UiState};
+use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
 
 fn main() {
     simple_logger::init().unwrap();
-    druid::shell::init();
+    let main_window = WindowDesc::new(ui_builder);
+    let data = 0_u32;
+    AppLauncher::with_window(main_window)
+        .launch(data)
+        .expect("launch failed");
+}
 
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
-    let mut col = Column::new();
+fn ui_builder() -> impl Widget<u32> {
     let text =
         LocalizedString::new("hello-counter").with_arg("count", |_env, data: &u32| (*data).into());
     let label = Label::new(text);
     let button = Button::new("increment");
+
+    let mut col = Column::new();
     col.add_child(Align::centered(Padding::uniform(5.0, label)), 1.0);
     col.add_child(Padding::uniform(5.0, button), 1.0);
-    let root = ActionWrapper::new(col, |data: &mut u32, _env| *data += 1);
-    let state = UiState::new(root, 0u32);
-    builder.set_title("Hello example");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    ActionWrapper::new(col, |data: &mut u32, _env| *data += 1)
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -14,9 +14,8 @@
 
 //! This example shows how to construct a basic layout.
 
-use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{Button, Column, Label, Padding, Row, SizedBox};
-use druid::{UiMain, UiState, Widget};
+use druid::{AppLauncher, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
     // Begin construction of vertical layout
@@ -43,19 +42,8 @@ fn build_app() -> impl Widget<u32> {
 }
 
 fn main() {
-    druid::shell::init();
-
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
-
-    // Build app layout
-    let root = build_app();
-    // Set up initial app state
-    let state = UiState::new(root, 0u32);
-    builder.set_title("Layout example");
-    builder.set_handler(Box::new(UiMain::new(state)));
-
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    let window = WindowDesc::new(build_app);
+    AppLauncher::with_window(window)
+        .launch(0u32)
+        .expect("launch failed");
 }

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -12,25 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{Button, Column, Padding, Scroll};
-use druid::{UiMain, UiState};
+use druid::{AppLauncher, Widget, WindowDesc};
 
 fn main() {
-    druid::shell::init();
+    let window = WindowDesc::new(build_widget);
+    AppLauncher::with_window(window)
+        .launch(0u32)
+        .expect("launch failed");
+}
 
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
+fn build_widget() -> impl Widget<u32> {
     let mut col = Column::new();
     for i in 0..30 {
         let button = Button::new(format!("Button {}", i));
         col.add_child(Padding::uniform(3.0, button), 0.0);
     }
-    let scroll = Scroll::new(col);
-    let state = UiState::new(scroll, 0u32);
-    builder.set_title("Scroll example");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    Scroll::new(col)
 }

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{
     ActionWrapper, Align, Button, Checkbox, Column, DynLabel, Label, Padding, ProgressBar, Row,
     Slider,
 };
-use druid::{Data, LensWrap, UiMain, UiState};
+use druid::{AppLauncher, Data, LensWrap, Widget, WindowDesc};
 
 #[derive(Clone)]
 struct DemoState {
@@ -60,12 +59,7 @@ impl Data for DemoState {
     }
 }
 
-fn main() {
-    druid_shell::init();
-
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
-
+fn build_widget() -> impl Widget<DemoState> {
     let mut col = Column::new();
     let label = DynLabel::new(|data: &DemoState, _env| {
         if data.double {
@@ -98,17 +92,15 @@ fn main() {
     col.add_child(Padding::uniform(5.0, row), 1.0);
     col.add_child(Padding::uniform(5.0, Align::right(button_1)), 0.0);
     col.add_child(Padding::uniform(5.0, button_2), 1.0);
+    col
+}
 
-    let state = UiState::new(
-        col,
-        DemoState {
+fn main() {
+    let window = WindowDesc::new(build_widget);
+    AppLauncher::with_window(window)
+        .launch(DemoState {
             value: 0.7f64,
             double: false,
-        },
-    );
-    builder.set_title("Widget demo");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+        })
+        .expect("launch failed");
 }

--- a/examples/textbox.rs
+++ b/examples/textbox.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::shell::{runloop, WindowBuilder};
 use druid::widget::{Column, DynLabel, Padding, TextBox};
-use druid::{UiMain, UiState};
+use druid::{AppLauncher, Widget, WindowDesc};
 
 fn main() {
-    druid::shell::init();
+    let window = WindowDesc::new(build_widget);
+    AppLauncher::with_window(window)
+        .launch("typing is fun!".to_string())
+        .expect("launch failed");
+}
 
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
+fn build_widget() -> impl Widget<String> {
     let mut col = Column::new();
 
     let textbox = TextBox::new();
@@ -30,11 +32,5 @@ fn main() {
     col.add_child(Padding::uniform(5.0, textbox), 1.0);
     col.add_child(Padding::uniform(5.0, textbox_2), 1.0);
     col.add_child(Padding::uniform(5.0, label), 1.0);
-
-    let state = UiState::new(col, "typing is fun!".to_string());
-    builder.set_title("TextBox example");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    col
 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -18,12 +18,10 @@ use std::time::{Duration, Instant};
 
 use druid::kurbo::{Line, Size};
 use druid::piet::{Color, RenderContext};
-use druid::shell::{runloop, WindowBuilder};
 use druid::{
-    Action, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken,
-    UpdateCtx, Widget,
+    Action, AppLauncher, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx,
+    TimerToken, UpdateCtx, Widget, WindowDesc,
 };
-use druid::{UiMain, UiState};
 
 struct TimerWidget {
     timer_id: TimerToken,
@@ -84,18 +82,12 @@ impl Widget<u32> for TimerWidget {
 }
 
 fn main() {
-    druid::shell::init();
-
-    let mut run_loop = runloop::RunLoop::new();
-    let mut builder = WindowBuilder::new();
-    let root = TimerWidget {
+    let window = WindowDesc::new(|| TimerWidget {
         timer_id: TimerToken::INVALID,
         on: false,
-    };
-    let state = UiState::new(root, 0u32);
-    builder.set_title("Timer example");
-    builder.set_handler(Box::new(UiMain::new(state)));
-    let window = builder.build().unwrap();
-    window.show();
-    run_loop.run();
+    });
+
+    AppLauncher::with_window(window)
+        .launch(0u32)
+        .expect("launch failed");
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,113 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Window building and app lifecycle.
+
+use std::sync::Arc;
+
+use crate::shell::{init, runloop, Error as PlatformError, WindowBuilder};
+use crate::{Data, LocalizedString, UiMain, UiState, Widget};
+
+/// Handles initial setup of an application, and starts the runloop.
+pub struct AppLauncher<T> {
+    windows: Vec<WindowDesc<T>>,
+}
+
+/// A function that can create a widget.
+///
+/// This type signature is a bit hairy because this has to work with `Command`,
+/// which requires things to be sync + send.
+type WidgetBuilderFn<T> = dyn Fn() -> Box<dyn Widget<T>> + Send + Sync + 'static;
+
+/// A description of a window to be instantiated.
+///
+/// This includes a function that can build the root widget, as well as other
+/// window properties such as the title.
+pub struct WindowDesc<T> {
+    pub(crate) root_builder: Arc<WidgetBuilderFn<T>>,
+    //TODO: more things you can configure on a window, like size and menu
+    pub(crate) title: Option<LocalizedString<T>>,
+}
+
+impl<T: Data + 'static> AppLauncher<T> {
+    /// Create a new `AppLauncher` with the provided window.
+    pub fn with_window(window: WindowDesc<T>) -> Self {
+        AppLauncher {
+            windows: vec![window],
+        }
+    }
+
+    /// Build the windows and start the runloop.
+    ///
+    /// Returns an error if a window cannot be instantiated. This is usually
+    /// a fatal error.
+    pub fn launch(mut self, data: T) -> Result<(), PlatformError> {
+        init();
+
+        //TODO: launch all windows, when multi-win lands
+        let window = self.windows.pop().expect("launch called with no window");
+        let WindowDesc {
+            root_builder,
+            title,
+            ..
+        } = window;
+
+        //TODO: use title when multi-win lands
+        let title = title.unwrap_or(LocalizedString::new("app-name-exclaim"));
+        let root = root_builder();
+        let state = UiState::new(root, data);
+
+        let mut builder = WindowBuilder::new();
+        builder.set_handler(Box::new(UiMain::new(state)));
+        builder.set_title(title.localized_str());
+        let window = builder.build()?;
+
+        let mut main_loop = runloop::RunLoop::new();
+        window.show();
+
+        main_loop.run();
+        Ok(())
+    }
+}
+
+impl<T: Data + 'static> WindowDesc<T> {
+    /// Create a new `WindowDesc`, taking a funciton that will generate the root
+    /// [`Widget`] for this window.
+    ///
+    /// It is possible that a `WindowDesc` can be reused to launch multiple windows.
+    ///
+    /// [`Widget`]: trait.Widget.html
+    pub fn new<W, F>(root: F) -> WindowDesc<T>
+    where
+        W: Widget<T> + 'static,
+        F: Fn() -> W + 'static + Send + Sync,
+    {
+        // wrap this closure in another closure that dyns the result
+        // this just makes our API slightly cleaner; callers don't need to explicitly box.
+        let root_builder: Arc<WidgetBuilderFn<T>> = Arc::new(move || Box::new(root()));
+        WindowDesc {
+            root_builder,
+            title: None,
+        }
+    }
+
+    /// Set the title for this window. This is a [`LocalizedString`] that will
+    /// be kept up to date as the application's state changes.
+    ///
+    /// [`LocalizedString`]: struct.LocalizedString.html
+    pub fn title(mut self, title: LocalizedString<T>) -> Self {
+        self.title = Some(title);
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use druid_shell::{self as shell, kurbo, piet};
 
 pub mod widget;
 
+mod app;
 mod data;
 mod env;
 mod event;
@@ -49,6 +50,7 @@ use druid_shell::window::{self, Text, WinCtx, WinHandler, WindowHandle};
 pub use druid_shell::window::{Cursor, MouseButton, MouseEvent, TimerToken};
 pub use shell::hotkey::{HotKey, RawMods, SysMods};
 
+pub use app::{AppLauncher, WindowDesc};
 pub use data::Data;
 pub use env::{Env, Key, Value};
 pub use event::{Event, WheelEvent};


### PR DESCRIPTION
This simplifies the API for creating windows and starting a druid
application.

This was broken out of multi-window work. That work requires a
platform-agnostic way to describe a window; that window description
is used here as the basis for simpler initial setup.

This approach will also make it easier, in the future, for us
to implement things like state restoration.

-----
notes:

There's some stuff in here (like the title being a localized string) that doesn't make a ton of sense right now, but will end up being relevant for multi-win.

I'm not sure about names, in particular `WindowDesc`. I'm also not sure about `app.rs`. 🤷‍♀ 

@LiHRaM If you were interested, this is where a custom logging impl would go; we would add a method to `AppLauncher` that would enable logging, and if the user called that we would set up some (maybe custom?) simple logger that prints to stdout.