### PR TITLE
[shell] Move mouse-related types to mouse.rs

### DIFF
--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -22,10 +22,9 @@ use druid_shell::dialog::{FileDialogOptions, FileSpec};
 use druid_shell::hotkey::{HotKey, SysMods};
 use druid_shell::keyboard::{KeyEvent, KeyModifiers};
 use druid_shell::menu::Menu;
+use druid_shell::mouse::{Cursor, MouseEvent};
 use druid_shell::runloop;
-use druid_shell::window::{
-    Cursor, MouseEvent, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle,
-};
+use druid_shell::window::{TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -41,6 +41,7 @@ pub mod hotkey;
 pub mod keyboard;
 pub mod keycodes;
 pub mod menu;
+pub mod mouse;
 //TODO: don't expose this directly? currently making this private causes
 //a bunch of compiler warnings, so let's revisit that later.
 pub mod platform;

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -1,0 +1,82 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Common types for representing mouse events and state
+
+use crate::kurbo::Point;
+
+use crate::keyboard::KeyModifiers;
+
+/// The state of the mouse for a click, mouse-up, or move event.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MouseEvent {
+    /// The location of the mouse in the current window.
+    ///
+    /// This is in px units, that is, adjusted for hi-dpi.
+    pub pos: Point,
+    /// Keyboard modifiers at the time of the mouse event.
+    pub mods: KeyModifiers,
+    /// The number of mouse clicks associated with this event. This will always
+    /// be `0` for a mouse-up event.
+    pub count: u32,
+    /// The currently pressed button in the case of a move or click event,
+    /// or the released button in the case of a mouse-up event.
+    pub button: MouseButton,
+}
+
+/// An indicator of which mouse button was pressed.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum MouseButton {
+    /// Left mouse button.
+    Left,
+    /// Middle mouse button.
+    Middle,
+    /// Right mouse button.
+    Right,
+    /// First X button.
+    X1,
+    /// Second X button.
+    X2,
+}
+
+impl MouseButton {
+    /// Returns `true` if this is the left mouse button.
+    #[inline(always)]
+    pub fn is_left(self) -> bool {
+        self == MouseButton::Left
+    }
+
+    /// Returns `true` if this is the right mouse button.
+    #[inline(always)]
+    pub fn is_right(self) -> bool {
+        self == MouseButton::Right
+    }
+}
+
+//NOTE: this currently only contains cursors that are included by default on
+//both Windows and macOS. We may want to provide polyfills for various additional cursors,
+//and we will also want to add some mechanism for adding custom cursors.
+/// Mouse cursors.
+#[derive(Clone)]
+pub enum Cursor {
+    /// The default arrow cursor.
+    Arrow,
+    /// A vertical I-beam, for indicating insertion points in text.
+    IBeam,
+    Crosshair,
+    OpenHand,
+    NotAllowed,
+    ResizeLeftRight,
+    ResizeUpDown,
+}

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -39,7 +39,8 @@ use super::util::assert_main_thread;
 use crate::clipboard::ClipboardItem;
 use crate::dialog::FileDialogOptions;
 use crate::keyboard;
-use crate::window::{self, Cursor, FileInfo, MouseButton, Text, TimerToken, WinCtx, WinHandler};
+use crate::mouse::{Cursor, MouseButton, MouseEvent};
+use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
 
 /// Taken from https://gtk-rs.org/docs-src/tutorial/closures
