### PR TITLE
Make LocalizedString::placeholder() take String instead of &'static str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.18.4"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -193,7 +193,7 @@ name = "druid-shell"
 version = "0.3.0"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -863,7 +863,7 @@ dependencies = [
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
-"checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
+"checksum cocoa 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8cd20045e880893b4a8286d5639e9ade85fb1f6a14c291f882cf8cf2149d37d9"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -67,7 +67,7 @@ pub trait Lens<T, U> {
 ///
 /// Every widget in druid is instantiated with access to data of some
 /// type; the root widget has access to the entire application data.
-/// Often, a part of the widget hiearchy is only concerned with a part
+/// Often, a part of the widget hierarchy is only concerned with a part
 /// of that data. The `LensWrap` widget is a way to "focus" the data
 /// reference down, for the subtree. One advantage is performance;
 /// data changes that don't intersect the scope of the lens aren't

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -90,7 +90,7 @@ struct ArgSource<T>(ArgClosure<T>);
 #[derive(Debug, Clone)]
 pub struct LocalizedString<T> {
     pub(crate) key: &'static str,
-    placeholder: Option<&'static str>,
+    placeholder: Option<String>,
     args: Option<Vec<(&'static str, ArgSource<T>)>>,
     resolved: Option<String>,
     resolved_lang: Option<LanguageIdentifier>,
@@ -304,7 +304,7 @@ impl<T> LocalizedString<T> {
     /// Add a placeholder value. This will be used if localization fails.
     ///
     /// This is intended for use during prototyping.
-    pub const fn with_placeholder(mut self, placeholder: &'static str) -> Self {
+    pub fn with_placeholder(mut self, placeholder: String) -> Self {
         self.placeholder = Some(placeholder);
         self
     }
@@ -315,7 +315,7 @@ impl<T> LocalizedString<T> {
         self.resolved
             .as_ref()
             .map(|s| s.as_str())
-            .or(self.placeholder)
+            .or(self.placeholder.as_ref().map(String::as_ref))
             .unwrap_or(self.key)
     }
 }

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -63,7 +63,7 @@ impl Widget<f64> for SliderRaw {
         let knob_size = env.get(theme::BASIC_WIDGET_HEIGHT);
         let track_thickness = 4.;
 
-        //Store the width so we can calulate slider position from mouse events
+        //Store the width so we can calculate slider position from mouse events
         self.width = rect.width();
 
         //Paint the background

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -47,9 +47,9 @@ const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 /// This is something of an internal detail and possibly we don't want to surface
 /// it publicly.
 pub struct DruidHandler<T: Data> {
-    /// The shared app state
+    /// The shared app state.
     app_state: Rc<RefCell<AppState<T>>>,
-    /// The id for the currenet window.
+    /// The id for the current window.
     window_id: WindowId,
 }
 


### PR DESCRIPTION
Resolves https://github.com/xi-editor/druid/issues/159 and fixes some typos.