### PR TITLE
Replace mem::uninitialized with mem::MaybeUninit

### DIFF
--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -390,8 +390,11 @@ impl WndProc for MyWndProc {
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let s = s.as_mut().unwrap();
                     if s.dcomp_state.is_some() {
-                        let mut rect = mem::MaybeUninit::<RECT>::zeroed().assume_init();
-                        GetClientRect(hwnd, &mut rect);
+                        let mut rect: RECT = mem::zeroed();
+                        if GetClientRect(hwnd, &mut rect) == 0 {
+                            warn!("GetClientRect failed.");
+                            return None;
+                        }
                         let width = (rect.right - rect.left) as u32;
                         let height = (rect.bottom - rect.top) as u32;
                         let res = (*s.dcomp_state.as_mut().unwrap().swap_chain).ResizeBuffers(
@@ -878,8 +881,13 @@ unsafe fn choose_adapter(factory: *mut IDXGIFactory2) -> *mut IDXGIAdapter {
         if !SUCCEEDED((*factory).EnumAdapters(i, &mut adapter)) {
             break;
         }
-        let mut desc = mem::MaybeUninit::<DXGI_ADAPTER_DESC>::zeroed().assume_init(); // TODO: Confirm that this works correctly
-        (*adapter).GetDesc(&mut desc);
+        let mut desc = mem::MaybeUninit::uninit();
+        let hr = (*adapter).GetDesc(desc.as_mut_ptr());
+        if !SUCCEEDED(hr) {
+            error!("Failed to get adapter description: {:?}", Error::Hr(hr));
+            break;
+        }
+        let mut desc: DXGI_ADAPTER_DESC = desc.assume_init();
         let vram = desc.DedicatedVideoMemory;
         if i == 0 || vram > best_vram {
             best_vram = vram;

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -390,7 +390,7 @@ impl WndProc for MyWndProc {
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let s = s.as_mut().unwrap();
                     if s.dcomp_state.is_some() {
-                        let mut rect: RECT = mem::uninitialized();
+                        let mut rect = mem::MaybeUninit::<RECT>::zeroed().assume_init();
                         GetClientRect(hwnd, &mut rect);
                         let width = (rect.right - rect.left) as u32;
                         let height = (rect.bottom - rect.top) as u32;
@@ -878,7 +878,7 @@ unsafe fn choose_adapter(factory: *mut IDXGIFactory2) -> *mut IDXGIAdapter {
         if !SUCCEEDED((*factory).EnumAdapters(i, &mut adapter)) {
             break;
         }
-        let mut desc: DXGI_ADAPTER_DESC = mem::uninitialized();
+        let mut desc = mem::MaybeUninit::<DXGI_ADAPTER_DESC>::zeroed().assume_init(); // TODO: Confirm that this works correctly
         (*adapter).GetDesc(&mut desc);
         let vram = desc.DedicatedVideoMemory;
         if i == 0 || vram > best_vram {

--- a/druid-shell/src/windows/paint.rs
+++ b/druid-shell/src/windows/paint.rs
@@ -22,7 +22,7 @@
 use std::mem;
 use std::ptr::null_mut;
 
-use log::error;
+use log::{error, warn};
 
 use winapi::ctypes::c_void;
 use winapi::shared::dxgi::*;
@@ -52,20 +52,24 @@ pub(crate) unsafe fn create_render_target(
     d2d_factory: &direct2d::Factory,
     hwnd: HWND,
 ) -> Result<HwndRenderTarget, Error> {
-    let mut rect = mem::MaybeUninit::<RECT>::zeroed().assume_init();
-    GetClientRect(hwnd, &mut rect);
-    let width = (rect.right - rect.left) as u32;
-    let height = (rect.bottom - rect.top) as u32;
-    let res = HwndRenderTarget::create(d2d_factory)
-        .with_hwnd(hwnd)
-        .with_target_type(RenderTargetType::Default)
-        .with_alpha_mode(AlphaMode::Unknown)
-        .with_pixel_size(width, height)
-        .build();
-    if let Err(ref e) = res {
-        error!("Creating hwnd render target failed: {:?}", e);
+    let mut rect: RECT = mem::zeroed();
+    if GetClientRect(hwnd, &mut rect) == 0 {
+        warn!("GetClientRect failed.");
+        Err(Error::D2Error)
+    } else {
+        let width = (rect.right - rect.left) as u32;
+        let height = (rect.bottom - rect.top) as u32;
+        let res = HwndRenderTarget::create(d2d_factory)
+            .with_hwnd(hwnd)
+            .with_target_type(RenderTargetType::Default)
+            .with_alpha_mode(AlphaMode::Unknown)
+            .with_pixel_size(width, height)
+            .build();
+        if let Err(ref e) = res {
+            error!("Creating hwnd render target failed: {:?}", e);
+        }
+        res.map_err(|_| Error::D2Error)
     }
-    res.map_err(|_| Error::D2Error)
 }
 
 /// Create a render target from a DXGI swapchain.

--- a/druid-shell/src/windows/paint.rs
+++ b/druid-shell/src/windows/paint.rs
@@ -52,7 +52,7 @@ pub(crate) unsafe fn create_render_target(
     d2d_factory: &direct2d::Factory,
     hwnd: HWND,
 ) -> Result<HwndRenderTarget, Error> {
-    let mut rect: RECT = mem::uninitialized();
+    let mut rect = mem::MaybeUninit::<RECT>::zeroed().assume_init();
     GetClientRect(hwnd, &mut rect);
     let width = (rect.right - rect.left) as u32;
     let height = (rect.bottom - rect.top) as u32;

--- a/druid-shell/src/windows/win_main.rs
+++ b/druid-shell/src/windows/win_main.rs
@@ -84,7 +84,7 @@ impl RunLoop {
 
                 // Handle windows messages
                 loop {
-                    let mut msg = mem::uninitialized();
+                    let mut msg = mem::MaybeUninit::<MSG>::zeroed().assume_init();
                     // Note: we could use PM_REMOVE here and avoid the GetMessage below
                     let res = PeekMessageW(&mut msg, null_mut(), 0, 0, PM_NOREMOVE);
                     if res == 0 {

--- a/druid-shell/src/windows/win_main.rs
+++ b/druid-shell/src/windows/win_main.rs
@@ -84,16 +84,17 @@ impl RunLoop {
 
                 // Handle windows messages
                 loop {
-                    let mut msg = mem::MaybeUninit::<MSG>::zeroed().assume_init();
+                    let mut msg = mem::MaybeUninit::uninit();
                     // Note: we could use PM_REMOVE here and avoid the GetMessage below
-                    let res = PeekMessageW(&mut msg, null_mut(), 0, 0, PM_NOREMOVE);
+                    let res = PeekMessageW(msg.as_mut_ptr(), null_mut(), 0, 0, PM_NOREMOVE);
                     if res == 0 {
                         break;
                     }
-                    let res = GetMessageW(&mut msg, null_mut(), 0, 0);
+                    let res = GetMessageW(msg.as_mut_ptr(), null_mut(), 0, 0);
                     if res <= 0 {
                         return;
                     }
+                    let mut msg: MSG = msg.assume_init();
                     if self.accel.is_null()
                         || TranslateAcceleratorW(msg.hwnd, self.accel, &mut msg) == 0
                     {


### PR DESCRIPTION
closes #164 

I ran some examples, and everything _seemed_ to work just the same. Using `::zeroed`, I believe the structs in these cases can handle zero values for all of their fields. I am not familiar with the external functions, however, and don't know if we want to `assume_init` after calling them.