### PR TITLE
Fix crash when typing on Windows

### DIFF
--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -321,7 +321,7 @@ impl Widget<String> for TextBox {
     }
 
     fn event(&mut self, event: &Event, ctx: &mut EventCtx, data: &mut String, env: &Env) {
-        let text_layout = self.get_layout(ctx.text(), data, env);
+        let mut text_layout = self.get_layout(ctx.text(), data, env);
         match event {
             Event::MouseDown(mouse) => {
                 ctx.request_focus();
@@ -443,6 +443,7 @@ impl Widget<String> for TextBox {
                     }
                     _ => {}
                 }
+                text_layout = self.get_layout(ctx.text(), data, env);
                 self.update_hscroll(&text_layout);
                 ctx.invalidate();
             }


### PR DESCRIPTION
When inserting text, the `update_scroll` method is called to measure the
new cursor position, but with a stale text layout. This patch rebuilds
the text layout when the text is changed.

I'm not sure if this is 100% correct, but fixes the panic.