### PR TITLE
Better organization for system menus

### DIFF
--- a/examples/multiwin.rs
+++ b/examples/multiwin.rs
@@ -134,8 +134,13 @@ impl<T: Data> Widget<T> for EventInterceptor<T> {
     }
 }
 
+#[allow(unused_assignments)]
 fn make_menu<T: Data>(state: &State) -> MenuDesc<T> {
-    let mut base = druid::menu::macos_menu_bar();
+    let mut base = MenuDesc::empty();
+    #[cfg(target_os = "macos")]
+    {
+        base = druid::menu::sys::mac::menu_bar();
+    }
     if state.menu_count != 0 {
         base = base.append(
             MenuDesc::new(LocalizedString::new("Custom")).append_iter(|| {

--- a/resources/i18n/en-US/builtin.ftl
+++ b/resources/i18n/en-US/builtin.ftl
@@ -3,7 +3,6 @@
 hello-counter = Current value is { $count }
 
 # The 'application' menu on macOS
-
 macos-menu-about-app = About { -app-name }
 macos-menu-preferences = Preferences...
 macos-menu-hide-app = Hide { -app-name }
@@ -13,12 +12,28 @@ macos-menu-services = Services
 macos-menu-application-menu = { -app-name }
 macos-menu-quit-app = Quit { -app-name }
 
-# macOS 'File' menu
-macos-menu-file-menu = File
-macos-menu-file-new = New File
-macos-menu-file-open = Open...
-macos-menu-file-close = Close
-macos-menu-file-save = Save...
-macos-menu-file-save-as = Save As...
-macos-menu-file-page-setup = Page Setup...
-macos-menu-file-print = Print...
+# common 'File' menu items
+common-menu-file-menu = File
+common-menu-file-new = New
+common-menu-file-new-window = New Window
+
+common-menu-file-open = Open...
+common-menu-file-close = Close
+
+common-menu-file-save = Save
+# used for new files, if we need to show a dialog
+common-menu-file-save-ellipsis = Save...
+common-menu-file-save-as = Save As...
+
+common-menu-file-page-setup = Page Setup...
+common-menu-file-print = Print...
+
+# windows 'File' menu items
+win-menu-file-exit = Exit
+
+# common 'Edit' menu items.
+common-menu-cut = Cut
+common-menu-copy = Copy
+common-menu-paste = Paste
+common-menu-undo = Undo
+common-menu-redo = Redo

--- a/resources/i18n/fr-CA/builtin.ftl
+++ b/resources/i18n/fr-CA/builtin.ftl
@@ -2,6 +2,7 @@
 
 hello-counter = La valeur actuelle est { $count }
 
+# The 'application' menu on macOS
 macos-menu-about-app = Àpropos du { -app-name }
 macos-menu-preferences = Préférences...
 macos-menu-hide-app = Masquer { -app-name }
@@ -11,12 +12,28 @@ macos-menu-services = Services
 macos-menu-application-menu = { -app-name }
 macos-menu-quit-app = Quitter { -app-name }
 
-# macOS 'file' menu
-macos-menu-file-menu = Ficher
-macos-menu-file-new = Nouveau
-macos-menu-file-open = Ouvrir...
-macos-menu-file-close = Fermer
-macos-menu-file-save = Enregistrer...
-macos-menu-file-save-as = Enregistrer sous...
-macos-menu-file-page-setup = Format d'impression...
-macos-menu-file-print = Imprimer...
+# common 'file' menu items
+common-menu-file-menu = Ficher
+common-menu-file-new = Nouveau
+common-menu-file-new-window = Nouvelle fenêtre
+
+common-menu-file-open = Ouvrir...
+common-menu-file-close = Fermer
+
+common-menu-file-save = Enregistrer
+# used for new files, if we need to show a dialog
+common-menu-file-save-ellipsis = Enregistrer...
+common-menu-file-save-as = Enregistrer sous...
+
+common-menu-file-page-setup = Format d'impression...
+common-menu-file-print = Imprimer...
+
+# windows 'File' menu items
+win-menu-file-exit = Quitter
+
+# common 'Edit' menu items.
+common-menu-cut = Couper
+common-menu-copy = Copier
+common-menu-paste = Coller
+common-menu-undo = Annuler
+common-menu-redo = Rétablir

--- a/src/command.rs
+++ b/src/command.rs
@@ -94,6 +94,25 @@ pub mod sys {
 
     /// Show the print dialog.
     pub const PRINT: Selector = Selector::new("druid-builtin.menu-file-print");
+
+    /// Show the print preview.
+    pub const PRINT_PREVIEW: Selector = Selector::new("druid-builtin.menu-file-print");
+
+    /// Cut the current selection.
+    pub const CUT: Selector = Selector::new("druid-builtin.menu-cut");
+
+    /// Copy the current selection.
+    pub const COPY: Selector = Selector::new("druid-builtin.menu-copy");
+
+    /// Paste.
+    pub const PASTE: Selector = Selector::new("druid-builtin.menu-paste");
+
+    /// Undo.
+    pub const UNDO: Selector = Selector::new("druid-builtin.menu-undo");
+
+    /// Redo.
+    pub const REDO: Selector = Selector::new("druid-builtin.menu-redo");
+
 }
 
 impl Selector {


### PR DESCRIPTION
This provides a menu::sys module, which contains a bunch of
other modules which contain various functions for generating
standard menu items.

This is largely an experiment around how we should surface these sorts of things. I'm not sure what the best approach is, but this is an improvement over what we had before, so I think it's worth trying.