### PR TITLE
Add procedural macro for deriving Data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
 name = "druid"
 version = "0.3.0"
 dependencies = [
+ "druid-derive-data 0.1.0",
  "druid-shell 0.3.0",
  "fluent-bundle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-locale 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -178,6 +179,15 @@ dependencies = [
  "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unic-langid 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "druid-derive-data"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -539,11 +549,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -653,6 +679,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +752,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -894,7 +935,9 @@ dependencies = [
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "982a35d1194084ba319d65c4a68d24ca28f5fdb5b8bc20899e4eef8641ea5178"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afdc77cc74ec70ed262262942ebb7dac3d479e9e5cfa2da1841c0806f6cdabcc"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
@@ -910,6 +953,7 @@ dependencies = [
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ee06ea4b620ab59a2267c6b48be16244a3389f8bfa0986bdd15c35b890b00af3"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unic-langid 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "33288471bc3e172fa79b2961474221b7d093b4f049e0408d65c898a6984a8497"
@@ -918,6 +962,7 @@ dependencies = [
 "checksum unic-langid-macros-impl 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "abb939907a0153c889d20f3ccc8eb38b54e21c018a0194a9a539114c0996322e"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "4de97fa1806bb1a99904216f6ac5e0c050dc4f8c676dc98775047c38e5c01b55"
 "checksum wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "5d82c170ef9f5b2c63ad4460dfcee93f3ec04a9a36a4cc20bc973c39e59ab8e3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ default-features = false
 [dependencies.druid-shell]
 path = "druid-shell"
 version = "0.3.0"
+
+[dependencies.druid-derive-data]
+path = "druid-derive-data"
+version = "0.1.0"

--- a/druid-derive-data/Cargo.toml
+++ b/druid-derive-data/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "druid-derive-data"
+version = "0.1.0"
+authors = ["Druid authors"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0.5"
+quote = "1.0.2"
+proc-macro2 = "1.0.4"
+

--- a/druid-derive-data/src/lib.rs
+++ b/druid-derive-data/src/lib.rs
@@ -1,0 +1,190 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{parse_macro_input, spanned::Spanned, Data, DataEnum, DataStruct, Fields};
+
+#[proc_macro_derive(Data)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    derive_inner(input).unwrap_or_else(|err| err.to_compile_error().into())
+}
+
+fn derive_inner(input: syn::DeriveInput) -> Result<TokenStream, syn::Error> {
+    match &input.data {
+        Data::Struct(s) => derive_struct(&input, s),
+        Data::Enum(e) => derive_enum(&input, e),
+        Data::Union(_u) => unimplemented!(),
+    }
+}
+
+fn number_to_tokenstream(i: usize) -> proc_macro2::TokenStream {
+    let lit = proc_macro2::Literal::usize_unsuffixed(i);
+    let lit: proc_macro2::TokenTree = lit.into();
+    lit.into()
+}
+
+// returns true for named and false for unnamed
+fn extract_fields(fs: &syn::Fields) -> (bool, Vec<proc_macro2::TokenStream>) {
+    match fs {
+        Fields::Named(fs) => {
+            let idents = fs
+                .named
+                .iter()
+                .map(|f| {
+                    let ident = f.ident.as_ref().expect("expected named field");
+                    quote_spanned!(ident.span()=> #ident)
+                })
+                .collect();
+            (true, idents)
+        }
+        Fields::Unnamed(fs) => {
+            let idents = fs
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(i, _)| number_to_tokenstream(i))
+                .collect();
+            (false, idents)
+        }
+        Fields::Unit => (false, Vec::default()),
+    }
+}
+
+fn derive_struct(input: &syn::DeriveInput, s: &DataStruct) -> Result<TokenStream, syn::Error> {
+    let generics_bounds = generics_bounds(&input.generics);
+    let generics = &input.generics;
+
+    let ty = &input.ident;
+    let fields = extract_fields(&s.fields).1;
+
+    let res = quote! {
+        impl<#generics_bounds> druid::Data for #ty #generics {
+            fn same(&self, other: &Self) -> bool {
+                #( self.#fields.same(&other.#fields) )&&*
+            }
+        }
+    };
+
+    Ok(res.into())
+}
+
+fn ident_from_str(s: &str) -> proc_macro2::Ident {
+    proc_macro2::Ident::new(s, proc_macro2::Span::call_site())
+}
+
+fn derive_enum(input: &syn::DeriveInput, s: &DataEnum) -> Result<TokenStream, syn::Error> {
+    let ty = &input.ident;
+
+    let cases: Vec<_> = s
+        .variants
+        .iter()
+        .map(|variant| {
+            let ident = &variant.ident;
+            let (kind, idents) = extract_fields(&variant.fields);
+
+            let tests: Vec<_> = idents
+                .iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    let var_left = ident_from_str(&format!("left{}", i));
+                    let var_right = ident_from_str(&format!("right{}", i));
+                    quote!( #var_left.same(#var_right) )
+                })
+                .collect();
+
+            if kind {
+                // named
+                let lefts: Vec<_> = idents
+                    .iter()
+                    .enumerate()
+                    .map(|(i, ident)| {
+                        let var = ident_from_str(&format!("left{}", i));
+                        quote!( #ident: #var )
+                    })
+                    .collect();
+                let rights: Vec<_> = idents
+                    .iter()
+                    .enumerate()
+                    .map(|(i, ident)| {
+                        let var = ident_from_str(&format!("right{}", i));
+                        quote!( #ident: #var )
+                    })
+                    .collect();
+
+                quote! {
+                    (#ty :: #ident { #( #lefts ),* }, #ty :: #ident { #( #rights ),* }) => {
+                        #( #tests )&&*
+                    }
+                }
+            } else {
+                // unamed
+                let vars_left: Vec<_> = idents
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| ident_from_str(&format!("left{}", i)))
+                    .collect();
+                let vars_right: Vec<_> = idents
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| ident_from_str(&format!("right{}", i)))
+                    .collect();
+
+                if idents.len() > 0 {
+                    quote! {
+                        ( #ty :: #ident( #(#vars_left),* ),  #ty :: #ident( #(#vars_right),* )) => {
+                            #( #tests )&&*
+                        }
+                    }
+                } else {
+                    quote! {
+                       ( #ty :: #ident ,  #ty :: #ident ) => { true }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let generics_bounds = generics_bounds(&input.generics);
+    let generics = &input.generics;
+
+    let res = quote! {
+        impl<#generics_bounds> ::druid::Data for #ty #generics {
+            fn same(&self, other: &Self) -> bool {
+                match (self, other) {
+                    #( #cases ),*
+                    _ => false,
+                }
+            }
+        }
+    };
+
+    Ok(res.into())
+}
+
+fn generics_bounds(generics: &syn::Generics) -> proc_macro2::TokenStream {
+    let res = generics.params.iter().map(|gp| {
+        use syn::GenericParam::*;
+        match gp {
+            Type(ty) => quote_spanned!(ty.span()=> #ty : ::druid::Data),
+            Lifetime(lf) => quote!(#lf),
+            Const(cst) => quote!(#cst),
+        }
+    });
+
+    quote!( #( #res, )* )
+}

--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -18,7 +18,7 @@ use druid::{AppLauncher, Data, LensWrap, Widget, WindowDesc};
 
 use druid::widget::{Button, Column, DynLabel, Padding, Row};
 
-#[derive(Clone)]
+#[derive(Clone, Data)]
 struct CalcState {
     /// The number displayed. Generally a valid float.
     value: String,
@@ -45,16 +45,6 @@ mod lenses {
                 f(&mut data.value)
             }
         }
-    }
-}
-
-// It should be able to get this from a derive macro.
-impl Data for CalcState {
-    fn same(&self, other: &Self) -> bool {
-        self.value.same(&other.value)
-            && self.operand.same(&other.operand)
-            && self.operator.same(&other.operator)
-            && self.in_num.same(&other.in_num)
     }
 }
 

--- a/examples/multiwin.rs
+++ b/examples/multiwin.rs
@@ -26,16 +26,10 @@ const MENU_COUNT_ACTION: Selector = Selector::new("menu-count-action");
 const MENU_INCREMENT_ACTION: Selector = Selector::new("menu-increment-action");
 const MENU_DECREMENT_ACTION: Selector = Selector::new("menu-decrement-action");
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Data)]
 struct State {
     menu_count: usize,
     selected: usize,
-}
-
-impl Data for State {
-    fn same(&self, other: &Self) -> bool {
-        self.menu_count == other.menu_count && self.selected == other.selected
-    }
 }
 
 fn main() {

--- a/examples/radio.rs
+++ b/examples/radio.rs
@@ -15,18 +15,12 @@
 use druid::widget::{Column, Padding, Radio, RadioGroup, SizedBox};
 use druid::{AppLauncher, Data, Widget, WindowDesc};
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Data)]
 enum Choice {
     A,
     B,
     C,
     D,
-}
-
-impl Data for Choice {
-    fn same(&self, other: &Self) -> bool {
-        self == other
-    }
 }
 
 fn build_widget() -> impl Widget<Choice> {

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -17,7 +17,7 @@ use druid::widget::{
 };
 use druid::{AppLauncher, Data, LensWrap, Widget, WindowDesc};
 
-#[derive(Clone)]
+#[derive(Clone, Data)]
 struct DemoState {
     value: f64,
     double: bool,
@@ -49,12 +49,6 @@ mod lenses {
                 f(&mut data.double)
             }
         }
-    }
-}
-
-impl Data for DemoState {
-    fn same(&self, other: &Self) -> bool {
-        self.value.same(&other.value) && self.double.same(&other.double)
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -16,6 +16,8 @@
 
 use std::sync::Arc;
 
+pub use druid_derive_data::Data;
+
 /// A trait used to represent value types.
 ///
 /// These should be cheap to compare and cheap to clone.


### PR DESCRIPTION
This PR adds a simple procedural macro to derive the Data trait.

It simply calls the `same` function recursively on each field. It can handle structs (with anonymous fields), and enums (with inline structs).

One thing it does _not_ do is  detect that an enum is C-like, and optimize the `same` implementation to equality.

The code is a bit rough, especially the error messages, but I wanted some feedback.