### PR TITLE
[mac] Fix capitalization of system cursor name

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -807,7 +807,7 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
                 Cursor::OpenHand => msg_send![nscursor, openHandCursor],
                 Cursor::NotAllowed => msg_send![nscursor, operationNotAllowedCursor],
                 Cursor::ResizeLeftRight => msg_send![nscursor, resizeLeftRightCursor],
-                Cursor::ResizeUpDown => msg_send![nscursor, ResizeUpDownCursor],
+                Cursor::ResizeUpDown => msg_send![nscursor, resizeUpDownCursor],
             };
             let () = msg_send![cursor, set];
         }


### PR DESCRIPTION
noticed this while reviewing #259 