### PR TITLE
Padding with insets

### DIFF
--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -113,7 +113,7 @@ impl CalcState {
 }
 
 fn pad<T: Data>(inner: impl Widget<T> + 'static) -> impl Widget<T> {
-    Padding::uniform(5.0, inner)
+    Padding::new(5.0, inner)
 }
 
 fn op_button_label(op: char, label: String) -> impl Widget<CalcState> {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -31,7 +31,7 @@ fn ui_builder() -> impl Widget<u32> {
     let button = Button::new("increment", |_ctx, data, _env| *data += 1);
 
     let mut col = Column::new();
-    col.add_child(Align::centered(Padding::uniform(5.0, label)), 1.0);
-    col.add_child(Padding::uniform(5.0, button), 1.0);
+    col.add_child(Align::centered(Padding::new(5.0, label)), 1.0);
+    col.add_child(Padding::new(5.0, button), 1.0);
     col
 }

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -27,10 +27,7 @@ fn build_app() -> impl Widget<u32> {
     // Spacing element that will fill all available space in between label
     // and a button. Notice that weight is non-zero.
     header.add_child(SizedBox::empty().expand(), 1.0);
-    header.add_child(
-        Padding::uniform(20.0, Button::new("Two", Button::noop)),
-        0.0,
-    );
+    header.add_child(Padding::new(20.0, Button::new("Two", Button::noop)), 0.0);
 
     col.add_child(SizedBox::new(header).height(100.0), 0.0);
 

--- a/examples/multiwin.rs
+++ b/examples/multiwin.rs
@@ -73,10 +73,10 @@ fn ui_builder() -> impl Widget<State> {
     });
 
     let mut col = Column::new();
-    col.add_child(Align::centered(Padding::uniform(5.0, label)), 1.0);
+    col.add_child(Align::centered(Padding::new(5.0, label)), 1.0);
     let mut row = Row::new();
-    row.add_child(Padding::uniform(5.0, inc_button), 1.0);
-    row.add_child(Padding::uniform(5.0, dec_button), 1.0);
+    row.add_child(Padding::new(5.0, inc_button), 1.0);
+    row.add_child(Padding::new(5.0, dec_button), 1.0);
     col.add_child(row, 1.0);
     col
 }

--- a/examples/radio.rs
+++ b/examples/radio.rs
@@ -27,21 +27,18 @@ fn build_widget() -> impl Widget<Choice> {
     let mut col = Column::new();
 
     col.add_child(
-        Padding::uniform(5.0, Radio::new("First choice", Choice::A)),
+        Padding::new(5.0, Radio::new("First choice", Choice::A)),
         0.0,
     );
     col.add_child(
-        Padding::uniform(5.0, Radio::new("Second choice", Choice::B)),
+        Padding::new(5.0, Radio::new("Second choice", Choice::B)),
         0.0,
     );
     col.add_child(
-        Padding::uniform(5.0, Radio::new("Worst choice", Choice::C)),
+        Padding::new(5.0, Radio::new("Worst choice", Choice::C)),
         0.0,
     );
-    col.add_child(
-        Padding::uniform(5.0, Radio::new("Best choice", Choice::D)),
-        0.0,
-    );
+    col.add_child(Padding::new(5.0, Radio::new("Best choice", Choice::D)), 0.0);
 
     col.add_child(SizedBox::empty(), 1.0);
 

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -27,7 +27,7 @@ fn build_widget() -> impl Widget<u32> {
     let mut col = Column::new();
     for i in 0..30 {
         let button = Button::new(format!("Button {}", i), Button::noop);
-        col.add_child(Padding::uniform(3.0, button), 0.0);
+        col.add_child(Padding::new(3.0, button), 0.0);
     }
     Scroll::new(col)
 }

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -36,7 +36,7 @@ fn build_widget() -> impl Widget<DemoState> {
     let checkbox = LensWrap::new(Checkbox::new(), lenses::demo_state::double);
     let checkbox_label = Label::new("double the value");
     row.add_child(checkbox, 0.0);
-    row.add_child(Padding::uniform(5.0, checkbox_label), 1.0);
+    row.add_child(Padding::new(5.0, checkbox_label), 1.0);
 
     let bar = LensWrap::new(ProgressBar::new(), lenses::demo_state::value);
     let slider = LensWrap::new(Slider::new(), lenses::demo_state::value);
@@ -51,12 +51,12 @@ fn build_widget() -> impl Widget<DemoState> {
         data.value -= 0.1
     });
 
-    col.add_child(Padding::uniform(5.0, bar), 1.0);
-    col.add_child(Padding::uniform(5.0, slider), 1.0);
-    col.add_child(Padding::uniform(5.0, label), 1.0);
-    col.add_child(Padding::uniform(5.0, row), 1.0);
-    col.add_child(Padding::uniform(5.0, Align::right(button_1)), 0.0);
-    col.add_child(Padding::uniform(5.0, button_2), 1.0);
+    col.add_child(Padding::new(5.0, bar), 1.0);
+    col.add_child(Padding::new(5.0, slider), 1.0);
+    col.add_child(Padding::new(5.0, label), 1.0);
+    col.add_child(Padding::new(5.0, row), 1.0);
+    col.add_child(Padding::new(5.0, Align::right(button_1)), 0.0);
+    col.add_child(Padding::new(5.0, button_2), 1.0);
     col
 }
 

