### PR TITLE
Refactor AppDelegate into a trait

### DIFF
--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -34,9 +34,8 @@ struct State {
 fn main() {
     simple_logger::init().unwrap();
     let main_window = WindowDesc::new(ui_builder).menu(make_menu(&State::default()));
-    let delegate = Box::new(MultiwinDelegate {});
     AppLauncher::with_window(main_window)
-        .delegate(delegate)
+        .delegate(Delegate)
         .launch(State::default())
         .expect("launch failed");
 }
@@ -82,9 +81,9 @@ fn ui_builder() -> impl Widget<State> {
     col
 }
 
-struct MultiwinDelegate {}
+struct Delegate;
 
-impl AppDelegate<State> for MultiwinDelegate {
+impl AppDelegate<State> for Delegate {
     fn event(
         &mut self,
         event: Event,

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -17,7 +17,7 @@
 use druid::menu::{ContextMenu, MenuDesc, MenuItem};
 use druid::widget::{Align, Button, Column, Label, Padding, Row};
 use druid::{
-    AppDelegate, AppLauncher, Command, Data, DelegateCtx, Event, EventCtx, LocalizedString,
+    AppDelegate, AppLauncher, Command, Data, DelegateCtx, Env, Event, EventCtx, LocalizedString,
     Selector, Widget, WindowDesc,
 };
 
@@ -34,8 +34,9 @@ struct State {
 fn main() {
     simple_logger::init().unwrap();
     let main_window = WindowDesc::new(ui_builder).menu(make_menu(&State::default()));
+    let delegate = Box::new(MultiwinDelegate {});
     AppLauncher::with_window(main_window)
-        .delegate(make_delegate())
+        .delegate(delegate)
         .launch(State::default())
         .expect("launch failed");
 }
@@ -81,8 +82,16 @@ fn ui_builder() -> impl Widget<State> {
     col
 }
 
-fn make_delegate() -> AppDelegate<State> {
-    AppDelegate::new().event_handler(|event, data, _env, ctx| {
+struct MultiwinDelegate {}
+
+impl AppDelegate<State> for MultiwinDelegate {
+    fn event(
+        &mut self,
+        event: Event,
+        data: &mut State,
+        _env: &Env,
+        ctx: &mut DelegateCtx,
+    ) -> Option<Event> {
         match event {
             Event::Command(ref cmd) if cmd.selector == druid::command::sys::NEW_FILE => {
                 let new_win = WindowDesc::new(ui_builder).menu(make_menu(data));
@@ -115,7 +124,7 @@ fn make_delegate() -> AppDelegate<State> {
             }
             other => Some(other),
         }
-    })
+    }
 }
 
 #[allow(unused_assignments)]

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -70,8 +70,8 @@ impl<T: Data + 'static> AppLauncher<T> {
     /// Set the [`AppDelegate`].
     ///
     /// [`AppDelegate`]: struct.AppDelegate.html
-    pub fn delegate(mut self, delegate: Box<dyn AppDelegate<T>>) -> Self {
-        self.delegate = Some(delegate);
+    pub fn delegate(mut self, delegate: impl AppDelegate<T> + 'static) -> Self {
+        self.delegate = Some(Box::new(delegate));
         self
     }
 

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -31,7 +31,7 @@ type EnvSetupFn = dyn FnOnce(&mut Env);
 pub struct AppLauncher<T> {
     windows: Vec<WindowDesc<T>>,
     env_setup: Option<Box<EnvSetupFn>>,
-    delegate: Option<AppDelegate<T>>,
+    delegate: Option<Box<dyn AppDelegate<T>>>,
 }
 
 /// A function that can create a widget.
@@ -70,7 +70,7 @@ impl<T: Data + 'static> AppLauncher<T> {
     /// Set the [`AppDelegate`].
     ///
     /// [`AppDelegate`]: struct.AppDelegate.html
-    pub fn delegate(mut self, delegate: AppDelegate<T>) -> Self {
+    pub fn delegate(mut self, delegate: Box<dyn AppDelegate<T>>) -> Self {
         self.delegate = Some(delegate);
         self
     }

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -47,8 +47,6 @@ impl<'a, 'b> DelegateCtx<'a, 'b> {
     }
 }
 
-type EventFn<T> = dyn Fn(Event, &mut T, &Env, &mut DelegateCtx) -> Option<Event> + 'static;
-
 /// A type that provides hooks for handling and modifying top-level events.
 ///
 /// The `AppDelegate` is a struct that is allowed to handle and modify
@@ -57,46 +55,18 @@ type EventFn<T> = dyn Fn(Event, &mut T, &Env, &mut DelegateCtx) -> Option<Event>
 /// It is a natural place for things like window and menu management.
 ///
 /// You customize the `AppDelegate` by passing closures during creation.
-pub struct AppDelegate<T> {
-    event_fn: Option<Box<EventFn<T>>>,
-}
-
-impl<T: Data> AppDelegate<T> {
-    /// Create a new `AppDelegate`.
-    pub fn new() -> Self {
-        AppDelegate { event_fn: None }
-    }
-
-    /// Set the `AppDelegate`'s event handler. This function receives all events,
+pub trait AppDelegate<T: Data> {
+    /// The `AppDelegate`'s event handler. This function receives all events,
     /// before they are passed down the tree.
     ///
     /// The return value of this function will be passed down the tree. This can
     /// be the even that was passed in, a different event, or no event. In all cases,
     /// the `update` method will be called as usual.
-    pub fn event_handler<F>(mut self, f: F) -> Self
-    where
-        F: Fn(Event, &mut T, &Env, &mut DelegateCtx) -> Option<Event> + 'static,
-    {
-        self.event_fn = Some(Box::new(f));
-        self
-    }
-
-    pub(crate) fn event(
+    fn event(
         &mut self,
         event: Event,
         data: &mut T,
         env: &Env,
         ctx: &mut DelegateCtx,
-    ) -> Option<Event> {
-        match self.event_fn.as_ref() {
-            Some(f) => (f)(event, data, env, ctx),
-            None => Some(event),
-        }
-    }
-}
-
-impl<T: Data> Default for AppDelegate<T> {
-    fn default() -> Self {
-        AppDelegate::new()
-    }
+    ) -> Option<Event>;
 }

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -62,11 +62,14 @@ pub trait AppDelegate<T: Data> {
     /// The return value of this function will be passed down the tree. This can
     /// be the even that was passed in, a different event, or no event. In all cases,
     /// the `update` method will be called as usual.
+    #[allow(unused)]
     fn event(
         &mut self,
         event: Event,
         data: &mut T,
         env: &Env,
         ctx: &mut DelegateCtx,
-    ) -> Option<Event>;
+    ) -> Option<Event> {
+        Some(event)
+    }
 }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -54,7 +54,7 @@ pub struct DruidHandler<T: Data> {
 
 /// State shared by all windows in the UI.
 pub(crate) struct AppState<T: Data> {
-    delegate: Option<AppDelegate<T>>,
+    delegate: Option<Box<dyn AppDelegate<T>>>,
     command_queue: VecDeque<(WindowId, Command)>,
     windows: Windows<T>,
     pub(crate) env: Env,
@@ -287,7 +287,11 @@ impl<'a, T: Data + 'static> SingleWindowState<'a, T> {
 }
 
 impl<T: Data + 'static> AppState<T> {
-    pub(crate) fn new(data: T, env: Env, delegate: Option<AppDelegate<T>>) -> Rc<RefCell<Self>> {
+    pub(crate) fn new(
+        data: T,
+        env: Env,
+        delegate: Option<Box<dyn AppDelegate<T>>>,
+    ) -> Rc<RefCell<Self>> {
         Rc::new(RefCell::new(AppState {
             delegate,
             command_queue: VecDeque::new(),


### PR DESCRIPTION
While working on #268, @cmyr and I decided it might be worthwhile to implement `AppDelegate` as a trait rather than an object storing closures.
This is the initial attempt, and it feels nice and simple.

I implemented the trait for an empty struct in `multiwin`, which smells a bit.
This approach makes it possible for the AppDelegate to maintain state separately from the data which is passed to it via events, any thoughts on how that could be useful? Otherwise this approach might need some tweaking.