### PR TITLE
Allow custom comparison functions for fields when deriving Data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 name = "druid"
 version = "0.3.0"
 dependencies = [
- "druid-derive-data 0.1.0",
+ "druid-derive-data 0.1.1",
  "druid-derive-lens 0.1.0",
  "druid-shell 0.3.0",
  "fluent-bundle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "druid-derive-data"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/druid-derive-data/Cargo.toml
+++ b/druid-derive-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-derive-data"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Druid authors"]
 edition = "2018"
 

--- a/druid-derive-data/tests/with_same.rs
+++ b/druid-derive-data/tests/with_same.rs
@@ -1,0 +1,72 @@
+use druid::Data;
+
+#[test]
+fn same_fn() {
+    #[derive(Clone, Data)]
+    struct Nanana {
+        bits: f64,
+        #[druid(same_fn = "PartialEq::eq")]
+        peq: f64,
+    }
+
+    let one = Nanana {
+        bits: 1.0,
+        peq: std::f64::NAN,
+    };
+    let two = Nanana {
+        bits: 1.0,
+        peq: std::f64::NAN,
+    };
+
+    //according to partialeq, two NaNs are never equal
+    assert!(!one.same(&two));
+
+    let one = Nanana {
+        bits: std::f64::NAN,
+        peq: 1.0,
+    };
+    let two = Nanana {
+        bits: std::f64::NAN,
+        peq: 1.0,
+    };
+
+    // the default 'same' impl uses bitwise equality, so two bitwise-equal NaNs are equal
+    assert!(one.same(&two));
+}
+
+#[test]
+fn enums() {
+    #[derive(Debug, Clone, Data)]
+    enum Hi {
+        One {
+            bits: f64,
+        },
+        Two {
+            #[druid(same_fn = "same_sign")]
+            bits: f64,
+        },
+        Tri(#[druid(same_fn = "same_sign")] f64),
+    }
+
+    let oneone = Hi::One {
+        bits: std::f64::NAN,
+    };
+    let onetwo = Hi::One {
+        bits: std::f64::NAN,
+    };
+    assert!(oneone.same(&onetwo));
+
+    let twoone = Hi::Two { bits: -1.1 };
+    let twotwo = Hi::Two {
+        bits: std::f64::NEG_INFINITY,
+    };
+    assert!(twoone.same(&twotwo));
+
+    let trione = Hi::Tri(1001.);
+    let tritwo = Hi::Tri(-1.);
+    assert!(!trione.same(&tritwo));
+}
+
+fn same_sign(one: &f64, two: &f64) -> bool {
+    one.signum() == two.signum()
+}


### PR DESCRIPTION
This is includes commits from #247, which should get merged first.

This lets you write,

```rust
#[derive(Clone, Data)]
struct NonBitwiseFloat {
    #[druid(with_same = "PartialEq::eq")]
    inner: f64,
}
```

And you will get an implementation of `Data` that uses `PartialEq::eq` when checking that field.

I don't know what to call this attribute; serde uses `serialize_with = "..."` and `skip_serializing_if = "..."`. Maybe this should be `cmp_fn = "..."` or `same_fn = "..."` or `compare = "..."` or... I'm not sure, really.
