### PR TITLE
Make WindowId available in WindowDesc, tweak AppDelegate API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "druid"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "druid-derive 0.1.1",
  "druid-shell 0.3.2",
@@ -216,7 +216,7 @@ dependencies = [
 name = "druid-derive"
 version = "0.1.1"
 dependencies = [
- "druid 0.3.3",
+ "druid 0.4.0",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -16,4 +16,4 @@ quote = "1.0.2"
 proc-macro2 = "1.0.4"
 
 [dev-dependencies]
-druid = { path = "../druid", version = "0.3.1" }
+druid = { path = "../druid", version = "0.4.0" }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid"
-version = "0.3.3"
+version = "0.4.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Data-oriented Rust UI design toolkit."

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -20,7 +20,6 @@ use druid::{
     AppDelegate, AppLauncher, Command, Data, DelegateCtx, Env, Event, EventCtx, LocalizedString,
     Selector, Widget, WindowDesc, WindowId,
 };
-use druid_shell::window::WinCtx;
 
 use log::info;
 
@@ -93,7 +92,6 @@ impl AppDelegate<State> for Delegate {
         data: &mut State,
         _env: &Env,
         ctx: &mut DelegateCtx,
-        _win_ctx: &mut dyn WinCtx,
     ) -> Option<Event> {
         match event {
             Event::Command(ref cmd) if cmd.selector == druid::command::sys::NEW_FILE => {

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -47,7 +47,11 @@ pub struct WindowDesc<T> {
     pub(crate) title: Option<LocalizedString<T>>,
     pub(crate) size: Option<Size>,
     pub(crate) menu: Option<MenuDesc<T>>,
-    //TODO: more things you can configure on a window, like size?
+    /// The `WindowId` that will be assigned to this window.
+    ///
+    /// This can be used to track a window from when it is launched and when
+    /// it actually connects.
+    pub id: WindowId,
 }
 
 impl<T: Data + 'static> AppLauncher<T> {
@@ -129,6 +133,7 @@ impl<T: Data + 'static> WindowDesc<T> {
             title: None,
             size: None,
             menu: MenuDesc::platform_default(),
+            id: WindowId::next(),
         }
     }
 
@@ -167,8 +172,7 @@ impl<T: Data + 'static> WindowDesc<T> {
             .as_mut()
             .map(|m| m.build_window_menu(&state.borrow().data, &state.borrow().env));
 
-        let id = WindowId::next();
-        let handler = DruidHandler::new_shared(state.clone(), id);
+        let handler = DruidHandler::new_shared(state.clone(), self.id);
 
         let mut builder = WindowBuilder::new();
         builder.set_handler(Box::new(handler));
@@ -183,7 +187,7 @@ impl<T: Data + 'static> WindowDesc<T> {
         let root = (self.root_builder)();
         state
             .borrow_mut()
-            .add_window(id, Window::new(root, title, menu));
+            .add_window(self.id, Window::new(root, title, menu));
 
         Ok(WindowHandle {
             inner: builder.build()?,

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -16,13 +16,12 @@
 
 use std::collections::VecDeque;
 
-use crate::{Command, Data, Env, Event, WinCtx, WindowId};
+use crate::{Command, Data, Env, Event, WindowId};
 
 /// A context passed in to [`AppDelegate`] functions.
 pub struct DelegateCtx<'a> {
     pub(crate) source_id: WindowId,
     pub(crate) command_queue: &'a mut VecDeque<(WindowId, Command)>,
-    // pub(crate) win_ctx: &'a mut dyn WinCtx<'b>,
 }
 
 impl<'a> DelegateCtx<'a> {
@@ -62,7 +61,6 @@ pub trait AppDelegate<T: Data> {
         data: &mut T,
         env: &Env,
         ctx: &mut DelegateCtx,
-        win_ctx: &mut dyn WinCtx,
     ) -> Option<Event> {
         Some(event)
     }


### PR DESCRIPTION
This was motivated by actually trying to use the new AppDelegate
methods as I'd intended in Runebender.

I would like some way to track a window from the point where it
is requested to the point where it actually connects. The simplest
way to do this was to make `WindowId` be decided when `WindowDesc`
is created; you can then stash the `WindowId` at that point, and
check it against whatever id comes back when a window connects.

In addition, this tweaks the AppDelegate::event method somewhat;
it removes the `WinCtx` param. It isn't clear that access to the
`WinCtx` is actually necessary here; if it is we can revisit at
some point in the future.

This also refactors the `delegate_event` fn in win_handler.rs
to use the new `with_delegate` helper method.

As this breaks existing AppDelegate use I'm going to go ahead
and make this v0.4.0.