### PR TITLE
set is_hot upon MouseDown if the target is not already hot.

### DIFF
--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -567,7 +567,13 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 Event::Size(*size)
             }
             Event::MouseDown(mouse_event) => {
-                recurse = had_active || !ctx.had_active && rect.winding(mouse_event.pos) != 0;
+                let had_hot = child_ctx.base_state.is_hot;
+                let now_hot = rect.winding(mouse_event.pos) != 0;
+                if (!had_hot) && now_hot {
+                    child_ctx.base_state.is_hot = true;
+                    hot_changed = Some(true);
+                }
+                recurse = had_active || !ctx.had_active && now_hot;
                 let mut mouse_event = mouse_event.clone();
                 mouse_event.pos -= rect.origin().to_vec2();
                 Event::MouseDown(mouse_event)


### PR DESCRIPTION
I'm not sure about this, it seemed tricky to get right in examples/slider
is it correct that we may change child_ctxt but shouldn't recurse?

Anyhow the behavior this patch tries to change is that on at least gtk, if you 
start the application, and the mouse is already hovering over a button, and click it without moving the mouse.

Basically because the mouse never moved, the widget is not hot, and it gets ignored by button.
I tried to fix this by setting is_hot, if it isn't already.