### PR TITLE
[mac] Fix crash when holding RefMut while showing context menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,10 +194,10 @@ dependencies = [
 
 [[package]]
 name = "druid"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "druid-derive 0.1.1",
- "druid-shell 0.3.0",
+ "druid-shell 0.3.1",
  "fluent-bundle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-locale 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -211,7 +211,7 @@ dependencies = [
 name = "druid-derive"
 version = "0.1.1"
 dependencies = [
- "druid 0.3.1",
+ "druid 0.3.2",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "druid-shell"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-shell"
-version = "0.3.0"
+version = "0.3.1"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Platform abstracting application shell used for druid toolkit."

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid"
-version = "0.3.1"
+version = "0.3.2"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Data-oriented Rust UI design toolkit."
@@ -32,7 +32,7 @@ default-features = false
 
 [dependencies.druid-shell]
 path = "../druid-shell"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies.druid-derive]
 path = "../druid-derive"


### PR DESCRIPTION
Other events can arrive while we are showing the context menu. To work
around this, we need to not show the menu while holding a borrow on
the window state, and instead schedule it to be shown after we've
returned.

A consequence of this fix is that, currently, we don't actually use
the x, y values passed by the caller, and instead just always use
the last known mouse position.