### PR TITLE
Reorder (env, data) to (data, env) in l10n fns

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -26,7 +26,7 @@ fn main() {
 
 fn ui_builder() -> impl Widget<u32> {
     let text =
-        LocalizedString::new("hello-counter").with_arg("count", |_env, data: &u32| (*data).into());
+        LocalizedString::new("hello-counter").with_arg("count", |data: &u32, _env| (*data).into());
     let label = Label::new(text);
     let button = Button::new("increment");
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -323,7 +323,7 @@ impl<T: Data> LabelText<T> {
     pub fn resolve(&mut self, data: &T, env: &Env) -> bool {
         match self {
             LabelText::Specific(_) => false,
-            LabelText::Localized(s) => s.resolve(env, data),
+            LabelText::Localized(s) => s.resolve(data, env),
         }
     }
 }


### PR DESCRIPTION
This makes us consistent with other functions in druid that
take these two params.