### PR TITLE
basic copy & paste

### DIFF
--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -1,0 +1,40 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interacting with the system pasteboard/clipboard.
+
+/// An item on the system clipboard.
+#[derive(Debug, Clone)]
+pub enum ClipboardItem {
+    Text(String),
+    #[doc(hidden)]
+    __NotExhaustive,
+    // other things
+}
+
+impl ClipboardItem {
+    /// Create a new `ClipboardItem`.
+    pub fn new(item: impl Into<ClipboardItem>) -> Self {
+        item.into()
+    }
+}
+
+impl<T: Into<String>> From<T> for ClipboardItem {
+    fn from(src: T) -> ClipboardItem {
+        ClipboardItem::Text(src.into())
+    }
+}
+
+//TODO: custom formats.
+// https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#registered-clipboard-formats

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -28,6 +28,7 @@ extern crate objc;
 #[macro_use]
 extern crate lazy_static;
 
+pub mod clipboard;
 pub mod error;
 pub mod hotkey;
 pub mod keyboard;

--- a/druid-shell/src/mac/application.rs
+++ b/druid-shell/src/mac/application.rs
@@ -52,7 +52,7 @@ impl Application {
             let data_types: id = msg_send![pasteboard, types];
             let count: usize = msg_send![data_types, count];
 
-            for i in 0..=count {
+            for i in 0..count {
                 let dtype: id = msg_send![data_types, objectAtIndex: i];
                 let is_string: BOOL = msg_send![dtype, isEqualToString: NSPasteboardTypeString];
                 if is_string == YES {
@@ -68,7 +68,7 @@ impl Application {
         }
     }
 
-    /// Sets th contents of the system clipboard.
+    /// Sets the contents of the system clipboard.
     pub fn set_clipboard_contents(item: ClipboardItem) {
         unsafe {
             let nspasteboard = class!(NSPasteboard);

--- a/druid-shell/src/mac/application.rs
+++ b/druid-shell/src/mac/application.rs
@@ -67,4 +67,20 @@ impl Application {
             None
         }
     }
+
+    /// Sets th contents of the system clipboard.
+    pub fn set_clipboard_contents(item: ClipboardItem) {
+        unsafe {
+            let nspasteboard = class!(NSPasteboard);
+            let pasteboard: id = msg_send![nspasteboard, generalPasteboard];
+            match item {
+                ClipboardItem::Text(string) => {
+                    let nsstring = util::make_nsstring(&string);
+                    msg_send![pasteboard, clearContents];
+                    msg_send![pasteboard, setString: nsstring forType: NSPasteboardTypeString];
+                }
+                other => log::warn!("unhandled clipboard data {:?}", other),
+            }
+        }
+    }
 }

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -46,7 +46,9 @@ use cairo::{Context, QuartzSurface};
 use crate::kurbo::{Point, Vec2};
 use piet_common::{Piet, RenderContext};
 
+use crate::clipboard::ClipboardItem;
 use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
+use crate::platform::application::Application;
 use crate::platform::dialog::{FileDialogOptions, FileDialogType};
 use crate::util::make_nsstring;
 use crate::window::{Cursor, MouseButton, MouseEvent, Text, TimerToken, WinCtx, WinHandler};
@@ -784,6 +786,10 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
             msg_send![nstimer, scheduledTimerWithTimeInterval: ti target: view selector: selector userInfo: user_info repeats: NO];
         }
         TimerToken::new(token)
+    }
+
+    fn set_clipboard_contents(&mut self, contents: ClipboardItem) {
+        Application::set_clipboard_contents(contents);
     }
 }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -17,6 +17,8 @@
 use std::any::Any;
 use std::ops::Deref;
 
+use crate::clipboard::ClipboardItem;
+//TODO: why is this pub?
 pub use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::kurbo::{Point, Vec2};
 use crate::platform;
@@ -83,6 +85,8 @@ pub trait WinCtx<'a> {
     ///
     /// [`WinHandler::timer()`]: trait.WinHandler.html#tymethod.timer
     fn request_timer(&mut self, deadline: std::time::Instant) -> TimerToken;
+
+    fn set_clipboard_contents(&mut self, contents: ClipboardItem);
 }
 
 /// App behavior, supplied by the app.

--- a/druid-shell/src/windows/application.rs
+++ b/druid-shell/src/windows/application.rs
@@ -20,7 +20,7 @@ use winapi::shared::minwindef::FALSE;
 use winapi::shared::minwindef::UINT;
 use winapi::shared::ntdef::{LPWSTR, WCHAR};
 use winapi::shared::winerror::ERROR_SUCCESS;
-use winapi::um::errhandlingapi::*;
+use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::winbase::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
 use winapi::um::winuser::*;
 

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -57,16 +57,18 @@ use direct2d::render_target::{GenericRenderTarget, HwndRenderTarget, RenderTarge
 
 use piet_common::{Piet, RenderContext};
 
+use crate::application::Application;
+use crate::clipboard::ClipboardItem;
+use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 use crate::kurbo::{Point, Vec2};
 use crate::menu::Menu;
 use crate::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
+use crate::window::{self, Cursor, MouseButton, MouseEvent, Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
+
 use dcomp::{D3D11Device, DCompositionDevice, DCompositionTarget, DCompositionVisual};
 use dialog::{get_file_dialog_path, FileDialogOptions, FileDialogType};
 use timers::TimerSlots;
-
-use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
-use crate::window::{self, Cursor, MouseButton, MouseEvent, Text, TimerToken, WinCtx, WinHandler};
 
 extern "system" {
     pub fn DwmFlush();
@@ -1283,6 +1285,11 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
             })
             .unwrap_or(0);
         TimerToken::new(id)
+    }
+
+    fn set_clipboard_contents(&mut self, contents: ClipboardItem) {
+        log::info!("set_clipboard_contents item: {:?}", &contents);
+        Application::set_clipboard_contents(contents);
     }
 }
 

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -1288,7 +1288,6 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
     }
 
     fn set_clipboard_contents(&mut self, contents: ClipboardItem) {
-        log::info!("set_clipboard_contents item: {:?}", &contents);
         Application::set_clipboard_contents(contents);
     }
 }

