### PR TITLE
Make FileDialogType and FileDialogOptions platform indepedent

### DIFF
--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -51,8 +51,7 @@ impl WinHandler for HelloState {
         match id {
             0x100 => self.handle.close(),
             0x101 => {
-                let mut options = FileDialogOptions::default();
-                options.set_show_hidden();
+                let options = FileDialogOptions::new().show_hidden();
                 let filename = self.handle.file_dialog(FileDialogType::Open, options);
                 println!("result: {:?}", filename);
             }

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -1,0 +1,44 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! File open/save dialogs.
+
+/// Type of file dialog.
+pub enum FileDialogType {
+    /// File open dialog.
+    Open,
+    /// File save dialog.
+    Save,
+}
+
+/// Options for file dialogs.
+#[derive(Debug, Clone, Default)]
+pub struct FileDialogOptions {
+    pub show_hidden: bool,
+    // multi selection
+    // select directories
+}
+
+impl FileDialogOptions {
+    /// Create a new set of options.
+    pub fn new() -> FileDialogOptions {
+        FileDialogOptions::default()
+    }
+
+    /// Set the 'show hidden files' bit.
+    pub fn show_hidden(mut self) -> Self {
+        self.show_hidden = true;
+        self
+    }
+}

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -31,6 +31,7 @@ extern crate objc;
 extern crate lazy_static;
 
 pub mod clipboard;
+pub mod dialog;
 pub mod error;
 pub mod hotkey;
 pub mod keyboard;
@@ -52,7 +53,6 @@ pub use mac as platform;
 pub use error::Error;
 
 pub use platform::application;
-pub use platform::dialog;
 pub use platform::menu;
 pub use platform::util;
 pub use platform::win_main as runloop; // TODO: rename to "runloop"

--- a/druid-shell/src/mac/dialog.rs
+++ b/druid-shell/src/mac/dialog.rs
@@ -13,23 +13,3 @@
 // limitations under the License.
 
 //! File open/save dialogs, macOS implementation.
-
-// TODO: maybe these types should be platform-independent?
-
-/// Type of file dialog.
-pub enum FileDialogType {
-    /// File open dialog.
-    Open,
-    /// File save dialog.
-    Save,
-}
-
-/// Options for file dialog.
-#[derive(Default)]
-pub struct FileDialogOptions;
-
-impl FileDialogOptions {
-    pub fn set_show_hidden(&mut self) {
-        // TODO
-    }
-}

--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -47,9 +47,9 @@ use crate::kurbo::{Point, Vec2};
 use piet_common::{Piet, RenderContext};
 
 use crate::clipboard::ClipboardItem;
+use crate::dialog::{FileDialogOptions, FileDialogType};
 use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 use crate::platform::application::Application;
-use crate::platform::dialog::{FileDialogOptions, FileDialogType};
 use crate::util::make_nsstring;
 use crate::window::{Cursor, MouseButton, MouseEvent, Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;

--- a/druid-shell/src/windows/mod.rs
+++ b/druid-shell/src/windows/mod.rs
@@ -59,6 +59,7 @@ use piet_common::{Piet, RenderContext};
 
 use crate::application::Application;
 use crate::clipboard::ClipboardItem;
+use crate::dialog::{FileDialogOptions, FileDialogType};
 use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 use crate::kurbo::{Point, Vec2};
 use crate::menu::Menu;
@@ -67,7 +68,7 @@ use crate::window::{self, Cursor, MouseButton, MouseEvent, Text, TimerToken, Win
 use crate::Error;
 
 use dcomp::{D3D11Device, DCompositionDevice, DCompositionTarget, DCompositionVisual};
-use dialog::{get_file_dialog_path, FileDialogOptions, FileDialogType};
+use dialog::get_file_dialog_path;
 use timers::TimerSlots;
 
 extern "system" {


### PR DESCRIPTION
This will follow an increasingly common pattern where we have a
platform independent description of something that is then
converted to the concrete types for that platform as needed.

This will conflict with #179, and it doesn't really matter which goes in first.