### PR TITLE
Allow interacting with scrollbars via mouse pointer

### DIFF
--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -305,17 +305,21 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             match event {
                 Event::MouseMoved(event) => {
                     if self.scroll_bars.vertical_held {
+                        let scale_y = viewport.height() / self.child_size.height;
                         let bounds = self.calc_vertical_bar_bounds(&viewport);
                         let mouse_y = event.pos.y + self.scroll_offset.y;
+                        let delta = mouse_y - bounds.y0 - self.scroll_bars.held_offset;
                         self.scroll(
-                            Vec2::new(0f64, mouse_y - bounds.y0 - self.scroll_bars.held_offset),
+                            Vec2::new(0f64, (delta / scale_y).ceil()),
                             size,
                         );
                     } else if self.scroll_bars.horizontal_held {
+                        let scale_x = viewport.width() / self.child_size.width;
                         let bounds = self.calc_horizontal_bar_bounds(&viewport);
                         let mouse_x = event.pos.x + self.scroll_offset.x;
+                        let delta = mouse_x - bounds.x0 - self.scroll_bars.held_offset;
                         self.scroll(
-                            Vec2::new(mouse_x - bounds.x0 - self.scroll_bars.held_offset, 0f64),
+                            Vec2::new((delta / scale_x).ceil(), 0f64),
                             size,
                         );
                     }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -157,7 +157,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
         self.scroll_offset
     }
 
-    fn calc_scollbar_bounds(&self, viewport: &Rect) -> Rect {
+    fn calc_scrollbar_screen_edges(&self, viewport: &Rect) -> Rect {
         return Rect::new(
             self.scroll_offset.x + SCROLL_BAR_PAD,
             self.scroll_offset.y + SCROLL_BAR_PAD,
@@ -167,7 +167,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     }
 
     fn calc_vertical_bar_bounds(&self, viewport: &Rect) -> Rect {
-        let scrollbar_bounds = self.calc_scollbar_bounds(viewport);
+        let scrollbar_bounds = self.calc_scrollbar_screen_edges(viewport);
 
         let scale_y = viewport.height() / self.child_size.height;
 
@@ -184,7 +184,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     }
 
     fn calc_horizontal_bar_bounds(&self, viewport: &Rect) -> Rect {
-        let scrollbar_bounds = self.calc_scollbar_bounds(viewport);
+        let scrollbar_bounds = self.calc_scrollbar_screen_edges(viewport);
 
         let scale_x = viewport.width() / self.child_size.width;
 

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -169,14 +169,9 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     fn calc_vertical_bar_bounds(&self, viewport: &Rect) -> Rect {
         let scrollbar_bounds = self.calc_scollbar_bounds(viewport);
 
-        let content_size = Size::new(
-            viewport.width() - 2.0 * SCROLL_BAR_PAD,
-            viewport.height() - 2.0 * SCROLL_BAR_PAD,
-        );
+        let scale_y = viewport.height() / self.child_size.height;
 
-        let scale_y = content_size.height / self.child_size.height;
-
-        let h = (scale_y * content_size.height).ceil();
+        let h = (scale_y * viewport.height()).ceil();
         let dh = (scale_y * self.scroll_offset.y).ceil();
 
         let x0 = scrollbar_bounds.x1 - SCROLL_BAR_WIDTH;
@@ -191,14 +186,9 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     fn calc_horizontal_bar_bounds(&self, viewport: &Rect) -> Rect {
         let scrollbar_bounds = self.calc_scollbar_bounds(viewport);
 
-        let content_size = Size::new(
-            viewport.width() - 2.0 * SCROLL_BAR_PAD,
-            viewport.height() - 2.0 * SCROLL_BAR_PAD,
-        );
+        let scale_x = viewport.width() / self.child_size.width;
 
-        let scale_x = content_size.width / self.child_size.width;
-
-        let w = (scale_x * content_size.width).ceil();
+        let w = (scale_x * viewport.width()).ceil();
         let dw = (scale_x * self.scroll_offset.x).ceil();
 
         let x0 = scrollbar_bounds.x0 + dw;

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -55,14 +55,14 @@ impl ScrollDirection {
 
 enum BarHoveredState {
     None,
-    VerticalHovered,
-    HorizontalHovered,
+    Vertical,
+    Horizontal,
 }
 
 impl BarHoveredState {
     fn is_hovered(&self) -> bool {
         match self {
-            BarHoveredState::VerticalHovered | BarHoveredState::HorizontalHovered => true,
+            BarHoveredState::Vertical | BarHoveredState::Horizontal => true,
             _ => false,
         }
     }
@@ -72,10 +72,10 @@ enum BarHeldState {
     None,
     /// Vertical scrollbar is being dragged. Contains an `f64` with
     /// the initial y-offset of the dragging input
-    VerticalHeld(f64),
+    Vertical(f64),
     /// Horizontal scrollbar is being dragged. Contains an `f64` with
     /// the initial x-offset of the dragging input
-    HorizontalHeld(f64),
+    Horizontal(f64),
 }
 
 struct ScrollBarsState {
@@ -309,7 +309,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
         if match event {
             Event::MouseMoved(_) | Event::MouseUp(_) => match self.scroll_bars.held {
-                BarHeldState::VerticalHeld(_) | BarHeldState::HorizontalHeld(_) => true,
+                BarHeldState::Vertical(_) | BarHeldState::Horizontal(_) => true,
                 _ => false,
             },
             _ => false,
@@ -317,14 +317,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             match event {
                 Event::MouseMoved(event) => {
                     match self.scroll_bars.held {
-                        BarHeldState::VerticalHeld(offset) => {
+                        BarHeldState::Vertical(offset) => {
                             let scale_y = viewport.height() / self.child_size.height;
                             let bounds = self.calc_vertical_bar_bounds(viewport);
                             let mouse_y = event.pos.y + self.scroll_offset.y;
                             let delta = mouse_y - bounds.y0 - offset;
                             self.scroll(Vec2::new(0f64, (delta / scale_y).ceil()), size);
                         }
-                        BarHeldState::HorizontalHeld(offset) => {
+                        BarHeldState::Horizontal(offset) => {
                             let scale_x = viewport.width() / self.child_size.width;
                             let bounds = self.calc_horizontal_bar_bounds(viewport);
                             let mouse_x = event.pos.x + self.scroll_offset.x;
@@ -354,9 +354,9 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     let mut transformed_event = event.clone();
                     transformed_event.pos += self.scroll_offset;
                     if self.point_hits_vertical_bar(viewport, transformed_event.pos) {
-                        self.scroll_bars.hovered = BarHoveredState::VerticalHovered;
+                        self.scroll_bars.hovered = BarHoveredState::Vertical;
                     } else {
-                        self.scroll_bars.hovered = BarHoveredState::HorizontalHovered;
+                        self.scroll_bars.hovered = BarHoveredState::Horizontal;
                     }
 
                     self.scroll_bars.opacity = 0.7;
@@ -367,11 +367,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     let pos = event.pos + self.scroll_offset;
 
                     if self.point_hits_vertical_bar(viewport, pos) {
-                        self.scroll_bars.held = BarHeldState::VerticalHeld(
+                        self.scroll_bars.held = BarHeldState::Vertical(
                             pos.y - self.calc_vertical_bar_bounds(viewport).y0,
                         );
                     } else if self.point_hits_horizontal_bar(viewport, pos) {
-                        self.scroll_bars.held = BarHeldState::HorizontalHeld(
+                        self.scroll_bars.held = BarHeldState::Horizontal(
                             pos.x - self.calc_horizontal_bar_bounds(viewport).x0,
                         );
                     }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -242,7 +242,8 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
 
     fn mouse_over_vertical_bar(&self, viewport: Rect, pos: Point) -> bool {
         if viewport.height() < self.child_size.height {
-            return self.calc_vertical_bar_bounds(&viewport).contains(pos);
+            let bounds = self.calc_vertical_bar_bounds(&viewport);
+            return pos.y > bounds.y0 && pos.y < bounds.y1 && pos.x > bounds.x0;
         }
 
         return false;
@@ -250,7 +251,8 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
 
     fn mouse_over_horizontal_bar(&self, viewport: Rect, pos: Point) -> bool {
         if viewport.width() < self.child_size.width {
-            return self.calc_horizontal_bar_bounds(&viewport).contains(pos);
+            let bounds = self.calc_horizontal_bar_bounds(&viewport);
+            return pos.x > bounds.x0 && pos.x < bounds.x1 && pos.y > bounds.y0;
         }
 
         return false;

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -157,7 +157,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
         self.scroll_offset
     }
 
-    fn calc_scrollbar_screen_edges(&self, viewport: &Rect) -> Rect {
+    fn calc_scrollbar_screen_edges(&self, viewport: Rect) -> Rect {
         return Rect::new(
             self.scroll_offset.x + SCROLL_BAR_PAD,
             self.scroll_offset.y + SCROLL_BAR_PAD,
@@ -167,7 +167,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     }
 
     fn calc_vertical_bar_bounds(&self, viewport: &Rect) -> Rect {
-        let scrollbar_bounds = self.calc_scrollbar_screen_edges(viewport);
+        let scrollbar_bounds = self.calc_scrollbar_screen_edges(*viewport);
 
         let scale_y = viewport.height() / self.child_size.height;
 
@@ -184,7 +184,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     }
 
     fn calc_horizontal_bar_bounds(&self, viewport: &Rect) -> Rect {
-        let scrollbar_bounds = self.calc_scrollbar_screen_edges(viewport);
+        let scrollbar_bounds = self.calc_scrollbar_screen_edges(*viewport);
 
         let scale_x = viewport.width() / self.child_size.width;
 
@@ -230,22 +230,22 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
         }
     }
 
-    fn mouse_over_vertical_bar(&self, viewport: Rect, pos: Point) -> bool {
+    fn point_hits_vertical_bar(&self, viewport: Rect, pos: Point) -> bool {
         if viewport.height() < self.child_size.height {
             let bounds = self.calc_vertical_bar_bounds(&viewport);
             return pos.y > bounds.y0 && pos.y < bounds.y1 && pos.x > bounds.x0;
         }
 
-        return false;
+        false
     }
 
-    fn mouse_over_horizontal_bar(&self, viewport: Rect, pos: Point) -> bool {
+    fn point_hits_horizontal_bar(&self, viewport: Rect, pos: Point) -> bool {
         if viewport.width() < self.child_size.width {
             let bounds = self.calc_horizontal_bar_bounds(&viewport);
             return pos.x > bounds.x0 && pos.x < bounds.x1 && pos.y > bounds.y0;
         }
 
-        return false;
+        false
     }
 }
 
@@ -319,8 +319,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             Event::MouseMoved(event) | Event::MouseDown(event) => {
                 let mut transformed_event = event.clone();
                 transformed_event.pos += self.scroll_offset;
-                self.mouse_over_vertical_bar(viewport, transformed_event.pos)
-                    || self.mouse_over_horizontal_bar(viewport, transformed_event.pos)
+                self.point_hits_vertical_bar(viewport, transformed_event.pos)
+                    || self.point_hits_horizontal_bar(viewport, transformed_event.pos)
             }
             _ => false,
         } {
@@ -334,11 +334,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 Event::MouseDown(event) => {
                     let pos = event.pos + self.scroll_offset;
 
-                    if self.mouse_over_vertical_bar(viewport, pos) {
+                    if self.point_hits_vertical_bar(viewport, pos) {
                         self.scroll_bars.vertical_held = true;
                         self.scroll_bars.held_offset =
                             pos.y - self.calc_vertical_bar_bounds(&viewport).y0;
-                    } else if self.mouse_over_horizontal_bar(viewport, pos) {
+                    } else if self.point_hits_horizontal_bar(viewport, pos) {
                         self.scroll_bars.horizontal_held = true;
                         self.scroll_bars.held_offset =
                             pos.x - self.calc_horizontal_bar_bounds(&viewport).x0;
@@ -357,8 +357,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     let mut transformed_event = event.clone();
                     transformed_event.pos += self.scroll_offset;
                     let currently_hovered = self
-                        .mouse_over_vertical_bar(viewport, transformed_event.pos)
-                        || self.mouse_over_horizontal_bar(viewport, transformed_event.pos);
+                        .point_hits_vertical_bar(viewport, transformed_event.pos)
+                        || self.point_hits_horizontal_bar(viewport, transformed_event.pos);
                     if self.scroll_bars.hovered && !currently_hovered {
                         self.scroll_bars.hovered = false;
                         self.reset_scrollbar_fade(ctx);

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -187,8 +187,8 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
         );
     }
 
-    fn calc_vertical_bar_bounds(&self, viewport: &Rect) -> Rect {
-        let scrollbar_bounds = self.calc_scrollbar_screen_edges(*viewport);
+    fn calc_vertical_bar_bounds(&self, viewport: Rect) -> Rect {
+        let scrollbar_bounds = self.calc_scrollbar_screen_edges(viewport);
 
         let scale_y = viewport.height() / self.child_size.height;
 
@@ -204,8 +204,8 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
         return Rect::new(x0, y0, x1, y1);
     }
 
-    fn calc_horizontal_bar_bounds(&self, viewport: &Rect) -> Rect {
-        let scrollbar_bounds = self.calc_scrollbar_screen_edges(*viewport);
+    fn calc_horizontal_bar_bounds(&self, viewport: Rect) -> Rect {
+        let scrollbar_bounds = self.calc_scrollbar_screen_edges(viewport);
 
         let scale_x = viewport.width() / self.child_size.width;
 
@@ -222,7 +222,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     }
 
     /// Draw scroll bars.
-    fn draw_bars(&self, paint_ctx: &mut PaintCtx, viewport: &Rect, env: &Env) {
+    fn draw_bars(&self, paint_ctx: &mut PaintCtx, viewport: Rect, env: &Env) {
         if self.scroll_bars.opacity <= 0.0 {
             return;
         }
@@ -253,7 +253,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
 
     fn point_hits_vertical_bar(&self, viewport: Rect, pos: Point) -> bool {
         if viewport.height() < self.child_size.height {
-            let bounds = self.calc_vertical_bar_bounds(&viewport);
+            let bounds = self.calc_vertical_bar_bounds(viewport);
             return pos.y > bounds.y0 && pos.y < bounds.y1 && pos.x > bounds.x0;
         }
 
@@ -262,7 +262,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
 
     fn point_hits_horizontal_bar(&self, viewport: Rect, pos: Point) -> bool {
         if viewport.width() < self.child_size.width {
-            let bounds = self.calc_horizontal_bar_bounds(&viewport);
+            let bounds = self.calc_horizontal_bar_bounds(viewport);
             return pos.x > bounds.x0 && pos.x < bounds.x1 && pos.y > bounds.y0;
         }
 
@@ -283,7 +283,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         let visible = viewport.with_origin(self.scroll_offset.to_point());
         paint_ctx.with_child_ctx(visible, |ctx| self.child.paint(ctx, data, env));
 
-        self.draw_bars(paint_ctx, &viewport, env);
+        self.draw_bars(paint_ctx, viewport, env);
 
         if let Err(e) = paint_ctx.restore() {
             error!("restoring render context failed: {:?}", e);
@@ -319,14 +319,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     match self.scroll_bars.held {
                         BarHeldState::VerticalHeld(offset) => {
                             let scale_y = viewport.height() / self.child_size.height;
-                            let bounds = self.calc_vertical_bar_bounds(&viewport);
+                            let bounds = self.calc_vertical_bar_bounds(viewport);
                             let mouse_y = event.pos.y + self.scroll_offset.y;
                             let delta = mouse_y - bounds.y0 - offset;
                             self.scroll(Vec2::new(0f64, (delta / scale_y).ceil()), size);
                         }
                         BarHeldState::HorizontalHeld(offset) => {
                             let scale_x = viewport.width() / self.child_size.width;
-                            let bounds = self.calc_horizontal_bar_bounds(&viewport);
+                            let bounds = self.calc_horizontal_bar_bounds(viewport);
                             let mouse_x = event.pos.x + self.scroll_offset.x;
                             let delta = mouse_x - bounds.x0 - offset;
                             self.scroll(Vec2::new((delta / scale_x).ceil(), 0f64), size);
@@ -368,11 +368,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
                     if self.point_hits_vertical_bar(viewport, pos) {
                         self.scroll_bars.held = BarHeldState::VerticalHeld(
-                            pos.y - self.calc_vertical_bar_bounds(&viewport).y0,
+                            pos.y - self.calc_vertical_bar_bounds(viewport).y0,
                         );
                     } else if self.point_hits_horizontal_bar(viewport, pos) {
                         self.scroll_bars.held = BarHeldState::HorizontalHeld(
-                            pos.x - self.calc_horizontal_bar_bounds(&viewport).x0,
+                            pos.x - self.calc_horizontal_bar_bounds(viewport).x0,
                         );
                     }
                 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -299,19 +299,13 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                         let bounds = self.calc_vertical_bar_bounds(&viewport);
                         let mouse_y = event.pos.y + self.scroll_offset.y;
                         let delta = mouse_y - bounds.y0 - self.scroll_bars.held_offset;
-                        self.scroll(
-                            Vec2::new(0f64, (delta / scale_y).ceil()),
-                            size,
-                        );
+                        self.scroll(Vec2::new(0f64, (delta / scale_y).ceil()), size);
                     } else if self.scroll_bars.horizontal_held {
                         let scale_x = viewport.width() / self.child_size.width;
                         let bounds = self.calc_horizontal_bar_bounds(&viewport);
                         let mouse_x = event.pos.x + self.scroll_offset.x;
                         let delta = mouse_x - bounds.x0 - self.scroll_bars.held_offset;
-                        self.scroll(
-                            Vec2::new((delta / scale_x).ceil(), 0f64),
-                            size,
-                        );
+                        self.scroll(Vec2::new((delta / scale_x).ceil(), 0f64), size);
                     }
                     ctx.invalidate();
                 }


### PR DESCRIPTION
Closes https://github.com/xi-editor/druid/issues/220
This handles showing the scrollbars on mouse over, not hiding until mouse out, and dragging the bars to scroll. 

In addition to the usual code quality review there is a strange behavior I'd like input on. At smaller window sizes dragging the scrollbar appears to be floaty for some reason (especially on `scroll_colors` but less so on `scroll` for some reason?). I cannot at this time figure out why this is. It does not seem to be the result of the whole number mouse positions as the innacuracy is much larger than a single pixel and swapping out the calls to `scroll` for directly setting to `scroll_offset` does not affect the issue.

Furthermore is there a way to track mouse movement and Up/Down when outside the window bounds? That is a situation where the current logic breaks down slightly (but not significantly).