### PR TITLE
Move default menu handling into druid

### DIFF
--- a/druid-shell/src/mac/menu.rs
+++ b/druid-shell/src/mac/menu.rs
@@ -19,7 +19,7 @@ use cocoa::appkit::{NSEventModifierFlags, NSMenu, NSMenuItem};
 use cocoa::base::{id, nil, NO};
 use cocoa::foundation::NSAutoreleasePool;
 
-use crate::hotkey::{HotKey, KeyCompare, SysMods};
+use crate::hotkey::{HotKey, KeyCompare};
 use crate::keyboard::{KeyCode, KeyModifiers};
 
 pub struct Menu {
@@ -120,24 +120,6 @@ impl Menu {
             let sep = id::separatorItem(self.menu);
             self.menu.addItem_(sep);
         }
-    }
-}
-
-impl Default for Menu {
-    fn default() -> Menu {
-        // The top level menu is just to contain the menus
-        let mut menu = Menu::new();
-        // this one is our actual menu
-        let mut submenu = Menu::new();
-        submenu.add_item(
-            1,
-            "Quit",
-            Some(&HotKey::new(SysMods::Cmd, "q")),
-            true,
-            false,
-        );
-        menu.add_dropdown(submenu, "Application", true);
-        menu
     }
 }
 

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -111,7 +111,7 @@ impl WindowBuilder {
             handler: None,
             title: String::new(),
             enable_mouse_move_events: true,
-            menu: Some(Menu::default()),
+            menu: None,
         }
     }
 
@@ -125,8 +125,8 @@ impl WindowBuilder {
 
     pub fn set_menu(&mut self, menu: Menu) {
         self.menu = Some(menu);
-        // TODO
     }
+
     pub fn set_enable_mouse_move_events(&mut self, to: bool) {
         self.enable_mouse_move_events = to;
     }
@@ -587,7 +587,6 @@ extern "C" fn dispatch_menu_item(this: &mut Object, _: Sel, item: id) {
 }
 
 extern "C" fn window_did_become_key(this: &mut Object, _: Sel, _notification: id) {
-    eprintln!("window did become key{:?}", _notification);
     unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);

--- a/src/app.rs
+++ b/src/app.rs
@@ -97,7 +97,7 @@ impl<T: Data + 'static> WindowDesc<T> {
         WindowDesc {
             root_builder,
             title: None,
-            menu: None,
+            menu: MenuDesc::platform_default(),
         }
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -246,6 +246,20 @@ impl<T: Data> MenuDesc<T> {
         }
     }
 
+    /// If this platform always expects windows to have a menu by default,
+    /// returns a menu. Otherwise returns `None`.
+    #[allow(unreachable_code)]
+    pub fn platform_default() -> Option<MenuDesc<T>> {
+        #[cfg(target_os = "macos")]
+        return Some(MenuDesc::empty().append(sys::mac::application::default()));
+        #[cfg(target_os = "windows")]
+        return None;
+
+        // we want to explicitly handle all platforms; log if a platform is missing.
+        log::warn!("MenuDesc::platform_default is not implemented for this platform.");
+        None
+    }
+
     /// Given a function that produces an iterator, appends that iterator's
     /// items to this menu.
     ///


### PR DESCRIPTION
For druid to be able to handle commands originating from menus, it
has to be soley responsible for assigning ids to those commands.

This moves all responsibility for creating default menus into druid.

on macOS, apps will now have this menu by default:

<img width="647" alt="macos-default-menu" src="https://user-images.githubusercontent.com/3330916/65333422-78cc3a80-db8e-11e9-9a5a-0427f5e7e0aa.png">