--- a/examples/textbox.rs
+++ b/examples/textbox.rs
@@ -40,9 +40,9 @@ fn build_widget() -> impl Widget<String> {
     let textbox_2 = TextBox::new();
     let label = DynLabel::new(|data: &String, _env| format!("value: {}", data));
 
-    col.add_child(Padding::uniform(5.0, textbox), 1.0);
-    col.add_child(Padding::uniform(5.0, textbox_2), 1.0);
-    col.add_child(Padding::uniform(5.0, label), 1.0);
+    col.add_child(Padding::new(5.0, textbox), 1.0);
+    col.add_child(Padding::new(5.0, textbox_2), 1.0);
+    col.add_child(Padding::new(5.0, label), 1.0);
     col
 }
 

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -14,6 +14,7 @@
 
 //! A widget that just adds padding during layout.
 
+use crate::kurbo::Insets;
 use crate::{
     BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point, Rect, Size,
     UpdateCtx, Widget, WidgetPod,
@@ -31,12 +32,53 @@ pub struct Padding<T: Data> {
 
 impl<T: Data> Padding<T> {
     /// Create widget with uniform padding.
+    #[deprecated(since = "0.3.0", note = "Use Padding::new() instead")]
     pub fn uniform(padding: f64, child: impl Widget<T> + 'static) -> Padding<T> {
         Padding {
             left: padding,
             right: padding,
             top: padding,
             bottom: padding,
+            child: WidgetPod::new(child).boxed(),
+        }
+    }
+
+    /// Create a new widget with the specified padding. This can either be an instance
+    /// of [`kurbo::Insets`], a f64 for uniform padding, a 2-tuple for axis-uniform padding
+    /// or 4-tuple with (left, top, right, bottom) values.
+    ///
+    /// # Examples
+    ///
+    /// Uniform padding:
+    ///
+    /// ```
+    /// use druid::widget::{Label, Padding};
+    /// use druid::kurbo::Insets;
+    ///
+    /// let _: Padding<()> = Padding::new(10.0, Label::new("uniform!"));
+    /// let _: Padding<()> = Padding::new(Insets::uniform(10.0), Label::new("uniform!"));
+    /// ```
+    ///
+    /// Uniform padding across each axis:
+    ///
+    /// ```
+    /// use druid::widget::{Label, Padding};
+    /// use druid::kurbo::Insets;
+    ///
+    /// let child: Label<()> = Label::new("I need my space!");
+    /// let _: Padding<()> = Padding::new((10.0, 20.0), Label::new("more y than x!"));
+    /// // equivalent:
+    /// let _: Padding<()> = Padding::new(Insets::uniform_xy(10.0, 20.0), Label::new("ditto :)"));
+    /// ```
+    ///
+    /// [`kurbo::Insets`]: https://docs.rs/kurbo/0.5.3/kurbo/struct.Insets.html
+    pub fn new(insets: impl Into<Insets>, child: impl Widget<T> + 'static) -> Padding<T> {
+        let insets = insets.into();
+        Padding {
+            left: insets.x0,
+            right: insets.x1,
+            top: insets.y0,
+            bottom: insets.y1,
             child: WidgetPod::new(child).boxed(),
         }
     }

--- a/src/widget/radio.rs
+++ b/src/widget/radio.rs
@@ -39,7 +39,7 @@ impl<T: Data + PartialEq + 'static> RadioGroup<T> {
         let mut col = Column::new();
         for (label, variant) in variants.into_iter() {
             let radio = Radio::new(label, variant);
-            col.add_child(Padding::uniform(5.0, radio), 0.0);
+            col.add_child(Padding::new(5.0, radio), 0.0);
         }
         col
     }


### PR DESCRIPTION
This adds a new constructor to the `Padding` widget to take advantage fo the new `Insets` type in kurbo.

Question: should this just be called `Padding::new`? Should we get rid of `Padding::uniform`, which can be well handled by a single `impl Into<Insets>` argument?

edit: this is based off of #236, which should go in first