### PR TITLE
Allow #[derive(Data)] on empty structs

### DIFF
--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -69,6 +69,10 @@ impl Fields {
         Ok(Fields { kind, fields })
     }
 
+    pub fn len(&self) -> usize {
+        self.fields.len()
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &Field> {
         self.fields.iter()
     }

--- a/druid-derive/tests/data.rs
+++ b/druid-derive/tests/data.rs
@@ -1,0 +1,73 @@
+//! Test #[derive(Data)]
+
+use druid::Data;
+
+#[derive(Data, Clone)]
+struct PlainStruct;
+
+#[derive(Data, Clone)]
+struct EmptyTupleStruct();
+
+#[derive(Data, Clone)]
+
+struct SingleTupleStruct(bool);
+
+#[derive(Data, Clone)]
+struct MultiTupleStruct(bool, i64, String);
+
+#[derive(Data, Clone)]
+struct EmptyFieldStruct {}
+
+#[derive(Data, Clone)]
+struct SingleFieldStruct {
+    a: bool,
+}
+
+#[derive(Data, Clone)]
+struct MultiFieldStruct {
+    a: bool,
+    b: i64,
+    c: String,
+}
+
+#[test]
+fn test_data_derive_same() {
+    let plain = PlainStruct;
+    assert!(plain.same(&plain));
+
+    let empty_tuple = EmptyTupleStruct();
+    assert!(empty_tuple.same(&empty_tuple));
+
+    let singletuple = SingleTupleStruct(true);
+    assert!(singletuple.same(&singletuple));
+    assert_eq!(false, singletuple.same(&SingleTupleStruct(false)));
+
+    let multituple = MultiTupleStruct(false, 33, "Test".to_string());
+    assert!(multituple.same(&multituple));
+    assert_eq!(
+        false,
+        multituple.same(&MultiTupleStruct(true, 33, "Test".to_string()))
+    );
+
+    let empty_field = EmptyFieldStruct {};
+    assert!(empty_field.same(&empty_field));
+
+    let singlefield = SingleFieldStruct { a: true };
+    assert!(singlefield.same(&singlefield));
+    assert_eq!(false, singlefield.same(&SingleFieldStruct { a: false }));
+
+    let multifield = MultiFieldStruct {
+        a: false,
+        b: 33,
+        c: "Test".to_string(),
+    };
+    assert!(multifield.same(&multifield));
+    assert_eq!(
+        false,
+        multifield.same(&MultiFieldStruct {
+            a: false,
+            b: 33,
+            c: "Fail".to_string()
+        })
+    );
+}


### PR DESCRIPTION
Detect structs with no fields and generate no-op
compare function accordingly.