### PR TITLE
Removing one unsafe block and denying unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Simple data-oriented GUI.
 
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(intra_doc_link_resolution_failure, unsafe_code)]
 
 pub use druid_shell::{self as shell, kurbo, piet};
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -398,8 +398,8 @@ impl MenuItemId {
     fn next() -> Self {
         use std::sync::atomic::{AtomicU32, Ordering};
         static MENU_ID: AtomicU32 = AtomicU32::new(1);
-        let raw = unsafe { NonZeroU32::new_unchecked(MENU_ID.fetch_add(2, Ordering::Relaxed)) };
-        MenuItemId(Some(raw))
+        let raw = NonZeroU32::new(MENU_ID.fetch_add(2, Ordering::Relaxed));
+        MenuItemId(raw)
     }
 
     fn as_u32(self) -> u32 {


### PR DESCRIPTION
This PR removes one unsafe block and denies unsafe code, this would make druid 100% safe code.
Denying unsafe code is both cool and describes in one line of code that the project does not contain unsafe code