### PR TITLE
Wrapper types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,8 +201,8 @@ dependencies = [
 name = "druid"
 version = "0.4.0"
 dependencies = [
- "druid-derive 0.1.1",
- "druid-shell 0.3.2",
+ "druid-derive 0.1.2",
+ "druid-shell 0.4.0",
  "fluent-bundle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-locale 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "druid-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "druid 0.4.0",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "druid-shell"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-derive"
-version = "0.1.1"
+version = "0.1.2"
 license = "Apache-2.0"
 authors = ["Druid authors"]
 description = "derive impls for druid, a Rust UI toolkit."

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-shell"
-version = "0.3.2"
+version = "0.4.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Platform abstracting application shell used for druid toolkit."

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -19,13 +19,9 @@ use time::get_time;
 use piet_common::kurbo::{Line, Rect};
 use piet_common::{Color, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
-#[cfg(target_os = "windows")]
-use druid_shell::platform::PresentStrategy;
-
 use druid_shell::keyboard::KeyEvent;
-use druid_shell::platform::WindowBuilder;
 use druid_shell::runloop;
-use druid_shell::window::{WinCtx, WinHandler, WindowHandle};
+use druid_shell::window::{WinCtx, WinHandler, WindowBuilder, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
@@ -124,10 +120,6 @@ fn main() {
     };
     builder.set_handler(Box::new(perf_test));
     builder.set_title("Performance tester");
-
-    // Note: experiment with changing this
-    #[cfg(target_os = "windows")]
-    builder.set_present_strategy(PresentStrategy::FlipRedirect);
 
     let window = builder.build().unwrap();
     window.show();

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -22,9 +22,10 @@ use druid_shell::dialog::{FileDialogOptions, FileSpec};
 use druid_shell::hotkey::{HotKey, SysMods};
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::menu::Menu;
-use druid_shell::platform::WindowBuilder;
 use druid_shell::runloop;
-use druid_shell::window::{Cursor, MouseEvent, TimerToken, WinCtx, WinHandler, WindowHandle};
+use druid_shell::window::{
+    Cursor, MouseEvent, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle,
+};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);

--- a/druid-shell/src/application.rs
+++ b/druid-shell/src/application.rs
@@ -1,0 +1,53 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The top-level application type.
+
+use crate::clipboard::ClipboardItem;
+use crate::platform::application as platform;
+
+//TODO: we may want to make the user create an instance of this (Application::global()?)
+//but for now I'd like to keep changes minimal.
+/// The top level application object.
+pub struct Application;
+
+impl Application {
+    /// Terminate the application.
+    pub fn quit() {
+        platform::Application::quit()
+    }
+
+    // TODO: do these two go in some kind of PlatformExt trait?
+    /// Hide the application this window belongs to. (cmd+H)
+    pub fn hide() {
+        #[cfg(all(target_os = "macos", not(feature = "use_gtk")))]
+        platform::Application::hide()
+    }
+
+    /// Hide all other applications. (cmd+opt+H)
+    pub fn hide_others() {
+        #[cfg(all(target_os = "macos", not(feature = "use_gtk")))]
+        platform::Application::hide_others()
+    }
+
+    /// Returns the contents of the clipboard, if any.
+    pub fn get_clipboard_contents() -> Option<ClipboardItem> {
+        platform::Application::get_clipboard_contents()
+    }
+
+    /// Sets the contents of the system clipboard.
+    pub fn set_clipboard_contents(item: ClipboardItem) {
+        platform::Application::set_clipboard_contents(item)
+    }
+}

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -15,6 +15,7 @@
 //! Platform abstraction for druid toolkit.
 
 #![deny(intra_doc_link_resolution_failure)]
+#![allow(clippy::new_without_default)]
 
 pub use piet_common as piet;
 pub use piet_common::kurbo;
@@ -31,6 +32,7 @@ extern crate objc;
 #[macro_use]
 extern crate lazy_static;
 
+pub mod application;
 pub mod clipboard;
 mod common_util;
 pub mod dialog;
@@ -38,13 +40,14 @@ pub mod error;
 pub mod hotkey;
 pub mod keyboard;
 pub mod keycodes;
+pub mod menu;
+//TODO: don't expose this directly? currently making this private causes
+//a bunch of compiler warnings, so let's revisit that later.
 pub mod platform;
+pub mod runloop;
 pub mod window;
 
 pub use error::Error;
-pub use platform::application;
-pub use platform::menu;
-pub use platform::util;
-pub use platform::win_main as runloop; // TODO: rename to "runloop"
-pub use platform::WindowBuilder;
-pub use util::{get_locale, init};
+pub use window::WindowBuilder;
+//TODO: move these to Application?
+pub use platform::util::{self, get_locale, init};

--- a/druid-shell/src/menu.rs
+++ b/druid-shell/src/menu.rs
@@ -1,0 +1,84 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::hotkey::HotKey;
+use crate::platform::menu as platform;
+
+/// A menu object.
+///
+/// This may be a window menu, an application menu (macOS) or a context (right-click)
+/// menu.
+///
+/// # Configuring menus
+///
+/// Currently, a menu and its items cannot be changed once created. If you need
+/// to change anything about a menu (for instance, disabling or selecting items)
+/// you need to create a new menu with the desired properties.
+pub struct Menu(platform::Menu);
+
+impl Menu {
+    /// Create a new empty window or application menu.
+    pub fn new() -> Menu {
+        Menu(platform::Menu::new())
+    }
+
+    /// Create a new empty context menu.
+    ///
+    /// Some platforms distinguish between these types of menus, and some
+    /// do not.
+    pub fn new_for_popup() -> Menu {
+        Menu(platform::Menu::new_for_popup())
+    }
+
+    /// Consume this `Menu`, returning the platform menu object.
+    pub(crate) fn into_inner(self) -> platform::Menu {
+        self.0
+    }
+
+    /// Add the provided `Menu` as a submenu of self, with the provided title.
+    pub fn add_dropdown(&mut self, menu: Menu, text: &str, enabled: bool) {
+        self.0.add_dropdown(menu.0, text, enabled)
+    }
+
+    /// Add an item to this menu.
+    ///
+    /// The `id` should uniquely identify this item. If the user selects this
+    /// item, the responsible [`WindowHandler`]'s [`command()`] method will
+    /// be called with this `id`. If the `enabled` argument is false, the menu
+    /// item will be grayed out; the hotkey will also be disabled.
+    /// If the `selected` argument is `true`, the menu will have a checkmark
+    /// or platform appropriate equivalent indicating that it is currently selected.
+    /// The `key` argument is an optional [`HotKey`] that will be registered
+    /// with the system.
+    ///
+    ///
+    /// [`WindowHandler`]: trait.WindowHandler.html
+    /// [`command()`]: trait.WindowHandler.html#tymethod.command
+    /// [`HotKey`]: struct.HotKey.html
+    pub fn add_item(
+        &mut self,
+        id: u32,
+        text: &str,
+        key: Option<&HotKey>,
+        enabled: bool,
+        selected: bool,
+    ) {
+        self.0.add_item(id, text, key, enabled, selected)
+    }
+
+    /// Add a seperator to the menu.
+    pub fn add_separator(&mut self) {
+        self.0.add_separator()
+    }
+}

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -33,4 +33,8 @@ impl Application {
             None
         }
     }
+
+    pub fn set_clipboard_contents(_item: ClipboardItem) {
+        log::warn!("set_clipboard_contents is unimplemented on GTK");
+    }
 }

--- a/druid-shell/src/platform/gtk/mod.rs
+++ b/druid-shell/src/platform/gtk/mod.rs
@@ -29,8 +29,8 @@ use gtk::prelude::*;
 use gtk::{AccelGroup, ApplicationWindow};
 
 use piet_common::{Piet, RenderContext};
+use runloop::with_application;
 use util::assert_main_thread;
-use win_main::with_application;
 
 use crate::clipboard::ClipboardItem;
 use crate::dialog::FileDialogOptions;
@@ -44,8 +44,8 @@ use crate::Error;
 pub mod application;
 pub mod dialog;
 pub mod menu;
+pub mod runloop;
 pub mod util;
-pub mod win_main;
 
 /// Taken from https://gtk-rs.org/docs-src/tutorial/closures
 /// It is used to reduce the boilerplate of setting up gtk callbacks
@@ -394,9 +394,7 @@ impl WindowBuilder {
         win_state
             .handler
             .borrow_mut()
-            .connect(&window::WindowHandle {
-                inner: handle.clone(),
-            });
+            .connect(&handle.clone().into());
 
         Ok(handle)
     }
@@ -498,7 +496,7 @@ impl WindowHandle {
         }
     }
 
