### PR TITLE
Measure cursor position using Piet hit testing

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -324,6 +324,7 @@ impl Widget<String> for TextBox {
         match event {
             Event::MouseDown(mouse) => {
                 ctx.request_focus();
+                ctx.set_active(true);
                 let cursor_off = self.offset_for_point(mouse.pos, &text_layout);
                 if mouse.mods.shift {
                     self.selection.end = cursor_off;
@@ -333,8 +334,18 @@ impl Widget<String> for TextBox {
                 ctx.invalidate();
                 self.reset_cursor_blink(ctx);
             }
-            Event::MouseMoved(_) => {
+            Event::MouseMoved(mouse) => {
                 ctx.set_cursor(&Cursor::IBeam);
+                if ctx.is_active() {
+                    self.selection.end = self.offset_for_point(mouse.pos, &text_layout);
+                    ctx.invalidate();
+                }
+            }
+            Event::MouseUp(_) => {
+                if ctx.is_active() {
+                    ctx.set_active(false);
+                    ctx.invalidate();
+                }
             }
             Event::Timer(id) => {
                 if *id == self.cursor_timer {

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -262,14 +262,13 @@ impl Widget<String> for TextBox {
                 // Draw selection rect
                 if !self.selection.is_caret() {
                     let (left, right) = (self.selection.min(), self.selection.max());
+                    let left_offset = self.x_for_offset(&text_layout, left);
+                    let right_offset = self.x_for_offset(&text_layout, right);
 
-                    let selection_width = self.x_for_offset(&text_layout, right)
-                        - self.x_for_offset(&text_layout, left);
+                    let selection_width = right_offset - left_offset;
 
-                    let selection_pos = Point::new(
-                        self.x_for_offset(&text_layout, left) + PADDING_LEFT - 1.,
-                        PADDING_TOP - 2.,
-                    );
+                    let selection_pos =
+                        Point::new(left_offset + PADDING_LEFT - 1., PADDING_TOP - 2.);
                     let selection_rect = RoundedRect::from_origin_size(
                         selection_pos,
                         Size::new(selection_width + 2., font_size + 4.).to_vec2(),


### PR DESCRIPTION
Builds on #256, should be merged after.

This removes the substring measurement hack we've been relying on to position the cursor and selection box when drawing. I also did some cleanup to the usage of `get_layout`, but I couldn't quite figure out how to cache layout, due to lifetime issues.

As a bonus, I also added PR to this click-and-drag selection because it was an easy fix!