### PR TITLE
support ignoring fields when deriving data

### DIFF
--- a/druid-derive-data/Cargo.toml
+++ b/druid-derive-data/Cargo.toml
@@ -12,3 +12,5 @@ syn = "1.0.5"
 quote = "1.0.2"
 proc-macro2 = "1.0.4"
 
+[dev-dependencies]
+druid = { path = ".." }

--- a/druid-derive-data/src/attr.rs
+++ b/druid-derive-data/src/attr.rs
@@ -1,0 +1,128 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! parsing #[druid(attributes)]
+
+use proc_macro2::{Ident, Literal, Span, TokenTree};
+use syn::spanned::Spanned;
+use syn::{Error, Meta, NestedMeta};
+
+const BASE_ATTR_PATH: &str = "druid";
+const IGNORE_ATTR_PATH: &str = "ignore";
+
+/// The fields for a struct or an enum variant.
+#[derive(Debug)]
+pub struct Fields {
+    pub kind: FieldKind,
+    fields: Vec<Field>,
+}
+
+#[derive(Debug, Clone)]
+pub enum FieldKind {
+    Named,
+    // this also covers Unit; we determine 'unit-ness' based on the number
+    // of fields.
+    Unnamed,
+}
+
+#[derive(Debug)]
+pub enum FieldIdent {
+    Named(String),
+    Unnamed(usize),
+}
+
+#[derive(Debug)]
+pub struct Field {
+    pub ident: FieldIdent,
+    /// `true` if this field should be ignored.
+    pub ignore: bool,
+    //TODO: more attrs here
+}
+
+impl Fields {
+    pub fn parse_ast(fields: &syn::Fields) -> Result<Self, Error> {
+        let kind = match fields {
+            syn::Fields::Named(_) => FieldKind::Named,
+            syn::Fields::Unnamed(_) | syn::Fields::Unit => FieldKind::Unnamed,
+        };
+
+        let fields = fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| Field::parse_ast(field, i))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Fields { kind, fields })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Field> {
+        self.fields.iter()
+    }
+}
+
+impl Field {
+    pub fn parse_ast(field: &syn::Field, index: usize) -> Result<Self, Error> {
+        let ident = match field.ident.as_ref() {
+            Some(ident) => FieldIdent::Named(ident.to_string().trim_start_matches("r#").to_owned()),
+            None => FieldIdent::Unnamed(index),
+        };
+
+        let mut ignore = false;
+
+        for attr in field
+            .attrs
+            .iter()
+            .filter(|attr| attr.path.is_ident(BASE_ATTR_PATH))
+        {
+            match attr.parse_meta()? {
+                Meta::List(meta) => {
+                    for nested in meta.nested.iter() {
+                        match nested {
+                            NestedMeta::Meta(Meta::Path(path))
+                                if path.is_ident(IGNORE_ATTR_PATH) =>
+                            {
+                                if ignore {
+                                    return Err(Error::new(nested.span(), "Duplicate attribute"));
+                                }
+                                ignore = true;
+                            }
+                            other => return Err(Error::new(other.span(), "Unknown attribute")),
+                        }
+                    }
+                }
+                other => {
+                    return Err(Error::new(
+                        other.span(),
+                        "Expected attribute list (the form #[druid(one, two)])",
+                    ))
+                }
+            }
+        }
+        Ok(Field { ident, ignore })
+    }
+
+    pub fn ident_tokens(&self) -> TokenTree {
+        match self.ident {
+            FieldIdent::Named(ref s) => Ident::new(&s, Span::call_site()).into(),
+            FieldIdent::Unnamed(num) => Literal::usize_unsuffixed(num).into(),
+        }
+    }
+
+    pub fn ident_string(&self) -> String {
+        match self.ident {
+            FieldIdent::Named(ref s) => s.clone(),
+            FieldIdent::Unnamed(num) => num.to_string(),
+        }
+    }
+}

--- a/druid-derive-data/tests/ignore.rs
+++ b/druid-derive-data/tests/ignore.rs
@@ -26,3 +26,35 @@ fn ignore_item_without_data_impl() {
         path: PathBuf,
     }
 }
+
+#[test]
+fn tuple_struct() {
+    #[derive(Clone, Data)]
+    struct Tup(usize, #[druid(ignore)] usize);
+
+    let one = Tup(1, 1);
+    let two = Tup(1, 5);
+    assert!(one.same(&two));
+}
+
+#[test]
+fn enums() {
+    #[derive(Clone, Data)]
+    enum Hmm {
+        Named {
+            one: usize,
+            #[druid(ignore)]
+            two: usize,
+        },
+        Tuple(#[druid(ignore)] usize, usize),
+    }
+
+    let name_one = Hmm::Named { one: 5, two: 4 };
+    let name_two = Hmm::Named { one: 5, two: 42 };
+    let tuple_one = Hmm::Tuple(2, 4);
+    let tuple_two = Hmm::Tuple(9, 4);
+
+    assert!(!name_one.same(&tuple_one));
+    assert!(name_one.same(&name_two));
+    assert!(tuple_one.same(&tuple_two));
+}

--- a/druid-derive-data/tests/ignore.rs
+++ b/druid-derive-data/tests/ignore.rs
@@ -1,0 +1,28 @@
+//! testing the ignore attribute
+
+use druid::Data;
+
+#[test]
+fn simple_ignore() {
+    #[derive(Clone, Data)]
+    struct Point {
+        x: f64,
+        #[druid(ignore)]
+        y: f64,
+    }
+    let p1 = Point { x: 0.0, y: 1.0 };
+    let p2 = Point { x: 0.0, y: 9.0 };
+    assert!(p1.same(&p2));
+}
+
+#[test]
+fn ignore_item_without_data_impl() {
+    use std::path::PathBuf;
+
+    #[derive(Clone, Data)]
+    struct CoolStruct {
+        len: usize,
+        #[druid(ignore)]
+        path: PathBuf,
+    }
+}


### PR DESCRIPTION
This was a bit of a rabbit hole.
tl;dr: you can now write this:

```rust
struct AppState {
    text: String,
    copies: usize,
    #[druid(ignore)]
    user: UserId,
}
```

And the last field will be ignored for the purpose of `same()`.

I ended up making some largish organizational changes as a result of this work.

@futurepaul want to take a look and see if this makes sense to you?
    