### PR TITLE
Add EnvScope widget to mutate env for theming children

### DIFF
--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -15,7 +15,7 @@
 //! Demos the textbox widget, as well as menu creation and overriding theme settings.
 
 use druid::piet::Color;
-use druid::widget::{Column, DynLabel, Padding, StyleChild, TextBox};
+use druid::widget::{Column, DynLabel, EnvScope, Padding, TextBox};
 use druid::{theme, AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
 
 fn main() {
@@ -37,7 +37,7 @@ fn build_widget() -> impl Widget<String> {
     let mut col = Column::new();
 
     let textbox = TextBox::new();
-    let textbox_2 = StyleChild::new(
+    let textbox_2 = EnvScope::new(
         |env| {
             env.set(theme::BACKGROUND_LIGHT, Color::rgb8(50, 50, 50));
             env.set(theme::LABEL_COLOR, Color::WHITE);

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -15,7 +15,7 @@
 //! Demos the textbox widget, as well as menu creation and overriding theme settings.
 
 use druid::piet::Color;
-use druid::widget::{Column, DynLabel, Padding, TextBox};
+use druid::widget::{Column, DynLabel, Padding, StyleChild, TextBox};
 use druid::{theme, AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
 
 fn main() {
@@ -37,7 +37,15 @@ fn build_widget() -> impl Widget<String> {
     let mut col = Column::new();
 
     let textbox = TextBox::new();
-    let textbox_2 = TextBox::new();
+    let textbox_2 = StyleChild::new(
+        |env| {
+            env.set(theme::BACKGROUND_LIGHT, Color::rgb8(50, 50, 50));
+            env.set(theme::LABEL_COLOR, Color::WHITE);
+            env.set(theme::CURSOR_COLOR, Color::WHITE);
+            env.set(theme::SELECTION_COLOR, Color::rgb8(100, 100, 100));
+        },
+        TextBox::new(),
+    );
     let label = DynLabel::new(|data: &String, _env| format!("value: {}", data));
 
     col.add_child(Padding::new(5.0, textbox), 1.0);

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -59,5 +59,5 @@ pub use crate::widget::container::Container;
 mod switch;
 pub use crate::widget::switch::Switch;
 
-mod style_child;
-pub use crate::widget::style_child::StyleChild;
+mod env_scope;
+pub use crate::widget::env_scope::EnvScope;

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -58,3 +58,6 @@ pub use crate::widget::container::Container;
 
 mod switch;
 pub use crate::widget::switch::Switch;
+
+mod style_child;
+pub use crate::widget::style_child::StyleChild;

--- a/druid/src/widget/style_child.rs
+++ b/druid/src/widget/style_child.rs
@@ -1,0 +1,78 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A widget that themes its child.
+
+use crate::{
+    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Rect, Size,
+    UpdateCtx, Widget, WidgetPod,
+};
+
+use crate::kurbo::Point;
+
+/// A widget that accepts a closure to update the theme for its child.
+pub struct StyleChild<T: Data, F: Fn(&mut Env) + 'static> {
+    f: F,
+    child: WidgetPod<T, Box<dyn Widget<T>>>,
+}
+
+impl<T: Data, F: Fn(&mut Env) + 'static> StyleChild<T, F> {
+    /// Create a widget that themes its child.
+    ///
+    /// Accepts a closure that sets theme values:
+    /// ```
+    /// |env| {
+    ///     env.set(theme::LABEL_COLOR, Color::WHITE);
+    /// }
+    /// ```
+    pub fn new(f: F, child: impl Widget<T> + 'static) -> StyleChild<T, F> {
+        StyleChild {
+            f,
+            child: WidgetPod::new(child).boxed(),
+        }
+    }
+}
+
+impl<T: Data, F: Fn(&mut Env) + 'static> Widget<T> for StyleChild<T, F> {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
+        let mut new_env = env.clone();
+        (self.f)(&mut new_env);
+
+        self.child.paint_with_offset(paint_ctx, data, &new_env);
+    }
+
+    fn layout(
+        &mut self,
+        layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &T,
+        env: &Env,
+    ) -> Size {
+        bc.debug_check("StyleChild");
+
+        let size = self.child.layout(layout_ctx, &bc, data, env);
+        self.child
+            .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+
+        size
+    }
+
+    fn event(&mut self, event: &Event, ctx: &mut EventCtx, data: &mut T, env: &Env) {
+        self.child.event(event, ctx, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+        self.child.update(ctx, data, env);
+    }
+}

--- a/druid/src/widget/style_child.rs
+++ b/druid/src/widget/style_child.rs
@@ -15,16 +15,14 @@
 //! A widget that themes its child.
 
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Rect, Size,
-    UpdateCtx, Widget, WidgetPod,
+    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Size, UpdateCtx,
+    Widget,
 };
-
-use crate::kurbo::Point;
 
 /// A widget that accepts a closure to update the theme for its child.
 pub struct StyleChild<T: Data, F: Fn(&mut Env) + 'static> {
     f: F,
-    child: WidgetPod<T, Box<dyn Widget<T>>>,
+    child: Box<dyn Widget<T>>,
 }
 
 impl<T: Data, F: Fn(&mut Env) + 'static> StyleChild<T, F> {
@@ -32,24 +30,37 @@ impl<T: Data, F: Fn(&mut Env) + 'static> StyleChild<T, F> {
     ///
     /// Accepts a closure that sets theme values:
     /// ```
-    /// |env| {
-    ///     env.set(theme::LABEL_COLOR, Color::WHITE);
-    /// }
+    /// # use druid::{theme, Widget};
+    /// # use druid::piet::{Color};
+    /// # use druid::widget::{Label, StyleChild};
+    ///
+    /// # fn build_width() -> impl Widget<String> {
+    ///
+    /// StyleChild::new(
+    ///     |env| {
+    ///         env.set(theme::LABEL_COLOR, Color::WHITE);
+    ///     },
+    ///     Label::new("White text!")
+    /// )
+    ///
+    /// # }
+    ///
+
     /// ```
     pub fn new(f: F, child: impl Widget<T> + 'static) -> StyleChild<T, F> {
         StyleChild {
             f,
-            child: WidgetPod::new(child).boxed(),
+            child: Box::new(child),
         }
     }
 }
 
 impl<T: Data, F: Fn(&mut Env) + 'static> Widget<T> for StyleChild<T, F> {
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env);
 
-        self.child.paint_with_offset(paint_ctx, data, &new_env);
+        self.child.paint(paint_ctx, base_state, data, &new_env);
     }
 
     fn layout(
@@ -61,18 +72,23 @@ impl<T: Data, F: Fn(&mut Env) + 'static> Widget<T> for StyleChild<T, F> {
     ) -> Size {
         bc.debug_check("StyleChild");
 
-        let size = self.child.layout(layout_ctx, &bc, data, env);
-        self.child
-            .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+        let mut new_env = env.clone();
+        (self.f)(&mut new_env);
 
-        size
+        self.child.layout(layout_ctx, &bc, data, &new_env)
     }
 
     fn event(&mut self, event: &Event, ctx: &mut EventCtx, data: &mut T, env: &Env) {
-        self.child.event(event, ctx, data, env)
+        let mut new_env = env.clone();
+        (self.f)(&mut new_env);
+
+        self.child.event(event, ctx, data, &new_env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
-        self.child.update(ctx, data, env);
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+        let mut new_env = env.clone();
+        (self.f)(&mut new_env);
+
+        self.child.update(ctx, old_data, data, &new_env);
     }
 }


### PR DESCRIPTION
I don't know if this is a terrible idea, I just wanted to present it as a possible way to do styling further down the tree. At least the API seems intuitive, although it might be better as a method on Container.

Btw I would've assumed this would be more appropriate to put into Update, not Paint, but it has no effect in Update.