### PR TITLE
Change Split to keep dragging until MouseUp

### DIFF
--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -279,12 +279,10 @@ impl<T: Data> Widget<T> for Split<T> {
                 }
                 Event::MouseMoved(mouse) => {
                     if ctx.is_active() {
-                        if !ctx.is_hot() {
-                            ctx.set_active(false);
-                        }
                         self.update_splitter(ctx.base_state.size(), mouse.pos);
                         ctx.invalidate();
                     }
+
                     if ctx.is_hot() && self.splitter_hit_test(ctx.base_state.size(), mouse.pos) {
                         match self.split_direction {
                             Axis::Vertical => ctx.set_cursor(&Cursor::ResizeUpDown),

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -283,7 +283,9 @@ impl<T: Data> Widget<T> for Split<T> {
                         ctx.invalidate();
                     }
 
-                    if ctx.is_hot() && self.splitter_hit_test(ctx.base_state.size(), mouse.pos) {
+                    if ctx.is_hot() && self.splitter_hit_test(ctx.base_state.size(), mouse.pos)
+                        || ctx.is_active()
+                    {
                         match self.split_direction {
                             Axis::Vertical => ctx.set_cursor(&Cursor::ResizeUpDown),
                             Axis::Horizontal => ctx.set_cursor(&Cursor::ResizeLeftRight),


### PR DESCRIPTION
I'd like to make a small change to the new Split Widget.
Currently when the MouseMoved Event is handled there is a if branch checking if the widget is no longer hot.
When that check succeeds the dragging stops.
This feels unintuitive and is inconsistent with most common UIs.

This PR removes that block, causing the the drag to keep happening until the MouseUp event is triggered.