### PR TITLE
Move Building Section from CONTRIBUTING.md to README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,25 +3,6 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-## Build
-Currently, druid only builds on Windows and macOS. 
-
-Other options may work, but not tested.
-
-#### Windows
-
-run `cargo build`
-
-#### macOS
-
-On macOS, druid requires cairo; see [gtk-rs dependencies] for installation instructions.
-
-You may also need to set your `PKG_CONFIG_PATH`; assuming you have installed `cairo` through homebrew, you can build with,
-
- ```shell
-$> PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig" cargo build
- ```
-
 ## Code reviews
 
 All submissions, including submissions by project members, require review. We

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ The biggest single obstacle to porting is 2d graphics, as druid currently
 uses Direct2D (and DirectWrite for text). One way forward is to create a
 [2d graphics] abstraction.
 
+## Build
+Currently, druid only builds on Windows and macOS. 
+
+Other options may work, but not tested.
+
+#### Windows
+
+run `cargo build`
+
+#### macOS
+
+On macOS, druid requires cairo; see [gtk-rs dependencies] for installation instructions.
+
+You may also need to set your `PKG_CONFIG_PATH`; assuming you have installed `cairo` through homebrew, you can build with,
+
+ ```shell
+$> PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig" cargo build
+ ```
+
 ## Alternatives
 
 In addition to wrappers for mature UI toolkits (mostly C++), [conrod]


### PR DESCRIPTION
This should lower the entry barrier for beginners,
as they will most likely first see the README and this way they can jump right into Developing with druid, only having read the README