### PR TITLE
Fix everything being broken if no AppDelegate is set

### DIFF
--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -334,9 +334,11 @@ impl<T: Data + 'static> AppState<T> {
     }
 
     fn delegate_event(&mut self, id: WindowId, event: Event) -> Option<Event> {
-        match self.with_delegate(id, |del, data, env, ctx| del.event(event, data, env, ctx)) {
-            Some(Some(event)) => Some(event),
-            _ => None,
+        if self.delegate.is_some() {
+            self.with_delegate(id, |del, data, env, ctx| del.event(event, data, env, ctx))
+                .unwrap()
+        } else {
+            Some(event)
         }
     }
 


### PR DESCRIPTION
This was a logic error where we would always return `None` when
attempting to forward an event to the AppDelegate, if there
was no delegate set. We should instead always return `Some(event)`.