### PR TITLE
Add convenience method for transforming PaintCtx

### DIFF
--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -342,6 +342,22 @@ impl<'a, 'b: 'a> PaintCtx<'a, 'b> {
         };
         f(&mut child_ctx)
     }
+
+    /// Creates a temporary `PaintCtx` with the given transform applied,
+    /// and called the closure with it.
+    pub fn with_transform_ctx(&mut self, transform: Affine, f: impl FnOnce(&mut PaintCtx)) {
+        if let Err(e) = self.render_ctx.save() {
+            log::error!("saving render context failed: {:?}", e);
+            return;
+        }
+
+        self.render_ctx.transform(transform);
+        f(self);
+
+        if let Err(e) = self.render_ctx.restore() {
+            error!("restoring render context failed: {:?}", e);
+        }
+    }
 }
 
 /// A context provided to layout handling methods of widgets.


### PR DESCRIPTION
Just an idea: there's a bunch of boilerplate involved around applying and popping a transform; this wraps that up.

This logs and swallows errors. Should it return them?

This is very similar to `with_child_ctx`. Should there be a shared implementation that combines them?

This does not update `paint_with_offset` to use this new method. If it did, that would look like,

```rust
let layout_origin = self.state.layout_rect.origin().to_vec2();
let visible = ctx.region().to_rect() - layout_origin;
paint_ctx.with_transform_ctx(Affine::translate(layout_origin), |ctx| {
    ctx.with_child_ctx(visible, |ctx| {
        self.inner.paint(ctx, &self.state, data, &env)
    })
})
```

which feels a bit funny (the nested closures) and is part of what motivates the question just above.