### PR TITLE
Add scrollbar constants and magic numbers to theme

### DIFF
--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -69,6 +69,7 @@ pub enum Value {
     Color(Color),
     LinearGradient(Arc<LinearGradient>),
     Float(f64),
+    UnsignedInt(u64),
     String(String),
 }
 
@@ -173,6 +174,7 @@ impl Debug for Value {
             // TODO: make PaintBrush impl debug?
             Value::LinearGradient(g) => write!(f, "LinearGradient {:?}", g),
             Value::Float(x) => write!(f, "Float {}", x),
+            Value::UnsignedInt(x) => write!(f, "UnsignedInt {}", x),
             Value::String(s) => write!(f, "String {:?}", s),
         }
     }
@@ -221,6 +223,7 @@ impl Value {
             (Color(_), Color(_)) => true,
             (LinearGradient(_), LinearGradient(_)) => true,
             (Float(_), Float(_)) => true,
+            (UnsignedInt(_), UnsignedInt(_)) => true,
             (String(_), String(_)) => true,
             _ => false,
         }
@@ -239,6 +242,7 @@ impl Data for Value {
             (Color(c1), Color(c2)) => c1.as_rgba_u32() == c2.as_rgba_u32(),
             (LinearGradient(g1), LinearGradient(g2)) => Arc::ptr_eq(g1, g2),
             (Float(f1), Float(f2)) => f1.same(&f2),
+            (UnsignedInt(f1), UnsignedInt(f2)) => f1.same(&f2),
             (String(s1), String(s2)) => s1 == s2,
             _ => false,
         }
@@ -362,6 +366,7 @@ macro_rules! impl_value_type_arc {
 }
 
 impl_value_type_owned!(f64, Float);
+impl_value_type_owned!(u64, UnsignedInt);
 impl_value_type_owned!(Color, Color);
 impl_value_type_owned!(Rect, Rect);
 impl_value_type_owned!(Point, Point);

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -42,16 +42,18 @@ pub const BORDERED_WIDGET_HEIGHT: Key<f64> = Key::new("bordered_widget_height");
 
 pub const SCROLL_BAR_COLOR: Key<Color> = Key::new("scroll_bar_color");
 pub const SCROLL_BAR_BORDER_COLOR: Key<Color> = Key::new("scroll_bar_border_color");
+pub const SCROLL_BAR_MAX_OPACITY: Key<f64> = Key::new("scroll_bar_max_opacity");
+pub const SCROLL_BAR_FADE_DELAY: Key<u64> = Key::new("scroll_bar_fade_time");
 pub const SCROLL_BAR_WIDTH: Key<f64> = Key::new("scroll_bar_width");
 pub const SCROLL_BAR_PAD: Key<f64> = Key::new("scroll_bar_pad");
