### PR TITLE
Add Radio button widget

### DIFF
--- a/examples/radio.rs
+++ b/examples/radio.rs
@@ -1,0 +1,71 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use druid::widget::{Column, Padding, Radio, RadioGroup, SizedBox};
+use druid::{AppLauncher, Data, Widget, WindowDesc};
+
+#[derive(Clone, PartialEq)]
+enum Choice {
+    A,
+    B,
+    C,
+    D,
+}
+
+impl Data for Choice {
+    fn same(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+fn build_widget() -> impl Widget<Choice> {
+    let mut col = Column::new();
+
+    col.add_child(
+        Padding::uniform(5.0, Radio::new("First choice", Choice::A)),
+        0.0,
+    );
+    col.add_child(
+        Padding::uniform(5.0, Radio::new("Second choice", Choice::B)),
+        0.0,
+    );
+    col.add_child(
+        Padding::uniform(5.0, Radio::new("Worst choice", Choice::C)),
+        0.0,
+    );
+    col.add_child(
+        Padding::uniform(5.0, Radio::new("Best choice", Choice::D)),
+        0.0,
+    );
+
+    col.add_child(SizedBox::empty(), 1.0);
+
+    col.add_child(
+        RadioGroup::new(vec![
+            ("Good times", Choice::A),
+            ("Ergonomics", Choice::B),
+            ("No fourth choice!", Choice::C),
+        ]),
+        0.0,
+    );
+
+    col
+}
+
+fn main() {
+    let window = WindowDesc::new(build_widget);
+    AppLauncher::with_window(window)
+        .launch(Choice::A)
+        .expect("launch failed");
+}

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -114,7 +114,7 @@ impl Widget<bool> for CheckboxRaw {
                     ctx.invalidate();
                 }
             }
-            Event::MouseMoved(_) => {
+            Event::HotChanged(_) => {
                 ctx.invalidate();
             }
             _ => (),

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -21,7 +21,7 @@ mod align;
 pub use crate::widget::align::Align;
 
 mod button;
-pub use crate::widget::button::{Button, DynLabel, Label};
+pub use crate::widget::button::{Button, DynLabel, Label, LabelText};
 
 mod flex;
 pub use crate::widget::flex::{Column, Flex, Row};
@@ -46,3 +46,6 @@ pub use crate::widget::sized_box::SizedBox;
 
 mod checkbox;
 pub use crate::widget::checkbox::Checkbox;
+
+mod radio;
+pub use crate::widget::radio::{Radio, RadioGroup};

--- a/src/widget/radio.rs
+++ b/src/widget/radio.rs
@@ -1,0 +1,148 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A radio button widget.
+
+use std::marker::PhantomData;
+
+use crate::kurbo::{Circle, Size};
+use crate::piet::{LinearGradient, RenderContext, UnitPoint};
+use crate::theme;
+use crate::widget::{Align, Column, Label, LabelText, Padding, Row};
+use crate::{
+    Action, BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,
+    Widget,
+};
+
+/// A group of radio buttons
+#[derive(Debug, Clone)]
+pub struct RadioGroup<T: Data + PartialEq + 'static> {
+    phantom: PhantomData<T>,
+}
+
+impl<T: Data + PartialEq + 'static> RadioGroup<T> {
+    pub fn new(
+        variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
+    ) -> impl Widget<T> {
+        let mut col = Column::new();
+        for (label, variant) in variants.into_iter() {
+            let radio = Radio::new(label, variant);
+            col.add_child(Padding::uniform(5.0, radio), 0.0);
+        }
+        col
+    }
+}
+
+/// A single radio button
+#[derive(Debug, Clone)]
+pub struct Radio<T: Data + PartialEq + 'static> {
+    phantom: PhantomData<T>,
+}
+
+impl<T: Data + PartialEq + 'static> Radio<T> {
+    pub fn new(label: impl Into<LabelText<T>>, variant: T) -> impl Widget<T> {
+        let mut row = Row::new();
+        row.add_child(RadioRaw { variant }, 0.0);
+        row.add_child(Label::new(label), 1.0);
+        Align::vertical(UnitPoint::CENTER, row)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RadioRaw<T: Data + PartialEq> {
+    variant: T,
+}
+
+impl<T: Data + PartialEq> RadioRaw<T> {}
+
+impl<T: Data + PartialEq> Widget<T> for RadioRaw<T> {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+        let size = env.get(theme::BASIC_WIDGET_HEIGHT);
+
+        let circle = Circle::new((size / 2., size / 2.), 7.);
+
+        //Paint the background
+        let background_gradient = LinearGradient::new(
+            UnitPoint::TOP,
+            UnitPoint::BOTTOM,
+            (
+                env.get(theme::BACKGROUND_LIGHT),
+                env.get(theme::BACKGROUND_DARK),
+            ),
+        );
+
+        paint_ctx.fill(circle, &background_gradient);
+
+        let border_color = if base_state.is_hot() {
+            env.get(theme::BORDER_LIGHT)
+        } else {
+            env.get(theme::BORDER)
+        };
+
+        paint_ctx.stroke(circle, &border_color, 1.);
+
+        // If data enum matches our variant
+        if *data == self.variant {
+            let inner_circle = Circle::new((size / 2., size / 2.), 2.);
+
+            paint_ctx.fill(inner_circle, &env.get(theme::LABEL_COLOR));
+        }
+    }
+
+    fn layout(
+        &mut self,
+        _layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _data: &T,
+        env: &Env,
+    ) -> Size {
+        bc.constrain(Size::new(
+            env.get(theme::BASIC_WIDGET_HEIGHT),
+            env.get(theme::BASIC_WIDGET_HEIGHT),
+        ))
+    }
+
+    fn event(
+        &mut self,
+        event: &Event,
+        ctx: &mut EventCtx,
+        data: &mut T,
+        _env: &Env,
+    ) -> Option<Action> {
+        match event {
+            Event::MouseDown(_) => {
+                ctx.set_active(true);
+                ctx.invalidate();
+            }
+            Event::MouseUp(_) => {
+                if ctx.is_active() {
+                    ctx.set_active(false);
+                    if ctx.is_hot() {
+                        *data = self.variant.clone();
+                    }
+                    ctx.invalidate();
+                }
+            }
+            Event::MouseMoved(_) => {
+                ctx.invalidate();
+            }
+            _ => (),
+        }
+        None
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {
+        ctx.invalidate();
+    }
+}

--- a/src/widget/textbox.rs
+++ b/src/widget/textbox.rs
@@ -522,5 +522,4 @@ mod tests {
         // Insert again
         widget.insert(&mut data, "a");
     }
-
 }


### PR DESCRIPTION
This needs some polish but I wanted to share where I'm at to make sure I'm on the right track. @raphlinus has an [alternative implementation using Lens](https://git.sr.ht/~raph/interp-toy/tree/master/src/radio.rs) that might be preferable. (Is implementing something as a function the only way to avoid this PhantomData stuff?)

Also: I don't know why rust fmt decided today was the day to remove a line break from textbox.rs \o/