### PR TITLE
Impl Data for unsized types when behind Rc or Arc

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -100,13 +100,13 @@ impl Data for f64 {
     }
 }
 
-impl<T> Data for Arc<T> {
+impl<T: ?Sized> Data for Arc<T> {
     fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(self, other)
     }
 }
 
-impl<T> Data for Rc<T> {
+impl<T: ?Sized> Data for Rc<T> {
     fn same(&self, other: &Self) -> bool {
         Rc::ptr_eq(self, other)
     }


### PR DESCRIPTION
`Rc<str>` is the idiomatic way to have a cloneable immutable String;
this was not supported by our current blanket impl.

references for the curious:

- https://github.com/rust-lang/rfcs/blob/master/text/1845-shared-from-slice.md#caching-and-string-interning
- https://doc.rust-lang.org/src/alloc/sync.rs.html#1800-1805