### PR TITLE
Update open api

### DIFF
--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -17,7 +17,7 @@ use std::any::Any;
 use druid_shell::kurbo::{Line, Rect, Vec2};
 use druid_shell::piet::{Color, RenderContext};
 
-use druid_shell::dialog::{FileDialogOptions, FileDialogType};
+use druid_shell::dialog::FileDialogOptions;
 use druid_shell::hotkey::{HotKey, SysMods};
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::menu::Menu;
@@ -47,12 +47,12 @@ impl WinHandler for HelloState {
         false
     }
 
-    fn command(&mut self, id: u32, _ctx: &mut dyn WinCtx) {
+    fn command(&mut self, id: u32, ctx: &mut dyn WinCtx) {
         match id {
             0x100 => self.handle.close(),
             0x101 => {
                 let options = FileDialogOptions::new().show_hidden();
-                let filename = self.handle.file_dialog(FileDialogType::Open, options);
+                let filename = ctx.open_file_sync(options);
                 println!("result: {:?}", filename);
             }
             _ => println!("unexpected id {}", id),

--- a/druid-shell/src/mac/dialog.rs
+++ b/druid-shell/src/mac/dialog.rs
@@ -13,3 +13,32 @@
 // limitations under the License.
 
 //! File open/save dialogs, macOS implementation.
+
+#![allow(non_upper_case_globals)]
+
+use std::ffi::OsString;
+
+use cocoa::base::id;
+use cocoa::foundation::NSInteger;
+
+use crate::dialog::FileDialogOptions;
+use crate::util::from_nsstring;
+
+const NSModalResponseOK: NSInteger = 1;
+const NSModalResponseCancel: NSInteger = 0;
+
+pub(crate) unsafe fn show_open_file_dialog_sync(_options: FileDialogOptions) -> Option<OsString> {
+    let nsopenpanel = class!(NSOpenPanel);
+    let panel: id = msg_send![nsopenpanel, openPanel];
+    let result: NSInteger = msg_send![panel, runModal];
+    match result {
+        NSModalResponseOK => {
+            let url: id = msg_send![panel, URL];
+            let path: id = msg_send![url, path];
+            let path: OsString = from_nsstring(path).into();
+            Some(path)
+        }
+        NSModalResponseCancel => None,
+        _ => unreachable!(),
+    }
+}

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -712,6 +712,7 @@ impl WindowHandle {
         ((x.into() as f32) * scale, (y.into() as f32) * scale)
     }
 
+    #[deprecated(since = "0.3", note = "use methods on WinCtx instead")]
     pub fn file_dialog(
         &self,
         ty: FileDialogType,
@@ -795,11 +796,8 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
         TimerToken::new(token)
     }
 
-    fn open_file_sync(&mut self) -> Option<FileInfo> {
-        unsafe {
-            dialog::show_open_file_dialog_sync(Default::default())
-                .map(|s| FileInfo { path: s.into() })
-        }
+    fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
+        unsafe { dialog::show_open_file_dialog_sync(options).map(|s| FileInfo { path: s.into() }) }
     }
 
     fn set_clipboard_contents(&mut self, contents: ClipboardItem) {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 
 use crate::clipboard::ClipboardItem;
 //TODO: why is this pub?
+use crate::dialog::FileDialogOptions;
 pub use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::kurbo::{Point, Vec2};
 use crate::platform;
@@ -90,7 +91,7 @@ pub trait WinCtx<'a> {
     /// Prompt the user to chose a file to open.
     ///
     /// Blocks while the user picks the file.
-    fn open_file_sync(&mut self) -> Option<FileInfo>;
+    fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo>;
 
     fn set_clipboard_contents(&mut self, contents: ClipboardItem);
 }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -16,6 +16,7 @@
 
 use std::any::Any;
 use std::ops::Deref;
+use std::path::PathBuf;
 
 use crate::clipboard::ClipboardItem;
 //TODO: why is this pub?
@@ -243,4 +244,10 @@ pub enum Cursor {
     NotAllowed,
     ResizeLeftRight,
     ResizeUpDown,
+}
+
+/// Information about a file to be opened or saved.
+#[derive(Debug, Clone)]
+pub struct FileInfo {
+    pub path: PathBuf,
 }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -87,6 +87,11 @@ pub trait WinCtx<'a> {
     /// [`WinHandler::timer()`]: trait.WinHandler.html#tymethod.timer
     fn request_timer(&mut self, deadline: std::time::Instant) -> TimerToken;
 
+    /// Prompt the user to chose a file to open.
+    ///
+    /// Blocks while the user picks the file.
+    fn open_file_sync(&mut self) -> Option<FileInfo>;
+
     fn set_clipboard_contents(&mut self, contents: ClipboardItem);
 }
 

--- a/examples/multiwin.rs
+++ b/examples/multiwin.rs
@@ -168,6 +168,10 @@ fn make_menu<T: Data>(state: &State) -> MenuDesc<T> {
     {
         base = druid::menu::sys::mac::menu_bar();
     }
+    #[cfg(target_os = "windows")]
+    {
+        base = base.append(druid::menu::sys::win::file::default());
+    }
     if state.menu_count != 0 {
         base = base.append(
             MenuDesc::new(LocalizedString::new("Custom")).append_iter(|| {

--- a/src/command.rs
+++ b/src/command.rs
@@ -84,7 +84,8 @@ pub mod sys {
     /// Show the new file dialog.
     pub const NEW_FILE: Selector = Selector::new("druid-builtin.menu-file-new");
 
-    /// Show the open dialog.
+    /// System command. A file picker dialog will be shown to the user, and an
+    /// Open Event will be sent if a file is chosen.
     pub const OPEN_FILE: Selector = Selector::new("druid-builtin.menu-file-open");
 
     /// Save the current file.

--- a/src/command.rs
+++ b/src/command.rs
@@ -86,6 +86,8 @@ pub mod sys {
 
     /// System command. A file picker dialog will be shown to the user, and an
     /// Open Event will be sent if a file is chosen.
+    ///
+    /// The argument should be a `FileDialogOptions` struct.
     pub const OPEN_FILE: Selector = Selector::new("druid-builtin.menu-file-open");
 
     /// Save the current file.

--- a/src/event.rs
+++ b/src/event.rs
@@ -18,7 +18,7 @@ use crate::kurbo::{Rect, Shape, Size, Vec2};
 
 use druid_shell::clipboard::ClipboardItem;
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
-use druid_shell::window::{MouseEvent, TimerToken};
+use druid_shell::window::{FileInfo, MouseEvent, TimerToken};
 
 use crate::Command;
 
@@ -47,6 +47,11 @@ use crate::Command;
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Debug, Clone)]
 pub enum Event {
+    /// Called when the system has a file the application should open.
+    ///
+    /// Most commonly this is in response to a request to show the file
+    /// picker.
+    OpenFile(FileInfo),
     /// Called on the root widget when the window size changes.
     ///
     /// Discussion: it's not obvious this should be propagated to user

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,6 +464,10 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut recurse = true;
         let mut hot_changed = None;
         let child_event = match event {
+            Event::OpenFile(file) => {
+                recurse = ctx.is_root;
+                Event::OpenFile(file.clone())
+            }
             Event::Size(size) => {
                 recurse = ctx.is_root;
                 Event::Size(*size)

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -712,7 +712,7 @@ pub mod sys {
             pub fn default<T: Data>() -> MenuDesc<T> {
                 MenuDesc::new(LocalizedString::new("common-menu-file-menu"))
                     .append(new_file())
-                    .append(open_file().disabled())
+                    .append(open_file())
                     // open recent?
                     .append_separator()
                     .append(close())

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -517,7 +517,7 @@ pub mod sys {
             pub fn default<T: Data>() -> MenuDesc<T> {
                 MenuDesc::new(LocalizedString::new("common-menu-file-menu"))
                     .append(new())
-                    .append(open().disabled())
+                    .append(open())
                     .append(close())
                     .append(save().disabled())
                     .append(save_as().disabled())

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -25,6 +25,7 @@ use log::{error, info, warn};
 use crate::kurbo::{Size, Vec2};
 use crate::piet::{Color, Piet, RenderContext};
 use crate::shell::application::Application;
+use crate::shell::dialog::FileDialogOptions;
 use crate::shell::window::{Cursor, WinCtx, WinHandler, WindowHandle};
 
 use crate::menu::ContextMenu;
@@ -447,7 +448,7 @@ impl<T: Data + 'static> DruidHandler<T> {
     fn handle_cmd(&mut self, window_id: WindowId, cmd: Command, win_ctx: &mut dyn WinCtx) {
         //FIXME: we need some way of getting the correct `WinCtx` for this window.
         match &cmd.selector {
-            &sys_cmd::OPEN_FILE => self.open_file(window_id, win_ctx),
+            &sys_cmd::OPEN_FILE => self.open_file(cmd, window_id, win_ctx),
             &sys_cmd::NEW_WINDOW => self.new_window(cmd),
             &sys_cmd::CLOSE_WINDOW => self.close_window(cmd, window_id),
             &sys_cmd::QUIT_APP => self.quit(),
@@ -464,8 +465,12 @@ impl<T: Data + 'static> DruidHandler<T> {
         }
     }
 
-    fn open_file(&mut self, window_id: WindowId, win_ctx: &mut dyn WinCtx) {
-        let result = win_ctx.open_file_sync();
+    fn open_file(&mut self, cmd: Command, window_id: WindowId, win_ctx: &mut dyn WinCtx) {
+        let options = cmd
+            .get_object::<FileDialogOptions>()
+            .map(|opts| opts.to_owned())
+            .unwrap_or_default();
+        let result = win_ctx.open_file_sync(options);
         if let Some(info) = result {
             let event = Event::OpenFile(info);
             self.app_state

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -447,6 +447,7 @@ impl<T: Data + 'static> DruidHandler<T> {
     fn handle_cmd(&mut self, window_id: WindowId, cmd: Command, win_ctx: &mut dyn WinCtx) {
         //FIXME: we need some way of getting the correct `WinCtx` for this window.
         match &cmd.selector {
+            &sys_cmd::OPEN_FILE => self.open_file(window_id, win_ctx),
             &sys_cmd::NEW_WINDOW => self.new_window(cmd),
             &sys_cmd::CLOSE_WINDOW => self.close_window(cmd, window_id),
             &sys_cmd::QUIT_APP => self.quit(),
@@ -460,6 +461,16 @@ impl<T: Data + 'static> DruidHandler<T> {
                     .borrow_mut()
                     .do_event(window_id, event, win_ctx);
             }
+        }
+    }
+
+    fn open_file(&mut self, window_id: WindowId, win_ctx: &mut dyn WinCtx) {
+        let result = win_ctx.open_file_sync();
+        if let Some(info) = result {
+            let event = Event::OpenFile(info);
+            self.app_state
+                .borrow_mut()
+                .do_event(window_id, event, win_ctx);
         }
     }
 


### PR DESCRIPTION
I'd originally wanted to make this API fully async, and I have the mac version of that working, but I got hung up on the windows version. In the process I discovered that there's actually a synchronous API on macOS I hadn't noticed, so this just implements that.

This also moves the API to `WinCtx`. I'm not sure what the correct API is long-term; I mostly just wanted to get _something_ working to open files on macOS, for the sake of Runebender.