### PR TITLE
Tweaks to Scroll widget

### DIFF
--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -73,42 +73,27 @@ impl Default for ScrollBarsState {
 /// when the child's bounds are larger than the viewport.
 ///
 /// The child is laid out with completely unconstrained layout bounds.
-pub struct Scroll<T: Data> {
-    child: WidgetPod<T, Box<dyn Widget<T>>>,
+pub struct Scroll<T: Data, W: Widget<T>> {
+    child: WidgetPod<T, W>,
     child_size: Size,
     scroll_offset: Vec2,
     direction: ScrollDirection,
     scroll_bars: ScrollBarsState,
 }
 
-impl<T: Data> Scroll<T> {
+impl<T: Data, W: Widget<T>> Scroll<T, W> {
     /// Create a new scroll container.
     ///
     /// This method will allow scrolling in all directions if child's bounds
     /// are larger than the viewport. Use [vertical](#method.vertical)
     /// and [horizontal](#method.horizontal) methods to limit scroll behavior.
-    pub fn new(child: impl Widget<T> + 'static) -> Scroll<T> {
+    pub fn new(child: W) -> Scroll<T, W> {
         Scroll {
-            child: WidgetPod::new(child).boxed(),
+            child: WidgetPod::new(child),
             child_size: Default::default(),
             scroll_offset: Vec2::new(0.0, 0.0),
             direction: ScrollDirection::All,
             scroll_bars: ScrollBarsState::default(),
-        }
-    }
-
-    /// Update the scroll.
-    ///
-    /// Returns `true` if the scroll has been updated.
-    fn scroll(&mut self, delta: Vec2, size: Size) -> bool {
-        let mut offset = self.scroll_offset + delta;
-        offset.x = offset.x.min(self.child_size.width - size.width).max(0.0);
-        offset.y = offset.y.min(self.child_size.height - size.height).max(0.0);
-        if (offset - self.scroll_offset).hypot2() > 1e-12 {
-            self.scroll_offset = offset;
-            true
-        } else {
-            false
         }
     }
 
@@ -124,6 +109,34 @@ impl<T: Data> Scroll<T> {
     pub fn horizontal(mut self) -> Self {
         self.direction = ScrollDirection::Horizontal;
         self
+    }
+
+    /// Update the scroll.
+    ///
+    /// Returns `true` if the scroll has been updated.
+    pub fn scroll(&mut self, delta: Vec2, size: Size) -> bool {
+        let mut offset = self.scroll_offset + delta;
+        offset.x = offset.x.min(self.child_size.width - size.width).max(0.0);
+        offset.y = offset.y.min(self.child_size.height - size.height).max(0.0);
+        if (offset - self.scroll_offset).hypot2() > 1e-12 {
+            self.scroll_offset = offset;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Makes the scrollbars visible, and resets the fade timer.
+    pub fn reset_scrollbar_fade(&mut self, ctx: &mut EventCtx) {
+        // Display scroll bars and schedule their disappearance
+        self.scroll_bars.opacity = 0.7;
+        let deadline = Instant::now() + Duration::from_millis(1500);
+        self.scroll_bars.timer_id = ctx.request_timer(deadline);
+    }
+
+    /// Returns the current scroll offset.
+    pub fn offset(&self) -> Vec2 {
+        self.scroll_offset
     }
 
     /// Draw scroll bars.
@@ -194,7 +207,7 @@ impl<T: Data> Scroll<T> {
     }
 }
 
-impl<T: Data> Widget<T> for Scroll<T> {
+impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         if let Err(e) = paint_ctx.save() {
             error!("saving render context failed: {:?}", e);
@@ -232,6 +245,8 @@ impl<T: Data> Widget<T> for Scroll<T> {
         };
 
         match event {
+            // Show the scrollbars any time our size changes
+            Event::Size(_) => self.reset_scrollbar_fade(ctx),
             // The scroll bars will fade immediately if there's some other widget requesting animation.
             // Guard by the timer id being invalid.
             Event::AnimFrame(interval) if self.scroll_bars.timer_id == TimerToken::INVALID => {
@@ -255,11 +270,7 @@ impl<T: Data> Widget<T> for Scroll<T> {
                 if self.scroll(wheel.delta, size) {
                     ctx.invalidate();
                     ctx.set_handled();
-
-                    // Display scroll bars and schedule their disappearance
-                    self.scroll_bars.opacity = 0.7;
-                    let deadline = Instant::now() + Duration::from_millis(1500);
-                    self.scroll_bars.timer_id = ctx.request_timer(deadline);
+                    self.reset_scrollbar_fade(ctx);
                 }
             }
         }


### PR DESCRIPTION
This is a set of changes motivated by wanting to embed a Scroll
widget in another widget, and call some of its methods.

It includes adding a method to get the current scroll_offset,
exposing the scroll() method, and adding a method to reset
the fadeout on the scroll bars.

This also changes the signature of Scroll so that the child does
not have to be boxed. This isn't strictly necessary, but the
previous API seems unnecessarily constrained given that there
can only ever be a single child.