@@ -256,7 +257,7 @@ impl WindowBuilder {
                 let mut ctx = WinCtxImpl::from(&handle);
 
                 state.handler.borrow_mut().mouse_down(
-                    &window::MouseEvent {
+                    &MouseEvent {
                         pos: Point::from(button.get_position()),
                         count: get_mouse_click_count(button.get_event_type()),
                         mods: get_modifiers(button.get_state()),
@@ -274,7 +275,7 @@ impl WindowBuilder {
                 let mut ctx = WinCtxImpl::from(&handle);
 
                 state.handler.borrow_mut().mouse_up(
-                    &window::MouseEvent {
+                    &MouseEvent {
                         pos: Point::from(button.get_position()),
                         mods: get_modifiers(button.get_state()),
                         count: 0,
@@ -292,7 +293,7 @@ impl WindowBuilder {
                 let mut ctx = WinCtxImpl::from(&handle);
 
                 let pos = Point::from(motion.get_position());
-                let mouse_event = window::MouseEvent {
+                let mouse_event = MouseEvent {
                     pos,
                     mods: get_modifiers(motion.get_state()),
                     count: 0,
@@ -669,7 +670,7 @@ fn make_gdk_cursor(cursor: &Cursor, gdk_window: &gdk::Window) -> Option<gdk::Cur
     )
 }
 
-fn get_mouse_button(button: u32) -> window::MouseButton {
+fn get_mouse_button(button: u32) -> MouseButton {
     match button {
         1 => MouseButton::Left,
         2 => MouseButton::Middle,
@@ -680,7 +681,7 @@ fn get_mouse_button(button: u32) -> window::MouseButton {
     }
 }
 
-fn get_mouse_button_from_modifiers(modifiers: gdk::ModifierType) -> window::MouseButton {
+fn get_mouse_button_from_modifiers(modifiers: gdk::ModifierType) -> MouseButton {
     match modifiers {
         modifiers if modifiers.contains(ModifierType::BUTTON1_MASK) => MouseButton::Left,
         modifiers if modifiers.contains(ModifierType::BUTTON2_MASK) => MouseButton::Middle,

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -45,10 +45,9 @@ use super::util::{assert_main_thread, make_nsstring};
 use crate::clipboard::ClipboardItem;
 use crate::dialog::FileDialogOptions;
 use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
+use crate::mouse::{Cursor, MouseButton, MouseEvent};
 use crate::platform::application::Application;
-use crate::window::{
-    Cursor, FileInfo, MouseButton, MouseEvent, Text, TimerToken, WinCtx, WinHandler,
-};
+use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
 
 #[allow(non_upper_case_globals)]

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -14,10 +14,7 @@
 
 //! Creation and management of windows.
 
-#![allow(
-    non_snake_case,
-    clippy::cast_lossless,
-    )]
+#![allow(non_snake_case, clippy::cast_lossless)]
 
 use std::any::Any;
 use std::cell::{Cell, RefCell};
@@ -61,10 +58,9 @@ use crate::application::Application;
 use crate::clipboard::ClipboardItem;
 use crate::dialog::{FileDialogOptions, FileDialogType};
 use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
+use crate::mouse::{Cursor, MouseButton, MouseEvent};
 use crate::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
-use crate::window::{
-    Cursor, FileInfo, MouseButton, MouseEvent, Text, TimerToken, WinCtx, WinHandler,
-};
+use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
 
 extern "system" {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -14,17 +14,27 @@
 
 //! Platform independent window types.
 
+#![allow(deprecated)] // for the three items that have moved
+
 use std::any::Any;
 use std::path::PathBuf;
 
 use crate::clipboard::ClipboardItem;
-//TODO: why is this pub?
 use crate::dialog::FileDialogOptions;
 use crate::error::Error;
-pub use crate::keyboard::{KeyEvent, KeyModifiers};
+use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::kurbo::{Point, Size, Vec2};
 use crate::menu::Menu;
 use crate::platform::window as platform;
+
+#[deprecated(since = "0.4.0", note = "Moved to druid_shell::mouse::MouseEvent")]
+pub type MouseEvent = crate::mouse::MouseEvent;
+
+#[deprecated(since = "0.4.0", note = "Moved to druid_shell::mouse::Cursor")]
+pub type Cursor = crate::mouse::Cursor;
+
+#[deprecated(since = "0.4.0", note = "Use druid_shell::mouse::MouseButton")]
+pub type MouseButton = crate::mouse::MouseButton;
 
 // It's possible we'll want to make this type alias at a lower level,
 // see https://github.com/linebender/piet/pull/37 for more discussion.
@@ -294,69 +304,6 @@ pub trait WinHandler {
 
     /// Get a reference to the handler state. Used mostly by idle handlers.
     fn as_any(&mut self) -> &mut dyn Any;
-}
-
-/// The state of the mouse for a click, mouse-up, or move event.
-#[derive(Debug, Clone, PartialEq)]
-pub struct MouseEvent {
-    /// The location of the mouse in the current window.
-    ///
-    /// This is in px units, that is, adjusted for hi-dpi.
-    pub pos: Point,
-    /// Keyboard modifiers at the time of the mouse event.
-    pub mods: KeyModifiers,
-    /// The number of mouse clicks associated with this event. This will always
-    /// be `0` for a mouse-up event.
-    pub count: u32,
-    /// The currently pressed button in the case of a move or click event,
-    /// or the released button in the case of a mouse-up event.
-    pub button: MouseButton,
-}
-
-/// An indicator of which mouse button was pressed.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub enum MouseButton {
-    /// Left mouse button.
-    Left,
-    /// Middle mouse button.
-    Middle,
-    /// Right mouse button.
-    Right,
-    /// First X button.
-    X1,
-    /// Second X button.
-    X2,
-}
-
-impl MouseButton {
-    /// Returns `true` if this is the left mouse button.
-    #[inline(always)]
-    pub fn is_left(self) -> bool {
-        self == MouseButton::Left
-    }
-
-    /// Returns `true` if this is the right mouse button.
-    #[inline(always)]
-    pub fn is_right(self) -> bool {
-        self == MouseButton::Right
-    }
-}
-
-//NOTE: this currently only contains cursors that are included by default on
-//both Windows and macOS. We may want to provide polyfills for various additional cursors,
-//and we will also want to add some mechanism for adding custom cursors.
-/// Mouse cursors.
-#[derive(Clone)]
-pub enum Cursor {
-    /// The default arrow cursor.
-    Arrow,
-    /// A vertical I-beam, for indicating insertion points in text.
-    IBeam,
-    Crosshair,
-    OpenHand,
-    NotAllowed,
-    ResizeLeftRight,
-    ResizeUpDown,
 }
 
 /// Information about a file to be opened or saved.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -49,7 +49,8 @@ pub use unicode_segmentation;
 pub use druid_shell::clipboard::ClipboardItem;
 pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
 pub use druid_shell::keyboard::{KeyCode, KeyEvent, KeyModifiers};
-pub use druid_shell::window::{Cursor, MouseButton, TimerToken};
+pub use druid_shell::mouse::{Cursor, MouseButton};
+pub use druid_shell::window::TimerToken;
 use druid_shell::window::{Text, WinCtx, WindowHandle};
 pub use shell::hotkey::{HotKey, RawMods, SysMods};
 

--- a/druid/src/mouse.rs
+++ b/druid/src/mouse.rs
@@ -37,9 +37,9 @@ pub struct MouseEvent {
     pub button: MouseButton,
 }
 
-impl From<druid_shell::window::MouseEvent> for MouseEvent {
-    fn from(src: druid_shell::window::MouseEvent) -> MouseEvent {
-        let druid_shell::window::MouseEvent {
+impl From<druid_shell::mouse::MouseEvent> for MouseEvent {
+    fn from(src: druid_shell::mouse::MouseEvent) -> MouseEvent {
+        let druid_shell::mouse::MouseEvent {
             pos,
             mods,
             count,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -26,7 +26,8 @@ use crate::kurbo::{Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 use crate::shell::application::Application;
 use crate::shell::dialog::FileDialogOptions;
-use crate::shell::window::{Cursor, MouseEvent, WinCtx, WinHandler, WindowHandle};
+use crate::shell::mouse::{Cursor, MouseEvent};
+use crate::shell::window::{WinCtx, WinHandler, WindowHandle};
 
 use crate::app_delegate::{AppDelegate, DelegateCtx};
 use crate::menu::ContextMenu;


### PR DESCRIPTION
This will likely break some existing code; to make that less painful
I've re-exported these types from their previous location, attaching
deprecation warnings pointing to the new location.

------

This is based on #320