### PR TITLE
fix: Make Linux use Windows file menu in Multiwin example

### DIFF
--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -135,7 +135,7 @@ fn make_menu<T: Data>(state: &State) -> MenuDesc<T> {
     {
         base = druid::menu::sys::mac::menu_bar();
     }
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     {
         base = base.append(druid::menu::sys::win::file::default());
     }


### PR DESCRIPTION
Closes #282 by using windows default toolbar on Linux for the multi-win example