### PR TITLE
Implement context menus

### DIFF
--- a/druid-shell/src/mac/menu.rs
+++ b/druid-shell/src/mac/menu.rs
@@ -83,6 +83,11 @@ impl Menu {
         }
     }
 
+    pub fn new_for_popup() -> Menu {
+        // mac doesn't distinguish between application and context menu types.
+        Menu::new()
+    }
+
     pub fn add_dropdown(&mut self, menu: Menu, text: &str, enabled: bool) {
         unsafe {
             let menu_item = NSMenuItem::alloc(nil);

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -275,6 +275,10 @@ lazy_static! {
             sel!(handleMenuItem:),
             handle_menu_item as extern "C" fn(&mut Object, Sel, id),
         );
+        decl.add_method(
+            sel!(dispatchMenuItem:),
+            dispatch_menu_item as extern "C" fn(&mut Object, Sel, id),
+        );
         ViewClass(decl.register())
     };
 }
@@ -562,6 +566,16 @@ extern "C" fn handle_timer(this: &mut Object, _: Sel, timer: id) {
 
 extern "C" fn handle_menu_item(this: &mut Object, _: Sel, item: id) {
     unsafe {
+        // in the case of right-click menus, to avoid reentring rust while
+        // holding a RefMut, we need to delay calling back until the next pass
+        // of the runloop.
+        let () = msg_send![this as *const _, performSelectorOnMainThread: sel!(dispatchMenuItem:)
+            withObject: item waitUntilDone: NO];
+    }
+}
+
+extern "C" fn dispatch_menu_item(this: &mut Object, _: Sel, item: id) {
+    unsafe {
         let tag: isize = msg_send![item, tag];
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
@@ -643,6 +657,15 @@ impl WindowHandle {
     pub fn set_menu(&self, menu: Menu) {
         unsafe {
             NSApp().setMainMenu_(menu.menu);
+        }
+    }
+
+    pub fn show_context_menu(&self, menu: Menu, x: f64, y: f64) {
+        if let Some(ref nsview) = self.nsview {
+            unsafe {
+                let location = NSPoint::new(x, y);
+                msg_send![menu.menu, popUpMenuPositioningItem: nil atLocation: location inView: *nsview.load()];
+            }
         }
     }
 

--- a/druid-shell/src/windows/menu.rs
+++ b/druid-shell/src/windows/menu.rs
@@ -39,9 +39,18 @@ impl Drop for Menu {
 }
 
 impl Menu {
+    /// Create a new menu for a window.
     pub fn new() -> Menu {
         unsafe {
             let hmenu = CreateMenu();
+            Menu { hmenu }
+        }
+    }
+
+    /// Create a new popup (context / right-click) menu.
+    pub fn new_for_popup() -> Menu {
+        unsafe {
+            let hmenu = CreatePopupMenu();
             Menu { hmenu }
         }
     }

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -1117,6 +1117,22 @@ impl WindowHandle {
         }
     }
 
+    pub fn show_context_menu(&self, menu: Menu, x: f64, y: f64) {
+        let hmenu = menu.into_hmenu();
+        if let Some(w) = self.state.upgrade() {
+            let hwnd = w.hwnd.get();
+            let (x, y) = self.px_to_pixels_xy(x as f32, y as f32);
+            unsafe {
+                let mut point = POINT { x, y };
+                ClientToScreen(hwnd, &mut point);
+                if TrackPopupMenu(hmenu, TPM_LEFTALIGN, point.x, point.y, 0, hwnd, null()) == FALSE
+                {
+                    warn!("failed to track popup menu");
+                }
+            }
+        }
+    }
+
     /// Get the raw HWND handle, for uses that are not wrapped in
     /// druid_win_shell.
     pub fn get_hwnd(&self) -> Option<HWND> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -123,7 +123,7 @@ impl<T: Data + 'static> WindowDesc<T> {
         let mut menu = self.menu.to_owned();
         let platform_menu = menu
             .as_mut()
-            .map(|m| m.build_native(&state.borrow().data, &state.borrow().env));
+            .map(|m| m.build_window_menu(&state.borrow().data, &state.borrow().env));
 
         let id = WindowId::new();
         let handler = DruidHandler::new_shared(state.clone(), id);

--- a/src/command.rs
+++ b/src/command.rs
@@ -62,10 +62,14 @@ pub mod sys {
     /// should be the id of the window to close.
     pub const CLOSE_WINDOW: Selector = Selector::new("druid-builtin.close-window");
 
+    /// Display a context (right-click) menu. The argument should be a...
+    //TODO
+    pub const SHOW_CONTEXT_MENU: Selector = Selector::new("druid-builtin.show-context-menu");
+
     /// The selector for a command to set the window's menu. The argument should
-    /// be a [`Menu`] object.
+    /// be a [`MenuDesc`] object.
     ///
-    /// [`Menu`]: struct.Menu.html
+    /// [`MenuDesc`]: ../struct.MenuDesc.html
     pub const SET_MENU: Selector = Selector::new("druid-builtin.set-menu");
 
     /// Show the application preferences.

--- a/src/window.rs
+++ b/src/window.rs
@@ -36,6 +36,7 @@ pub struct Window<T: Data> {
     pub(crate) title: LocalizedString<T>,
     size: Size,
     pub(crate) menu: Option<MenuDesc<T>>,
+    pub(crate) context_menu: Option<MenuDesc<T>>,
     // delegate?
 }
 
@@ -50,6 +51,7 @@ impl<T: Data> Window<T> {
             size: Size::ZERO,
             title,
             menu,
+            context_menu: None,
         }
     }
 
@@ -87,7 +89,10 @@ impl<T: Data> Window<T> {
     }
 
     pub(crate) fn get_menu_cmd(&self, cmd_id: u32) -> Option<Command> {
-        self.menu.as_ref().and_then(|m| m.command_for_id(cmd_id))
+        self.context_menu
+            .as_ref()
+            .and_then(|m| m.command_for_id(cmd_id))
+            .or(self.menu.as_ref().and_then(|m| m.command_for_id(cmd_id)))
     }
 }
 


### PR DESCRIPTION
These use all the same infrastructure as app/window menus. Tested
on mac and windows.

closes #101

screenshots:

![mac-context-menu](https://user-images.githubusercontent.com/3330916/65273597-7c5cb480-daef-11e9-9573-94e0b5e77769.png)
![win-context-menu](https://user-images.githubusercontent.com/3330916/65273601-7e267800-daef-11e9-9702-8f400dda9b62.png)

the menu items even do stuff if you click on them!