### PR TITLE
Fix up BoxConstraints from Padding and Flex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -713,7 +713,9 @@ impl BoxConstraints {
     }
 
     /// Check to see if these constraints are legit.
-    pub fn check(&self, name: &str) {
+    ///
+    /// Logs a warning if BoxConstraints are invalid.
+    pub fn debug_check(&self, name: &str) {
         if !(0.0 <= self.min.width && self.min.width <= self.max.width)
             || !(0.0 <= self.min.height && self.min.height <= self.max.height)
         {

--- a/src/widget/align.rs
+++ b/src/widget/align.rs
@@ -92,6 +92,10 @@ impl<T: Data> Widget<T> for Align<T> {
         data: &T,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Align");
+        }
+
         let size = self.child.layout(layout_ctx, &bc.loosen(), data, env);
         let mut my_size = size;
         if bc.is_width_bounded() {

--- a/src/widget/align.rs
+++ b/src/widget/align.rs
@@ -92,9 +92,7 @@ impl<T: Data> Widget<T> for Align<T> {
         data: &T,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Align");
-        }
+        bc.debug_check("Align");
 
         let size = self.child.layout(layout_ctx, &bc.loosen(), data, env);
         let mut my_size = size;

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -117,9 +117,7 @@ impl<T: Data> Widget<T> for Button<T> {
         data: &T,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Button");
-        }
+        bc.debug_check("Button");
 
         self.label.layout(layout_ctx, bc, data, env)
     }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -117,6 +117,10 @@ impl<T: Data> Widget<T> for Button<T> {
         data: &T,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Button");
+        }
+
         self.label.layout(layout_ctx, bc, data, env)
     }
 

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -83,6 +83,10 @@ impl Widget<bool> for CheckboxRaw {
         _data: &bool,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Checkbox");
+        }
+
         bc.constrain(Size::new(
             env.get(theme::BASIC_WIDGET_HEIGHT),
             env.get(theme::BASIC_WIDGET_HEIGHT),

--- a/src/widget/checkbox.rs
+++ b/src/widget/checkbox.rs
@@ -83,9 +83,7 @@ impl Widget<bool> for CheckboxRaw {
         _data: &bool,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Checkbox");
-        }
+        bc.debug_check("Checkbox");
 
         bc.constrain(Size::new(
             env.get(theme::BASIC_WIDGET_HEIGHT),

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -141,9 +141,7 @@ impl<T: Data> Widget<T> for Flex<T> {
         data: &T,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Flex");
-        }
+        bc.debug_check("Flex");
 
         // Measure non-flex children.
         let mut total_non_flex = 0.0;
@@ -178,11 +176,7 @@ impl<T: Data> Widget<T> for Flex<T> {
             if child.params.flex != 0.0 {
                 let major = remaining * child.params.flex / flex_sum;
 
-                let min_major = if major == std::f64::INFINITY {
-                    0.0
-                } else {
-                    major
-                };
+                let min_major = if major.is_infinite() { 0.0 } else { major };
 
                 let child_bc = match self.direction {
                     Axis::Horizontal => BoxConstraints::new(
@@ -212,10 +206,8 @@ impl<T: Data> Widget<T> for Flex<T> {
             major += self.direction.major(rect.size());
         }
 
-        if log::log_enabled!(log::Level::Warn) {
-            if flex_sum > 0.0 && total_major == std::f64::INFINITY {
-                log::warn!("A child of Flex is flex, but Flex is unbounded.")
-            }
+        if flex_sum > 0.0 && total_major.is_infinite() {
+            log::warn!("A child of Flex is flex, but Flex is unbounded.")
         }
 
         if flex_sum > 0.0 {

--- a/src/widget/flex.rs
+++ b/src/widget/flex.rs
@@ -141,19 +141,23 @@ impl<T: Data> Widget<T> for Flex<T> {
         data: &T,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Flex");
+        }
+
         // Measure non-flex children.
         let mut total_non_flex = 0.0;
-        let mut minor = 0.0f64;
+        let mut minor = self.direction.minor(bc.min());
         for child in &mut self.children {
             if child.params.flex == 0.0 {
                 let child_bc = match self.direction {
                     Axis::Horizontal => BoxConstraints::new(
-                        Size::new(0.0, bc.min.height),
+                        Size::new(0.0, bc.min().height),
                         Size::new(std::f64::INFINITY, bc.max.height),
                     ),
                     Axis::Vertical => BoxConstraints::new(
-                        Size::new(bc.min.width, 0.0),
-                        Size::new(bc.max.width, std::f64::INFINITY),
+                        Size::new(bc.min().width, 0.0),
+                        Size::new(bc.max().width, std::f64::INFINITY),
                     ),
                 };
                 let child_size = child.widget.layout(layout_ctx, &child_bc, data, env);
@@ -165,21 +169,28 @@ impl<T: Data> Widget<T> for Flex<T> {
             }
         }
 
-        let total_major = self.direction.major(bc.max);
-        let remaining = total_major - total_non_flex;
+        let total_major = self.direction.major(bc.max());
+        let remaining = (total_major - total_non_flex).max(0.0);
         let flex_sum: f64 = self.children.iter().map(|child| child.params.flex).sum();
 
         // Measure flex children.
         for child in &mut self.children {
             if child.params.flex != 0.0 {
                 let major = remaining * child.params.flex / flex_sum;
+
+                let min_major = if major == std::f64::INFINITY {
+                    0.0
+                } else {
+                    major
+                };
+
                 let child_bc = match self.direction {
                     Axis::Horizontal => BoxConstraints::new(
-                        Size::new(major, bc.min().height),
+                        Size::new(min_major, bc.min().height),
                         Size::new(major, bc.max().height),
                     ),
                     Axis::Vertical => BoxConstraints::new(
-                        Size::new(bc.min().width, major),
+                        Size::new(bc.min().width, min_major),
                         Size::new(bc.max().width, major),
                     ),
                 };
@@ -200,9 +211,17 @@ impl<T: Data> Widget<T> for Flex<T> {
             child.widget.set_layout_rect(rect.with_origin(pos));
             major += self.direction.major(rect.size());
         }
+
+        if log::log_enabled!(log::Level::Warn) {
+            if flex_sum > 0.0 && total_major == std::f64::INFINITY {
+                log::warn!("A child of Flex is flex, but Flex is unbounded.")
+            }
+        }
+
         if flex_sum > 0.0 {
             major = total_major;
         }
+
         // TODO: should be able to make this `into`
         let (width, height) = self.direction.pack(major, minor);
         Size::new(width, height)

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -110,9 +110,8 @@ impl<T: Data> Widget<T> for Label<T> {
         _data: &T,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Label");
-        }
+        bc.debug_check("Label");
+
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let text_layout = self.get_layout(layout_ctx.text(), env);
         // This magical 1.2 constant helps center the text vertically in the rect it's given
@@ -197,9 +196,7 @@ impl<T: Data, F: FnMut(&T, &Env) -> String> Widget<T> for DynLabel<T, F> {
         data: &T,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Label");
-        }
+        bc.debug_check("DynLabel");
 
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let text_layout = self.get_layout(layout_ctx.text(), env, data);

--- a/src/widget/label.rs
+++ b/src/widget/label.rs
@@ -110,6 +110,9 @@ impl<T: Data> Widget<T> for Label<T> {
         _data: &T,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Label");
+        }
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let text_layout = self.get_layout(layout_ctx.text(), env);
         // This magical 1.2 constant helps center the text vertically in the rect it's given
@@ -194,6 +197,10 @@ impl<T: Data, F: FnMut(&T, &Env) -> String> Widget<T> for DynLabel<T, F> {
         data: &T,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Label");
+        }
+
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let text_layout = self.get_layout(layout_ctx.text(), env, data);
         // This magical 1.2 constant helps center the text vertically in the rect it's given

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -54,9 +54,7 @@ impl<T: Data> Widget<T> for Padding<T> {
         data: &T,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Padding");
-        }
+        bc.debug_check("Padding");
 
         let hpad = self.left + self.right;
         let vpad = self.top + self.bottom;

--- a/src/widget/padding.rs
+++ b/src/widget/padding.rs
@@ -54,10 +54,21 @@ impl<T: Data> Widget<T> for Padding<T> {
         data: &T,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Padding");
+        }
+
         let hpad = self.left + self.right;
         let vpad = self.top + self.bottom;
-        let min = Size::new(bc.min().width - hpad, bc.min().height - vpad);
-        let max = Size::new(bc.max().width - hpad, bc.max().height - vpad);
+        let min = Size::new(
+            (bc.min().width - hpad).max(0.),
+            (bc.min().height - vpad).max(0.),
+        );
+        let max = Size::new(
+            (bc.max().width - hpad).max(0.),
+            (bc.max().height - vpad).max(0.),
+        );
+
         let child_bc = BoxConstraints::new(min, max);
         let size = self.child.layout(layout_ctx, &child_bc, data, env);
         let origin = Point::new(self.left, self.top);

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -89,9 +89,7 @@ impl Widget<f64> for ProgressBarRaw {
         _data: &f64,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("ProgressBar");
-        }
+        bc.debug_check("ProgressBar");
 
         let default_width = 100.0;
 

--- a/src/widget/progress_bar.rs
+++ b/src/widget/progress_bar.rs
@@ -89,6 +89,10 @@ impl Widget<f64> for ProgressBarRaw {
         _data: &f64,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("ProgressBar");
+        }
+
         let default_width = 100.0;
 
         if bc.is_width_bounded() {

--- a/src/widget/radio.rs
+++ b/src/widget/radio.rs
@@ -111,6 +111,10 @@ impl<T: Data + PartialEq> Widget<T> for RadioRaw<T> {
         data: &T,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Radio");
+        }
+
         let label_size = self.child_label.layout(layout_ctx, &bc, data, env);
         let padding = 5.0;
         let label_x_offset = env.get(theme::BASIC_WIDGET_HEIGHT) + padding;

--- a/src/widget/radio.rs
+++ b/src/widget/radio.rs
@@ -111,9 +111,7 @@ impl<T: Data + PartialEq> Widget<T> for RadioRaw<T> {
         data: &T,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Radio");
-        }
+        bc.debug_check("Radio");
 
         let label_size = self.child_label.layout(layout_ctx, &bc, data, env);
         let padding = 5.0;

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -226,9 +226,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Scroll");
-        }
+        bc.debug_check("Scroll");
 
         let child_bc = BoxConstraints::new(Size::ZERO, self.direction.max_size(bc));
         let size = self.child.layout(ctx, &child_bc, data, env);

--- a/src/widget/scroll.rs
+++ b/src/widget/scroll.rs
@@ -226,6 +226,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Scroll");
+        }
+
         let child_bc = BoxConstraints::new(Size::ZERO, self.direction.max_size(bc));
         let size = self.child.layout(ctx, &child_bc, data, env);
         self.child_size = size;

--- a/src/widget/sized_box.rs
+++ b/src/widget/sized_box.rs
@@ -84,6 +84,10 @@ impl<T: Data> Widget<T> for SizedBox<T> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("SizedBox");
+        }
+
         match self.inner {
             Some(ref mut inner) => {
                 let (min_width, max_width) = match self.width {

--- a/src/widget/sized_box.rs
+++ b/src/widget/sized_box.rs
@@ -84,9 +84,7 @@ impl<T: Data> Widget<T> for SizedBox<T> {
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("SizedBox");
-        }
+        bc.debug_check("SizedBox");
 
         match self.inner {
             Some(ref mut inner) => {

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -137,9 +137,7 @@ impl Widget<f64> for SliderRaw {
         _data: &f64,
         env: &Env,
     ) -> Size {
-        if log::log_enabled!(log::Level::Warn) {
-            bc.check("Slider");
-        }
+        bc.debug_check("Slider");
 
         let default_width = 100.0;
 

--- a/src/widget/slider.rs
+++ b/src/widget/slider.rs
@@ -137,6 +137,10 @@ impl Widget<f64> for SliderRaw {
         _data: &f64,
         env: &Env,
     ) -> Size {
+        if log::log_enabled!(log::Level::Warn) {
+            bc.check("Slider");
+        }
+
         let default_width = 100.0;
 
         if bc.is_width_bounded() {


### PR DESCRIPTION
I forgot I had these fixes for Flex leftover. I also did the simplest thing possible to fix Padding (#238).

Additionally, I've added bc.check to the top of every widget's layout method, which should only be called if we're in log level Warn. I ran all the examples and after these changes to Flex and Padding I get no failures of bc.check() when sizing the window. That doesn't mean we're perfect now, but it's a big improvement!