### PR TITLE
druid-shell/src/mac: call finishLaunching, set window level to 

### DIFF
--- a/druid-shell/src/mac/mod.rs
+++ b/druid-shell/src/mac/mod.rs
@@ -161,6 +161,7 @@ impl WindowBuilder {
                 NO,
             );
 
+            window.setLevel_(4);
             window.cascadeTopLeftFromPoint_(NSPoint::new(20.0, 20.0));
             window.setTitle_(make_nsstring(&self.title));
             // TODO: this should probably be a tracking area instead

--- a/druid-shell/src/mac/win_main.rs
+++ b/druid-shell/src/mac/win_main.rs
@@ -32,6 +32,7 @@ impl RunLoop {
 
             let ns_app = NSApp();
             ns_app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
+            ns_app.finishLaunching();
             RunLoop { ns_app }
         }
     }


### PR DESCRIPTION
CGWindowLevelkey normalWindow.

I can't test this not having a mac, but this is an attempt to fix #43, 
So, i would appreciate it if someone with a mac could test it.

I believe it should work because finishLaunching should initiate the connection between the app and the window server allowing the setWindowLevel_ (called before run) to be received by the window sever.

As it is the app -> window server event mechanism isn't being registered until run(), at which point setWindowLevel_ has already been called, causing the window server not to receive the windowLevel.

This is similar to [futurepaul PR 54](https://github.com/xi-editor/druid/pull/54), but also adds the call to finishLaunching.

I had initially put this into it's own function `startup_ritual`, but it seemed better to just put it into `RunLoop::new` unless there is a purpose for being able to make some call in between `new()` and `startup_ritual` (or whatever good name for it would be).

cc @futurepaul 