+pub const SCROLL_BAR_RADIUS: Key<f64> = Key::new("scroll_bar_radius");
+pub const SCROLL_BAR_EDGE_WIDTH: Key<f64> = Key::new("scroll_bar_edge_width");
 
 /// An initial theme.
 pub fn init() -> Env {
     let mut env = Env::default()
         .adding(WINDOW_BACKGROUND_COLOR, Color::rgb8(0x29, 0x29, 0x29))
-
         .adding(LABEL_COLOR, Color::rgb8(0xf0, 0xf0, 0xea))
-
         .adding(PRIMARY_LIGHT, Color::rgb8(0x5c, 0xc4, 0xff))
         .adding(PRIMARY_DARK, Color::rgb8(0x00, 0x8d, 0xdd))
         .adding(BACKGROUND_LIGHT, Color::rgb8(0x3a, 0x3a, 0x3a))
@@ -64,15 +66,17 @@ pub fn init() -> Env {
         .adding(BORDER_LIGHT, Color::rgb8(0xa1, 0xa1, 0xa1))
         .adding(SELECTION_COLOR, Color::rgb8(0xf3, 0x00, 0x21))
         .adding(CURSOR_COLOR, Color::WHITE)
-
         .adding(TEXT_SIZE_NORMAL, 15.0)
         .adding(BASIC_WIDGET_HEIGHT, 18.0)
         .adding(BORDERED_WIDGET_HEIGHT, 24.0)
-
         .adding(SCROLL_BAR_COLOR, Color::rgb8(0xff, 0xff, 0xff))
         .adding(SCROLL_BAR_BORDER_COLOR, Color::rgb8(0x77, 0x77, 0x77))
+        .adding(SCROLL_BAR_MAX_OPACITY, 0.7)
+        .adding(SCROLL_BAR_FADE_DELAY, 1500u64)
         .adding(SCROLL_BAR_WIDTH, 8.)
-        .adding(SCROLL_BAR_PAD, 2.);
+        .adding(SCROLL_BAR_PAD, 2.)
+        .adding(SCROLL_BAR_RADIUS, 5.)
+        .adding(SCROLL_BAR_EDGE_WIDTH, 1.);
 
     #[cfg(target_os = "windows")]
     {

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -42,12 +42,16 @@ pub const BORDERED_WIDGET_HEIGHT: Key<f64> = Key::new("bordered_widget_height");
 
 pub const SCROLL_BAR_COLOR: Key<Color> = Key::new("scroll_bar_color");
 pub const SCROLL_BAR_BORDER_COLOR: Key<Color> = Key::new("scroll_bar_border_color");
+pub const SCROLL_BAR_WIDTH: Key<f64> = Key::new("scroll_bar_width");
+pub const SCROLL_BAR_PAD: Key<f64> = Key::new("scroll_bar_pad");
 
 /// An initial theme.
 pub fn init() -> Env {
     let mut env = Env::default()
         .adding(WINDOW_BACKGROUND_COLOR, Color::rgb8(0x29, 0x29, 0x29))
+
         .adding(LABEL_COLOR, Color::rgb8(0xf0, 0xf0, 0xea))
+
         .adding(PRIMARY_LIGHT, Color::rgb8(0x5c, 0xc4, 0xff))
         .adding(PRIMARY_DARK, Color::rgb8(0x00, 0x8d, 0xdd))
         .adding(BACKGROUND_LIGHT, Color::rgb8(0x3a, 0x3a, 0x3a))
@@ -60,11 +64,15 @@ pub fn init() -> Env {
         .adding(BORDER_LIGHT, Color::rgb8(0xa1, 0xa1, 0xa1))
         .adding(SELECTION_COLOR, Color::rgb8(0xf3, 0x00, 0x21))
         .adding(CURSOR_COLOR, Color::WHITE)
+
         .adding(TEXT_SIZE_NORMAL, 15.0)
         .adding(BASIC_WIDGET_HEIGHT, 18.0)
         .adding(BORDERED_WIDGET_HEIGHT, 24.0)
+
         .adding(SCROLL_BAR_COLOR, Color::rgb8(0xff, 0xff, 0xff))
-        .adding(SCROLL_BAR_BORDER_COLOR, Color::rgb8(0x77, 0x77, 0x77));
+        .adding(SCROLL_BAR_BORDER_COLOR, Color::rgb8(0x77, 0x77, 0x77))
+        .adding(SCROLL_BAR_WIDTH, 8.)
+        .adding(SCROLL_BAR_PAD, 2.);
 
     #[cfg(target_os = "windows")]
     {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -29,9 +29,6 @@ use crate::theme;
 
 use crate::kurbo::{Affine, RoundedRect};
 
-const SCROLL_BAR_WIDTH: f64 = 8.;
-const SCROLL_BAR_PAD: f64 = 2.;
-
 #[derive(Debug, Clone)]
 enum ScrollDirection {
     Horizontal,
@@ -178,32 +175,38 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
         self.scroll_offset
     }
 
-    fn calc_vertical_bar_bounds(&self, viewport: Rect) -> Rect {
+    fn calc_vertical_bar_bounds(&self, viewport: Rect, env: &Env) -> Rect {
+        let bar_width = env.get(theme::SCROLL_BAR_WIDTH);
+        let bar_pad = env.get(theme::SCROLL_BAR_PAD);
+
         let scale_y = viewport.height() / self.child_size.height;
 
         let top_y_offset = (scale_y * self.scroll_offset.y).ceil();
         let bottom_y_offset = (scale_y * viewport.height()).ceil() + top_y_offset;
 
-        let x0 = self.scroll_offset.x + viewport.width() - SCROLL_BAR_WIDTH - SCROLL_BAR_PAD;
-        let y0 = self.scroll_offset.y + top_y_offset + SCROLL_BAR_PAD;
+        let x0 = self.scroll_offset.x + viewport.width() - bar_width - bar_pad;
+        let y0 = self.scroll_offset.y + top_y_offset + bar_pad;
 
-        let x1 = self.scroll_offset.x + viewport.width() - SCROLL_BAR_PAD;
-        let y1 = self.scroll_offset.y + bottom_y_offset - (SCROLL_BAR_PAD * 2.) - SCROLL_BAR_WIDTH;
+        let x1 = self.scroll_offset.x + viewport.width() - bar_pad;
+        let y1 = self.scroll_offset.y + bottom_y_offset - (bar_pad * 2.) - bar_width;
 
         Rect::new(x0, y0, x1, y1)
     }
 
-    fn calc_horizontal_bar_bounds(&self, viewport: Rect) -> Rect {
+    fn calc_horizontal_bar_bounds(&self, viewport: Rect, env: &Env) -> Rect {
+        let bar_width = env.get(theme::SCROLL_BAR_WIDTH);
+        let bar_pad = env.get(theme::SCROLL_BAR_PAD);
+
         let scale_x = viewport.width() / self.child_size.width;
 
         let left_x_offset = (scale_x * self.scroll_offset.x).ceil();
         let right_x_offset = (scale_x * viewport.width()).ceil() + left_x_offset;
 
-        let x0 = self.scroll_offset.x + left_x_offset + SCROLL_BAR_PAD;
-        let y0 = self.scroll_offset.y + viewport.height() - SCROLL_BAR_WIDTH - SCROLL_BAR_PAD;
+        let x0 = self.scroll_offset.x + left_x_offset + bar_pad;
+        let y0 = self.scroll_offset.y + viewport.height() - bar_width - bar_pad;
 
-        let x1 = self.scroll_offset.x + right_x_offset - (SCROLL_BAR_PAD * 2.) - SCROLL_BAR_WIDTH;
-        let y1 = self.scroll_offset.y + viewport.height() - SCROLL_BAR_PAD;
+        let x1 = self.scroll_offset.x + right_x_offset - (bar_pad * 2.) - bar_width;
+        let y1 = self.scroll_offset.y + viewport.height() - bar_pad;
 
         Rect::new(x0, y0, x1, y1)
     }
@@ -225,31 +228,31 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
 
         // Vertical bar
         if viewport.height() < self.child_size.height {
-            let rect = RoundedRect::from_rect(self.calc_vertical_bar_bounds(viewport), 5.0);
+            let rect = RoundedRect::from_rect(self.calc_vertical_bar_bounds(viewport, &env), 5.0);
             paint_ctx.render_ctx.fill(rect, &brush);
             paint_ctx.render_ctx.stroke(rect, &border_brush, 1.0);
         }
 
         // Horizontal bar
         if viewport.width() < self.child_size.width {
-            let rect = RoundedRect::from_rect(self.calc_horizontal_bar_bounds(viewport), 5.0);
+            let rect = RoundedRect::from_rect(self.calc_horizontal_bar_bounds(viewport, &env), 5.0);
             paint_ctx.render_ctx.fill(rect, &brush);
             paint_ctx.render_ctx.stroke(rect, &border_brush, 1.0);
         }
     }
 
-    fn point_hits_vertical_bar(&self, viewport: Rect, pos: Point) -> bool {
+    fn point_hits_vertical_bar(&self, viewport: Rect, pos: Point, env: &Env) -> bool {
         if viewport.height() < self.child_size.height {
-            let bounds = self.calc_vertical_bar_bounds(viewport);
+            let bounds = self.calc_vertical_bar_bounds(viewport, &env);
             return pos.y > bounds.y0 && pos.y < bounds.y1 && pos.x > bounds.x0;
         }
 
         false
     }
 
-    fn point_hits_horizontal_bar(&self, viewport: Rect, pos: Point) -> bool {
+    fn point_hits_horizontal_bar(&self, viewport: Rect, pos: Point, env: &Env) -> bool {
         if viewport.width() < self.child_size.width {
-            let bounds = self.calc_horizontal_bar_bounds(viewport);
+            let bounds = self.calc_horizontal_bar_bounds(viewport, &env);
             return pos.x > bounds.x0 && pos.x < bounds.x1 && pos.y > bounds.y0;
         }
 
@@ -306,14 +309,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     match self.scroll_bars.held {
                         BarHeldState::Vertical(offset) => {
                             let scale_y = viewport.height() / self.child_size.height;
-                            let bounds = self.calc_vertical_bar_bounds(viewport);
+                            let bounds = self.calc_vertical_bar_bounds(viewport, &env);
                             let mouse_y = event.pos.y + self.scroll_offset.y;
                             let delta = mouse_y - bounds.y0 - offset;
                             self.scroll(Vec2::new(0f64, (delta / scale_y).ceil()), size);
                         }
                         BarHeldState::Horizontal(offset) => {
                             let scale_x = viewport.width() / self.child_size.width;
-                            let bounds = self.calc_horizontal_bar_bounds(viewport);
+                            let bounds = self.calc_horizontal_bar_bounds(viewport, &env);
                             let mouse_x = event.pos.x + self.scroll_offset.x;
                             let delta = mouse_x - bounds.x0 - offset;
                             self.scroll(Vec2::new((delta / scale_x).ceil(), 0f64), size);
@@ -331,8 +334,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             Event::MouseMoved(event) | Event::MouseDown(event) => {
                 let mut transformed_event = event.clone();
                 transformed_event.pos += self.scroll_offset;
-                self.point_hits_vertical_bar(viewport, transformed_event.pos)
-                    || self.point_hits_horizontal_bar(viewport, transformed_event.pos)
+                self.point_hits_vertical_bar(viewport, transformed_event.pos, &env)
+                    || self.point_hits_horizontal_bar(viewport, transformed_event.pos, &env)
             }
             _ => false,
         } {
@@ -340,7 +343,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 Event::MouseMoved(event) => {
                     let mut transformed_event = event.clone();
                     transformed_event.pos += self.scroll_offset;
-                    if self.point_hits_vertical_bar(viewport, transformed_event.pos) {
+                    if self.point_hits_vertical_bar(viewport, transformed_event.pos, &env) {
                         self.scroll_bars.hovered = BarHoveredState::Vertical;
                     } else {
                         self.scroll_bars.hovered = BarHoveredState::Horizontal;
@@ -353,13 +356,13 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 Event::MouseDown(event) => {
                     let pos = event.pos + self.scroll_offset;
 
-                    if self.point_hits_vertical_bar(viewport, pos) {
+                    if self.point_hits_vertical_bar(viewport, pos, &env) {
                         self.scroll_bars.held = BarHeldState::Vertical(
-                            pos.y - self.calc_vertical_bar_bounds(viewport).y0,
+                            pos.y - self.calc_vertical_bar_bounds(viewport, &env).y0,
                         );
-                    } else if self.point_hits_horizontal_bar(viewport, pos) {
+                    } else if self.point_hits_horizontal_bar(viewport, pos, &env) {
                         self.scroll_bars.held = BarHeldState::Horizontal(
-                            pos.x - self.calc_horizontal_bar_bounds(viewport).x0,
+                            pos.x - self.calc_horizontal_bar_bounds(viewport, &env).x0,
                         );
                     }
                 }
@@ -376,8 +379,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     let mut transformed_event = event.clone();
                     transformed_event.pos += self.scroll_offset;
                     let currently_hovered = self
-                        .point_hits_vertical_bar(viewport, transformed_event.pos)
-                        || self.point_hits_horizontal_bar(viewport, transformed_event.pos);
+                        .point_hits_vertical_bar(viewport, transformed_event.pos, &env)
+                        || self.point_hits_horizontal_bar(viewport, transformed_event.pos, &env);
                     if self.scroll_bars.hovered.is_hovered() && !currently_hovered {
                         self.scroll_bars.hovered = BarHoveredState::None;
                         self.reset_scrollbar_fade(ctx);


### PR DESCRIPTION
This *should be* (:crossed_fingers:) a short and sweet patch which adds a number of scrollbar constants to the theme. I didn't add an option to enable/disable scrollbar overlap as it seemed like more discussion is required about how to handle overlap, floating, and default style on different platforms.