### PR TITLE
Implement a simple 'app delegate'

### DIFF
--- a/examples/multiwin.rs
+++ b/examples/multiwin.rs
@@ -14,12 +14,11 @@
 
 //! Opening and closing windows and using window and context menus.
 
-use druid::kurbo::Size;
 use druid::menu::{ContextMenu, MenuDesc, MenuItem};
 use druid::widget::{Align, Button, Column, Label, Padding, Row};
 use druid::{
-    AppLauncher, BaseState, BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx,
-    LocalizedString, PaintCtx, Selector, UpdateCtx, Widget, WindowDesc,
+    AppDelegate, AppLauncher, Command, Data, DelegateCtx, Event, EventCtx, LocalizedString,
+    Selector, Widget, WindowDesc,
 };
 
 const MENU_COUNT_ACTION: Selector = Selector::new("menu-count-action");
@@ -36,6 +35,7 @@ fn main() {
     simple_logger::init().unwrap();
     let main_window = WindowDesc::new(ui_builder).menu(make_menu(&State::default()));
     AppLauncher::with_window(main_window)
+        .delegate(make_delegate())
         .launch(State::default())
         .expect("launch failed");
 }
@@ -46,6 +46,13 @@ trait EventCtxExt {
 }
 
 impl EventCtxExt for EventCtx<'_, '_> {
+    fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>) {
+        let cmd = Command::new(druid::command::sys::SET_MENU, menu);
+        self.submit_command(cmd, None);
+    }
+}
+
+impl EventCtxExt for DelegateCtx<'_, '_> {
     fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>) {
         let cmd = Command::new(druid::command::sys::SET_MENU, menu);
         self.submit_command(cmd, None);
@@ -71,88 +78,44 @@ fn ui_builder() -> impl Widget<State> {
     row.add_child(Padding::uniform(5.0, inc_button), 1.0);
     row.add_child(Padding::uniform(5.0, dec_button), 1.0);
     col.add_child(row, 1.0);
+    col
+}
 
-    EventInterceptor::new(col, |event, ctx, data, _env| match event {
-        Event::Command(ref cmd) if cmd.selector == druid::command::sys::NEW_FILE => {
-            let new_win = WindowDesc::new(ui_builder).menu(make_menu(data));
-            let command = Command::new(druid::command::sys::NEW_WINDOW, new_win);
-            ctx.submit_command(command, None);
-            None
+fn make_delegate() -> AppDelegate<State> {
+    AppDelegate::new().event_handler(|event, data, _env, ctx| {
+        match event {
+            Event::Command(ref cmd) if cmd.selector == druid::command::sys::NEW_FILE => {
+                let new_win = WindowDesc::new(ui_builder).menu(make_menu(data));
+                let command = Command::new(druid::command::sys::NEW_WINDOW, new_win);
+                ctx.submit_command(command, None);
+                None
+            }
+            Event::Command(ref cmd) if cmd.selector == MENU_COUNT_ACTION => {
+                data.selected = *cmd.get_object().unwrap();
+                ctx.set_menu(make_menu::<State>(data));
+                None
+            }
+            // wouldn't it be nice if a menu (like a button) could just mutate state
+            // directly if desired?
+            Event::Command(ref cmd) if cmd.selector == MENU_INCREMENT_ACTION => {
+                data.menu_count += 1;
+                ctx.set_menu(make_menu::<State>(data));
+                None
+            }
+            Event::Command(ref cmd) if cmd.selector == MENU_DECREMENT_ACTION => {
+                data.menu_count = data.menu_count.saturating_sub(1);
+                ctx.set_menu(make_menu::<State>(data));
+                None
+            }
+            Event::MouseDown(ref mouse) if mouse.button.is_right() => {
+                let menu = ContextMenu::new(make_context_menu::<State>(), mouse.pos);
+                let cmd = Command::new(druid::command::sys::SHOW_CONTEXT_MENU, menu);
+                ctx.submit_command(cmd, None);
+                None
+            }
+            other => Some(other),
         }
-        Event::Command(ref cmd) if cmd.selector == MENU_COUNT_ACTION => {
-            data.selected = *cmd.get_object().unwrap();
-            ctx.set_menu(make_menu::<State>(data));
-            None
-        }
-        // wouldn't it be nice if a menu (like a button) could just mutate state
-        // directly if desired?
-        Event::Command(ref cmd) if cmd.selector == MENU_INCREMENT_ACTION => {
-            data.menu_count += 1;
-            ctx.set_menu(make_menu::<State>(data));
-            None
-        }
-        Event::Command(ref cmd) if cmd.selector == MENU_DECREMENT_ACTION => {
-            data.menu_count = data.menu_count.saturating_sub(1);
-            ctx.set_menu(make_menu::<State>(data));
-            None
-        }
-        Event::MouseDown(ref mouse) if mouse.button.is_right() => {
-            let menu = ContextMenu::new(make_context_menu::<State>(), mouse.pos);
-            let cmd = Command::new(druid::command::sys::SHOW_CONTEXT_MENU, menu);
-            ctx.submit_command(cmd, None);
-            None
-        }
-        other => Some(other),
     })
-}
-
-// should something like this be in druid proper? I'm just experimenting here...
-/// A widget that wraps another widget and intercepts the `event` fn.
-///
-/// This is instantiated with a closure that has the same signature as `event`,
-/// and which can either consume events itself or return them to have them
-/// be passed to the inner widget.
-struct EventInterceptor<T> {
-    inner: Box<dyn Widget<T> + 'static>,
-    f: Box<dyn Fn(Event, &mut EventCtx, &mut T, &Env) -> Option<Event>>,
-}
-
-impl<T: Data + 'static> EventInterceptor<T> {
-    fn new<W, F>(inner: W, f: F) -> Self
-    where
-        W: Widget<T> + 'static,
-        F: Fn(Event, &mut EventCtx, &mut T, &Env) -> Option<Event> + 'static,
-    {
-        EventInterceptor {
-            inner: Box::new(inner),
-            f: Box::new(f),
-        }
-    }
-}
-
-impl<T: Data> Widget<T> for EventInterceptor<T> {
-    fn paint(&mut self, ctx: &mut PaintCtx, state: &BaseState, d: &T, env: &Env) {
-        self.inner.paint(ctx, state, d, env)
-    }
-
-    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, d: &T, env: &Env) -> Size {
-        self.inner.layout(ctx, bc, d, env)
-    }
-
-    fn event(&mut self, event: &Event, ctx: &mut EventCtx, data: &mut T, env: &Env) {
-        if !ctx.has_focus() {
-            ctx.request_focus();
-        }
-        let event = event.clone();
-        let EventInterceptor { inner, f } = self;
-        if let Some(event) = (f)(event, ctx, data, env) {
-            inner.event(&event, ctx, data, env);
-        }
-    }
-
-    fn update(&mut self, ctx: &mut UpdateCtx, old: Option<&T>, new: &T, env: &Env) {
-        self.inner.update(ctx, old, new, env)
-    }
 }
 
 #[allow(unused_assignments)]

--- a/src/app_delegate.rs
+++ b/src/app_delegate.rs
@@ -1,0 +1,94 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Customizing application-level behaviour.
+
+use std::collections::VecDeque;
+
+use crate::{Command, Data, Env, Event, WinCtx, WindowId};
+
+/// A context passed in to [`AppDelegate`] functions.
+pub struct DelegateCtx<'a, 'b> {
+    pub(crate) source_id: WindowId,
+    pub(crate) command_queue: &'a mut VecDeque<(WindowId, Command)>,
+    pub(crate) win_ctx: &'a mut dyn WinCtx<'b>,
+}
+
+impl<'a, 'b> DelegateCtx<'a, 'b> {
+    /// Get the [`WinCtx`].
+    ///
+    /// [`WinCtx`] trait.WinCtx.html
+    pub fn win_ctx(&self) -> &dyn WinCtx<'b> {
+        self.win_ctx
+    }
+
+    /// Submit a [`Command`] to be run after this event is handled.
+    ///
+    /// Commands are run in the order they are submitted; all commands
+    /// submitted during the handling of an event are executed before
+    /// the [`update()`] method is called.
+    ///
+    /// [`Command`]: struct.Command.html
+    /// [`update()`]: trait.Widget.html#tymethod.update
+    pub fn submit_command(&mut self, command: Command, window_id: impl Into<Option<WindowId>>) {
+        let window_id = window_id.into().unwrap_or(self.source_id);
+        self.command_queue.push_back((window_id, command))
+    }
+}
+
+/// A type that provides hooks for handling and modifying top-level events.
+///
+/// The `AppDelegate` is a struct that is allowed to handle and modify
+/// events before they are passed down the widget tree.
+///
+/// It is a natural place for things like window and menu management.
+///
+/// You customize the `AppDelegate` by passing closures during creation.
+pub struct AppDelegate<T> {
+    event_fn: Option<Box<dyn Fn(Event, &mut T, &Env, &mut DelegateCtx) -> Option<Event> + 'static>>,
+}
+
+impl<T: Data> AppDelegate<T> {
+    /// Create a new `AppDelegate`.
+    pub fn new() -> Self {
+        AppDelegate { event_fn: None }
+    }
+
+    /// Set the `AppDelegate`'s event handler. This function receives all events,
+    /// before they are passed down the tree.
+    ///
+    /// The return value of this function will be passed down the tree. This can
+    /// be the even that was passed in, a different event, or no event. In all cases,
+    /// the `update` method will be called as usual.
+    pub fn event_handler<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Event, &mut T, &Env, &mut DelegateCtx) -> Option<Event> + 'static,
+    {
+        self.event_fn = Some(Box::new(f));
+        self
+    }
+
+    pub(crate) fn event(
+        &mut self,
+        event: Event,
+        data: &mut T,
+        env: &Env,
+        ctx: &mut DelegateCtx,
+    ) -> Option<Event> {
+        match self.event_fn.as_ref() {
+            Some(f) => (f)(event, data, env, ctx),
+            None => Some(event),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,8 @@
 
 pub use druid_shell::{self as shell, kurbo, piet};
 
-pub mod widget;
-
 mod app;
+mod app_delegate;
 pub mod command;
 mod data;
 mod env;
@@ -29,6 +28,7 @@ mod lens;
 pub mod localization;
 pub mod menu;
 pub mod theme;
+pub mod widget;
 mod win_handler;
 mod window;
 
@@ -58,6 +58,7 @@ use druid_shell::window::{Text, WinCtx, WindowHandle};
 pub use shell::hotkey::{HotKey, RawMods, SysMods};
 
 pub use app::{AppLauncher, WindowDesc};
+pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use command::{Command, Selector};
 pub use data::Data;
 pub use env::{Env, Key, Value};


### PR DESCRIPTION
This is an experiment for one possible way to allow more top-level customization. This is motivated by the fact that there's currently no way to modify menus or create and close windows without implementing a custom widget.

The basic idea is to introduce an `AppDelegate` struct, which if used will be called at various points and allowed to handle events and modify state. Initially there is only one customization point, which is the ability to intercept and modify events before they're passed to the rest of the tree.

I can imagine this expanding over time; in particular I think that the app delegate should probably have access to all window state, and might even be the place to implement things like opening and saving files.

This is just a sketch; I'm going to try and use this in Runebender shortly, but I wanted to open a PR for discussion.