-    pub fn show_context_menu(&self, menu: Menu, _x: f64, _y: f64) {
+    pub fn show_context_menu(&self, menu: Menu, _pos: Point) {
         if let Some(state) = self.state.upgrade() {
             let window = &state.window;
 
@@ -769,11 +767,5 @@ fn hardware_keycode_to_keyval(keycode: u16) -> Option<u32> {
         } else {
             None
         }
-    }
-}
-
-impl Default for WindowBuilder {
-    fn default() -> Self {
-        WindowBuilder::new()
     }
 }

--- a/druid-shell/src/platform/gtk/runloop.rs
+++ b/druid-shell/src/platform/gtk/runloop.rs
@@ -98,9 +98,3 @@ where
         f(app)
     })
 }
-
-impl Default for RunLoop {
-    fn default() -> Self {
-        RunLoop::new()
-    }
-}

--- a/druid-shell/src/platform/mac/menu.rs
+++ b/druid-shell/src/platform/mac/menu.rs
@@ -104,12 +104,6 @@ impl Menu {
     }
 }
 
-impl Default for Menu {
-    fn default() -> Self {
-        Menu::new()
-    }
-}
-
 impl HotKey {
     /// Return the string value of this hotkey, for use with Cocoa `NSResponder`
     /// objects.

--- a/druid-shell/src/platform/mac/runloop.rs
+++ b/druid-shell/src/platform/mac/runloop.rs
@@ -51,9 +51,3 @@ pub fn request_quit() {
         let () = msg_send![NSApp(), terminate: nil];
     }
 }
