### PR TITLE
Allow user to customize the env before app launch

### DIFF
--- a/examples/textbox.rs
+++ b/examples/textbox.rs
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Demos the textbox widget, as well as menu creation and overriding theme settings.
+
+use druid::piet::Color;
 use druid::widget::{Column, DynLabel, Padding, TextBox};
-use druid::{AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
+use druid::{theme, AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
 
 fn main() {
     let window = WindowDesc::new(build_widget).menu(make_main_menu());
     AppLauncher::with_window(window)
+        .configure_env(|env| {
+            env.set(theme::SELECTION_COLOR, Color::rgb8(0xA6, 0xCC, 0xFF));
+            env.set(theme::WINDOW_BACKGROUND_COLOR, Color::WHITE);
+            env.set(theme::LABEL_COLOR, Color::BLACK);
+            env.set(theme::CURSOR_COLOR, Color::BLACK);
+            env.set(theme::BACKGROUND_LIGHT, Color::rgb8(230, 230, 230));
+        })
         .use_simple_logger()
         .launch("typing is fun!".to_string())
         .expect("launch failed");

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,11 +22,15 @@ use crate::shell::window::WindowHandle;
 use crate::shell::{init, runloop, Error as PlatformError, WindowBuilder};
 use crate::win_handler::AppState;
 use crate::window::{Window, WindowId};
-use crate::{theme, Data, DruidHandler, LocalizedString, MenuDesc, Widget};
+use crate::{theme, Data, DruidHandler, Env, LocalizedString, MenuDesc, Widget};
+
+/// A function that modifies the initial environment.
+type EnvSetupFn = dyn FnOnce(&mut Env);
 
 /// Handles initial setup of an application, and starts the runloop.
 pub struct AppLauncher<T> {
     windows: Vec<WindowDesc<T>>,
+    env_setup: Option<Box<EnvSetupFn>>,
 }
 
 /// A function that can create a widget.
@@ -48,7 +52,17 @@ impl<T: Data + 'static> AppLauncher<T> {
     pub fn with_window(window: WindowDesc<T>) -> Self {
         AppLauncher {
             windows: vec![window],
+            env_setup: None,
         }
+    }
+
+    /// Provide an optional closure that will be given mutable access to
+    /// the environment before launch.
+    ///
+    /// This can be used to set or override theme values.
+    pub fn configure_env(mut self, f: impl Fn(&mut Env) + 'static) -> Self {
+        self.env_setup = Some(Box::new(f));
+        self
     }
 
     /// Initialize a minimal logger for printing logs out to stderr.
@@ -63,10 +77,14 @@ impl<T: Data + 'static> AppLauncher<T> {
     ///
     /// Returns an error if a window cannot be instantiated. This is usually
     /// a fatal error.
-    pub fn launch(self, data: T) -> Result<(), PlatformError> {
+    pub fn launch(mut self, data: T) -> Result<(), PlatformError> {
         init();
         let mut main_loop = runloop::RunLoop::new();
-        let env = theme::init();
+        let mut env = theme::init();
+        if let Some(f) = self.env_setup.take() {
+            f(&mut env);
+        }
+
         let state = AppState::new(data, env);
 
         for desc in self.windows {

--- a/src/env.rs
+++ b/src/env.rs
@@ -138,7 +138,7 @@ impl Env {
     ///
     /// Panics if the environment already has a value for the key, but it is
     /// of a different type.
-    pub fn set<'a, V: ValueType<'a>>(mut self, key: Key<V>, value: impl Into<V::Owned>) {
+    pub fn set<'a, V: ValueType<'a>>(&'a mut self, key: Key<V>, value: impl Into<V::Owned>) {
         let env = Arc::make_mut(&mut self.0);
         let value = value.into().into();
         let key = key.into();

--- a/src/win_handler.rs
+++ b/src/win_handler.rs
@@ -23,12 +23,13 @@ use std::time::Instant;
 use log::{error, info, warn};
 
 use crate::kurbo::{Size, Vec2};
-use crate::piet::{Color, Piet, RenderContext};
+use crate::piet::{Piet, RenderContext};
 use crate::shell::application::Application;
 use crate::shell::dialog::FileDialogOptions;
 use crate::shell::window::{Cursor, WinCtx, WinHandler, WindowHandle};
 
 use crate::menu::ContextMenu;
+use crate::theme;
 use crate::window::Window;
 use crate::{
     BaseState, Command, Data, Env, Event, EventCtx, KeyEvent, KeyModifiers, LayoutCtx, MenuDesc,
@@ -36,9 +37,6 @@ use crate::{
 };
 
 use crate::command::sys as sys_cmd;
-
-// TODO: this should come from the theme.
-const BACKGROUND_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 
 /// The struct implements the druid-shell `WinHandler` trait.
 ///
@@ -135,7 +133,7 @@ impl<'a, T: Data + 'static> SingleWindowState<'a, T> {
     fn paint(&mut self, piet: &mut Piet, ctx: &mut dyn WinCtx) -> bool {
         let request_anim = self.do_anim_frame(ctx);
         self.do_layout(piet);
-        piet.clear(BACKGROUND_COLOR);
+        piet.clear(self.env.get(theme::WINDOW_BACKGROUND_COLOR));
         self.do_paint(piet);
         request_anim
     }


### PR DESCRIPTION
There's currently no way to set custom theme keys/values, or to override existing ones.

This also fixes a few small issues related to themes; `Env::set` had the wrong signature, and we weren't using the theme when setting the background color.