### PR TITLE
Limit file types in dialog

### DIFF
--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -17,6 +17,7 @@ use std::any::Any;
 use druid_shell::kurbo::{Line, Rect, Vec2};
 use druid_shell::piet::{Color, RenderContext};
 
+use druid_shell::application::Application;
 use druid_shell::dialog::{FileDialogOptions, FileSpec};
 use druid_shell::hotkey::{HotKey, SysMods};
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
@@ -49,7 +50,10 @@ impl WinHandler for HelloState {
 
     fn command(&mut self, id: u32, ctx: &mut dyn WinCtx) {
         match id {
-            0x100 => self.handle.close(),
+            0x100 => {
+                self.handle.close();
+                Application::quit();
+            }
             0x101 => {
                 let options = FileDialogOptions::new().show_hidden().allowed_types(vec![
                     FileSpec::new("Rust Files", &["rs", "toml"]),

--- a/druid-shell/examples/hello.rs
+++ b/druid-shell/examples/hello.rs
@@ -17,7 +17,7 @@ use std::any::Any;
 use druid_shell::kurbo::{Line, Rect, Vec2};
 use druid_shell::piet::{Color, RenderContext};
 
-use druid_shell::dialog::FileDialogOptions;
+use druid_shell::dialog::{FileDialogOptions, FileSpec};
 use druid_shell::hotkey::{HotKey, SysMods};
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::menu::Menu;
@@ -51,7 +51,11 @@ impl WinHandler for HelloState {
         match id {
             0x100 => self.handle.close(),
             0x101 => {
-                let options = FileDialogOptions::new().show_hidden();
+                let options = FileDialogOptions::new().show_hidden().allowed_types(vec![
+                    FileSpec::new("Rust Files", &["rs", "toml"]),
+                    FileSpec::TEXT,
+                    FileSpec::JPG,
+                ]);
                 let filename = ctx.open_file_sync(options);
                 println!("result: {:?}", filename);
             }

--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -26,8 +26,34 @@ pub enum FileDialogType {
 #[derive(Debug, Clone, Default)]
 pub struct FileDialogOptions {
     pub show_hidden: bool,
+    pub allowed_types: Option<Vec<FileSpec>>,
     // multi selection
     // select directories
+}
+
+/// A description of a filetype, for specifiying allowed types in a file dialog.
+///
+/// # Windows
+///
+/// On windows, each instance of this type is converted to a [`COMDLG_FILTERSPEC`]
+/// struct.
+///
+/// [`COMDLG_FILTERSPEC`]: https://docs.microsoft.com/en-ca/windows/win32/api/shtypes/ns-shtypes-comdlg_filterspec
+#[derive(Debug, Clone, Copy)]
+pub struct FileSpec {
+    /// A human readable name, describing this filetype.
+    ///
+    /// This is used in the Windows file dialog, where the user can select
+    /// from a dropdown the type of file they would like to choose.
+    ///
+    /// This should not include the file extensions; they will be added automatically.
+    /// For instance, if we are describing Word documents, the name would be "Word Document",
+    /// and the displayed string would be "Word Document (*.doc)".
+    pub name: &'static str,
+    /// The file extensions used by this file type.
+    ///
+    /// This should not include the leading '.'.
+    pub extensions: &'static [&'static str],
 }
 
 impl FileDialogOptions {
@@ -40,5 +66,24 @@ impl FileDialogOptions {
     pub fn show_hidden(mut self) -> Self {
         self.show_hidden = true;
         self
+    }
+
+    /// Set the filetypes the user is allowed to select.
+    pub fn allowed_types(mut self, types: Vec<FileSpec>) -> Self {
+        self.allowed_types = Some(types);
+        self
+    }
+}
+
+impl FileSpec {
+    pub const TEXT: FileSpec = FileSpec::new("Text", &["txt"]);
+    pub const JPG: FileSpec = FileSpec::new("Jpeg", &["jpg", "jpeg"]);
+    pub const GIF: FileSpec = FileSpec::new("Gif", &["gif"]);
+    pub const PDF: FileSpec = FileSpec::new("PDF", &["pdf"]);
+    pub const HTML: FileSpec = FileSpec::new("Web Page", &["htm", "html"]);
+
+    /// Create a new `FileSpec`.
+    pub const fn new(name: &'static str, extensions: &'static [&'static str]) -> Self {
+        FileSpec { name, extensions }
     }
 }

--- a/druid-shell/src/mac/dialog.rs
+++ b/druid-shell/src/mac/dialog.rs
@@ -18,18 +18,40 @@
 
 use std::ffi::OsString;
 
-use cocoa::base::id;
-use cocoa::foundation::NSInteger;
+use cocoa::base::{id, nil, YES};
+use cocoa::foundation::{NSArray, NSInteger};
 
 use crate::dialog::FileDialogOptions;
-use crate::util::from_nsstring;
+use crate::util::{from_nsstring, make_nsstring};
 
 const NSModalResponseOK: NSInteger = 1;
 const NSModalResponseCancel: NSInteger = 0;
 
-pub(crate) unsafe fn show_open_file_dialog_sync(_options: FileDialogOptions) -> Option<OsString> {
+pub(crate) unsafe fn show_open_file_dialog_sync(options: FileDialogOptions) -> Option<OsString> {
     let nsopenpanel = class!(NSOpenPanel);
     let panel: id = msg_send![nsopenpanel, openPanel];
+
+    // set options
+
+    if options.show_hidden {
+        msg_send![panel, setShowsHiddenFiles: YES];
+    }
+
+    // A vector of NSStrings. this must outlive `nsarray_allowed_types`.
+    let allowed_types = options.allowed_types.as_ref().map(|specs| {
+        specs
+            .iter()
+            .flat_map(|spec| spec.extensions.iter().map(|s| make_nsstring(s)))
+            .collect::<Vec<_>>()
+    });
+
+    let nsarray_allowed_types = allowed_types
+        .as_ref()
+        .map(|types| NSArray::arrayWithObjects(nil, types.as_slice()));
+    if let Some(nsarray) = nsarray_allowed_types {
+        msg_send![panel, setAllowedFileTypes: nsarray];
+    }
+
     let result: NSInteger = msg_send![panel, runModal];
     match result {
         NSModalResponseOK => {

--- a/druid-shell/src/windows/dialog.rs
+++ b/druid-shell/src/windows/dialog.rs
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 //! File open/save dialogs, Windows implementation.
+//!
+//! For more information about how windows handles file dialogs, see
+//! documentation for [_FILEOPENDIALOGOPTIONS] and [SetFileTypes].
+//!
+//! [_FILEOPENDIALOGOPTIONS]: https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/ne-shobjidl_core-_fileopendialogoptions
+//! [SetFileTypes]: https://docs.microsoft.com/en-ca/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setfiletypes
 
 #![allow(non_upper_case_globals)]
 
@@ -23,34 +29,45 @@ use winapi::shared::wtypesbase::*;
 use winapi::um::combaseapi::*;
 use winapi::um::shobjidl::*;
 use winapi::um::shobjidl_core::*;
+use winapi::um::shtypes::COMDLG_FILTERSPEC;
 use winapi::Interface;
 use wio::com::ComPtr;
 
-use crate::dialog::{FileDialogOptions, FileDialogType};
-use crate::util::{as_result, FromWide};
+use crate::dialog::{FileDialogOptions, FileDialogType, FileSpec};
+use crate::util::{as_result, FromWide, ToWide};
 use crate::Error;
 use std::ffi::OsString;
 use std::ptr::null_mut;
-
-/// Set the options for this dialog.
-///
-/// See documentation for
-/// [_FILEOPENDIALOGOPTIONS](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/ne-shobjidl_core-_fileopendialogoptions)
-/// for more information on the winapi implementation.
-fn set_options(dialog: &IFileDialog, options: &FileDialogOptions) -> Result<(), Error> {
-    let mut flags: DWORD = 0;
-    if options.show_hidden {
-        flags |= FOS_FORCESHOWHIDDEN;
-    }
-
-    unsafe { as_result(dialog.SetOptions(flags)) }
-}
 
 // TODO: remove these when they get added to winapi
 DEFINE_GUID! {CLSID_FileOpenDialog,
 0xDC1C5A9C, 0xE88A, 0x4DDE, 0xA5, 0xA1, 0x60, 0xF8, 0x2A, 0x20, 0xAE, 0xF7}
 DEFINE_GUID! {CLSID_FileSaveDialog,
 0xC0B4E2F3, 0xBA21, 0x4773, 0x8D, 0xBA, 0x33, 0x5E, 0xC9, 0x46, 0xEB, 0x8B}
+
+/// For each item in `spec`, returns a pair of utf16 strings representing the name
+/// and the filter spec.
+///
+/// As an example: given the name `"Markdown Document"`, and the extensions
+/// `&["md", "mdown", "markdown"]`, this will return
+/// `("Markdown Document (*.md; *.mdown; *.markdown)", "*.md;*.mdown;*.markdown")`.
+///
+/// The first of these is displayed to the user, and the second is used to match the path.
+unsafe fn make_wstrs(spec: &FileSpec) -> (Vec<u16>, Vec<u16>) {
+    let exts = spec
+        .extensions
+        .iter()
+        .map(normalize_extension)
+        .collect::<Vec<_>>();
+    let name = format!("{} ({})", spec.name, exts.as_slice().join("; ")).to_wide();
+    let extensions = exts.as_slice().join(";").to_wide();
+    (name, extensions)
+}
+
+/// add preceding *., trimming preceding *. that might've been included by the user.
+fn normalize_extension(ext: &&str) -> String {
+    format!("*.{}", ext.trim_start_matches('*').trim_start_matches('.'))
+}
 
 pub(crate) unsafe fn get_file_dialog_path(
     hwnd_owner: HWND,
@@ -70,7 +87,44 @@ pub(crate) unsafe fn get_file_dialog_path(
         &mut pfd as *mut *mut IFileDialog as *mut LPVOID,
     ))?;
     let file_dialog = ComPtr::from_raw(pfd);
-    set_options(&file_dialog, &options)?;
+
+    // set options
+    let mut flags: DWORD = 0;
+    if options.show_hidden {
+        flags |= FOS_FORCESHOWHIDDEN;
+    }
+
+    // - allowed filetypes
+
+    // this is a vec of vec<u16>, e.g wide strings. this memory needs to be live
+    // until `Show` returns.
+    let spec = options.allowed_types.as_ref().map(|allowed_types| {
+        allowed_types
+            .iter()
+            .map(|t| make_wstrs(t))
+            .collect::<Vec<_>>()
+    });
+
+    // this is a vector of structs whose members point into the vector above.
+    // this has to outlive that vector.
+    let raw_spec = spec.as_ref().map(|buf_pairs| {
+        buf_pairs
+            .iter()
+            .map(|(name, ext)| COMDLG_FILTERSPEC {
+                pszName: name.as_ptr(),
+                pszSpec: ext.as_ptr(),
+            })
+            .collect::<Vec<_>>()
+    });
+
+    if let Some(spec) = &raw_spec {
+        as_result(file_dialog.SetFileTypes(spec.len() as u32, spec.as_ptr()))?;
+        as_result(file_dialog.SetFileTypeIndex(1))?;
+    }
+
+    as_result(file_dialog.SetOptions(flags))?;
+
+    // show the dialog
     as_result(file_dialog.Show(hwnd_owner))?;
     let mut result_ptr: *mut IShellItem = null_mut();
     as_result(file_dialog.GetResult(&mut result_ptr))?;


### PR DESCRIPTION
~this is based on #180 and #179, which should go in first.~

This lets you filter the allowed filetypes in an open/close dialog.

I don't love the API here, but it will do. This is one of the situations where the behaviour is quite different between platforms, and it's tricky to find a middle ground.