### PR TITLE
remove "Raw" indirection from basic widgets

### DIFF
--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -23,19 +23,16 @@ use crate::{
 };
 
 /// A checkbox that toggles a boolean
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Checkbox;
 
 impl Checkbox {
     pub fn new() -> impl Widget<bool> {
-        Align::vertical(UnitPoint::CENTER, CheckboxRaw::default())
+        Align::vertical(UnitPoint::CENTER, Self::default())
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct CheckboxRaw;
-
-impl Widget<bool> for CheckboxRaw {
+impl Widget<bool> for Checkbox {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &bool, env: &Env) {
         let size = env.get(theme::BASIC_WIDGET_HEIGHT);
 

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -23,19 +23,16 @@ use crate::{
 };
 
 /// A progress bar, displaying a numeric progress value.
-#[derive(Debug, Clone)]
-pub struct ProgressBar;
+#[derive(Debug, Clone, Default)]
+pub struct ProgressBar {}
 
 impl ProgressBar {
     pub fn new() -> impl Widget<f64> {
-        Align::vertical(UnitPoint::CENTER, ProgressBarRaw::default())
+        Align::vertical(UnitPoint::CENTER, Self::default())
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct ProgressBarRaw {}
-
-impl Widget<f64> for ProgressBarRaw {
+impl Widget<f64> for ProgressBar {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &f64, env: &Env) {
         let clamped = data.max(0.0).min(1.0);
 

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -46,15 +46,15 @@ impl<T: Data + PartialEq + 'static> RadioGroup<T> {
 }
 
 /// A single radio button
-#[derive(Debug, Clone)]
-pub struct Radio<T: Data + PartialEq + 'static> {
-    phantom: PhantomData<T>,
+pub struct Radio<T: Data + PartialEq> {
+    variant: T,
+    child_label: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
 impl<T: Data + PartialEq + 'static> Radio<T> {
     /// Create a lone Radio button from label text and an enum variant
     pub fn new(label: impl Into<LabelText<T>>, variant: T) -> impl Widget<T> {
-        let radio = RadioRaw {
+        let radio = Self {
             variant,
             child_label: WidgetPod::new(Label::new(label)).boxed(),
         };
@@ -62,12 +62,7 @@ impl<T: Data + PartialEq + 'static> Radio<T> {
     }
 }
 
-pub struct RadioRaw<T: Data + PartialEq> {
-    variant: T,
-    child_label: WidgetPod<T, Box<dyn Widget<T>>>,
-}
-
-impl<T: Data + PartialEq> Widget<T> for RadioRaw<T> {
+impl<T: Data + PartialEq> Widget<T> for Radio<T> {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         let size = env.get(theme::BASIC_WIDGET_HEIGHT);
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -93,17 +93,7 @@ impl Selection {
 
 /// A widget that allows user text input.
 #[derive(Debug, Clone)]
-pub struct TextBox;
-
-impl TextBox {
-    pub fn new() -> impl Widget<String> {
-        Align::vertical(UnitPoint::CENTER, TextBoxRaw::new())
-    }
-}
-
-/// A widget that allows user text input.
-#[derive(Debug, Clone)]
-pub struct TextBoxRaw {
+pub struct TextBox {
     width: f64,
     hscroll_offset: f64,
     selection: Selection,
@@ -111,10 +101,15 @@ pub struct TextBoxRaw {
     cursor_on: bool,
 }
 
-impl TextBoxRaw {
-    /// Create a new TextBox widget with a width set in pixels
-    pub fn new() -> TextBoxRaw {
-        TextBoxRaw {
+impl TextBox {
+    /// Create a new TextBox widget
+    pub fn new() -> impl Widget<String> {
+        Align::vertical(UnitPoint::CENTER, Self::raw())
+    }
+
+    /// Create a new TextBox widget with no Align wrapper
+    pub fn raw() -> TextBox {
+        Self {
             width: 0.0,
             hscroll_offset: 0.,
             selection: Selection::caret(0),
@@ -218,7 +213,7 @@ impl TextBoxRaw {
     }
 }
 
-impl Widget<String> for TextBoxRaw {
+impl Widget<String> for TextBox {
     fn paint(
         &mut self,
         paint_ctx: &mut PaintCtx,
@@ -488,7 +483,7 @@ mod tests {
     /// can still be used to insert characters.
     #[test]
     fn data_can_be_changed_externally() {
-        let mut widget = TextBoxRaw::new();
+        let mut widget = TextBox::raw();
         let mut data = "".to_string();
 
         // First insert some chars


### PR DESCRIPTION
This wasn't obvious to me when I did it, but we don't need an actual distinct "Raw" version of each struct when we're wrapping a widget in Align. This PR brings the basic widgets in line with the style of the new Switch widget.

The drawback is that when the new() method on a widget returns a Align-wrapped widget, you lose access to methods on that struct. I solved that in the case of TextBox's tests by adding a raw() method. Maybe that's a better pattern? Also, perhaps core layout widgets could have a way of routing method calls to a child? Don't know if that's a can of worms.

Also used this opportunity to use winding hit testing in Slider and the newfound ability to get width off of the EventCtx instead of storing it as state!

(I'll probably have to rebase because this touches textbox?)