--- a/examples/textbox.rs
+++ b/examples/textbox.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use druid::widget::{Column, DynLabel, Padding, TextBox};
-use druid::{AppLauncher, Widget, WindowDesc};
+use druid::{AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
 
 fn main() {
-    let window = WindowDesc::new(build_widget);
+    let window = WindowDesc::new(build_widget).menu(make_main_menu());
     AppLauncher::with_window(window)
         .use_simple_logger()
         .launch("typing is fun!".to_string())
@@ -34,4 +34,15 @@ fn build_widget() -> impl Widget<String> {
     col.add_child(Padding::uniform(5.0, textbox_2), 1.0);
     col.add_child(Padding::uniform(5.0, label), 1.0);
     col
+}
+
+fn make_main_menu<T: Data>() -> MenuDesc<T> {
+    let edit_menu = MenuDesc::new(LocalizedString::new("common-menu-edit-menu"))
+        .append(druid::menu::sys::common::cut())
+        .append(druid::menu::sys::common::copy())
+        .append(druid::menu::sys::common::paste());
+
+    MenuDesc::platform_default()
+        .unwrap_or(MenuDesc::empty())
+        .append(edit_menu)
 }

--- a/resources/i18n/en-US/builtin.ftl
+++ b/resources/i18n/en-US/builtin.ftl
@@ -32,6 +32,8 @@ common-menu-file-print = Print...
 win-menu-file-exit = Exit
 
 # common 'Edit' menu items.
+common-menu-edit-menu = Edit
+
 common-menu-cut = Cut
 common-menu-copy = Copy
 common-menu-paste = Paste

--- a/resources/i18n/fr-CA/builtin.ftl
+++ b/resources/i18n/fr-CA/builtin.ftl
@@ -32,6 +32,8 @@ common-menu-file-print = Imprimer...
 win-menu-file-exit = Quitter
 
 # common 'Edit' menu items.
+common-menu-edit-menu = Édition
+
 common-menu-cut = Couper
 common-menu-copy = Copier
 common-menu-paste = Coller

--- a/src/event.rs
+++ b/src/event.rs
@@ -16,6 +16,7 @@
 
 use crate::kurbo::{Rect, Shape, Size, Vec2};
 
+use druid_shell::clipboard::ClipboardItem;
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::window::{MouseEvent, TimerToken};
 
@@ -87,6 +88,8 @@ pub enum Event {
     /// Because of repeat, there may be a number `KeyDown` events before
     /// a corresponding `KeyUp` is sent.
     KeyUp(KeyEvent),
+    /// Called when a paste command is received.
+    Paste(ClipboardItem),
     /// Called when the mouse wheel or trackpad is scrolled.
     Wheel(WheelEvent),
     /// Called when the "hot" status changes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 Event::KeyUp(*e)
             }
             Event::Paste(e) => {
-                log::info!("pasting {:?}", e);
                 recurse = child_ctx.base_state.has_focus;
                 Event::Paste(e.clone())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub use unicode_segmentation;
 // placeholders for functionality not yet implemented.
 #[allow(unused)]
 use druid_shell::application::Application;
+pub use druid_shell::clipboard::ClipboardItem;
 pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 pub use druid_shell::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 #[allow(unused)]
@@ -494,6 +495,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             Event::KeyUp(e) => {
                 recurse = child_ctx.base_state.has_focus;
                 Event::KeyUp(*e)
+            }
+            Event::Paste(e) => {
+                log::info!("pasting {:?}", e);
+                recurse = child_ctx.base_state.has_focus;
+                Event::Paste(e.clone())
             }
             Event::Wheel(wheel_event) => {
                 recurse = had_active || child_ctx.base_state.is_hot;

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -452,6 +452,7 @@ impl<T: Data + 'static> DruidHandler<T> {
             &sys_cmd::QUIT_APP => self.quit(),
             &sys_cmd::HIDE_APPLICATION => self.hide_app(),
             &sys_cmd::HIDE_OTHERS => self.hide_others(),
+            &sys_cmd::PASTE => self.do_paste(window_id, win_ctx),
             sel => {
                 info!("handle_cmd {}", sel);
                 let event = Event::Command(cmd);
@@ -486,6 +487,13 @@ impl<T: Data + 'static> DruidHandler<T> {
         let handle = self.app_state.borrow_mut().remove_window(*id);
         if let Some(handle) = handle {
             handle.close();
+        }
+    }
+
+    fn do_paste(&mut self, window_id: WindowId, ctx: &mut dyn WinCtx) {
+        if let Some(clip_item) = Application::get_clipboard_contents() {
+            let event = Event::Paste(clip_item);
+            self.app_state.borrow_mut().do_event(window_id, event, ctx);
         }
     }
 


### PR DESCRIPTION
(This includes #175).

This adds basic clipboard support (text only) on mac and windows. 

The API is a bit funny; I've added an `Event` for paste, and but setting the clipboard is implemented in `platform::Application`, and then hung off of `WinCtx` because we don't necessarily want to expose `platform::Application`?

There's a reasonable case that we could also have `Event::Cut` and `Event::Copy`.

I worry that our API is getting a bit fragmented; when should things be commands, when should they be events, when should they be on `WinCtx` or `WindowHandle` etc; I don't feel like I have much clarity around this stuff.

closes #98 