-
-impl Default for RunLoop {
-    fn default() -> Self {
-        RunLoop::new()
-    }
-}

--- a/druid-shell/src/platform/windows/menu.rs
+++ b/druid-shell/src/platform/windows/menu.rs
@@ -109,9 +109,3 @@ impl Menu {
         }
     }
 }
-
-impl Default for Menu {
-    fn default() -> Self {
-        Menu::new()
-    }
-}

--- a/druid-shell/src/platform/windows/runloop.rs
+++ b/druid-shell/src/platform/windows/runloop.rs
@@ -131,9 +131,3 @@ impl RunLoopHandle {
         self.0.lock().unwrap().listeners.push(listener);
     }
 }
-
-impl Default for RunLoop {
-    fn default() -> Self {
-        RunLoop::new()
-    }
-}

--- a/druid-shell/src/runloop.rs
+++ b/druid-shell/src/runloop.rs
@@ -1,0 +1,44 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The main application loop.
+
+use crate::platform::runloop as platform;
+
+/// The main application loop.
+pub struct RunLoop(platform::RunLoop);
+
+impl RunLoop {
+    /// Create a new `RunLoop`.
+    ///
+    /// The runloop does not start until [`RunLoop::new`] is called.
+    ///
+    /// [`RunLoop::new`]: struct.RunLoop.html#method.run
+    pub fn new() -> RunLoop {
+        RunLoop(platform::RunLoop::new())
+    }
+
+    /// Start the runloop.
+    ///
+    /// This will block the current thread until the program has finished executing.
+    pub fn run(&mut self) {
+        self.0.run()
+    }
+}
+
+//TODO: deprecate this in favor of methods on `Application`? This functionality is duplicated
+/// Request to quit the application, exiting the runloop.
+pub fn request_quit() {
+    platform::request_quit()
+}

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -32,7 +32,7 @@ default-features = false
 
 [dependencies.druid-shell]
 path = "../druid-shell"
-version = "0.3.2"
+version = "0.4.0"
 
 [dependencies.druid-derive]
 path = "../druid-derive"

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -189,9 +189,7 @@ impl<T: Data + 'static> WindowDesc<T> {
             .borrow_mut()
             .add_window(self.id, Window::new(root, title, menu));
 
-        Ok(WindowHandle {
-            inner: builder.build()?,
-        })
+        builder.build()
     }
 
     /// Set the menu for this window.

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -254,9 +254,7 @@ impl<'a, T: Data + 'static> SingleWindowState<'a, T> {
             }
         };
         let platform_menu = menu.build_popup_menu(&self.data, &self.env);
-        self.state
-            .handle
-            .show_context_menu(platform_menu, point.x, point.y);
+        self.state.handle.show_context_menu(platform_menu, point);
         self.window.context_menu = Some(menu);
     }
 


### PR DESCRIPTION
This moves to the pattern described in #310, where every public
type in druid-shell is defined as a newtype in the main
module, wrapping a concrete type on each platform.

There's a bunch of cleanup work to do, for which I have left
copious TODOs; but I would like to get this up as a proof-of-concept
before making more substantial changes.

-----

this includes #312, which should go in first