### PR TITLE
Don't expose platform::util at top level

### DIFF
--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -19,6 +19,7 @@ use time::get_time;
 use piet_common::kurbo::{Line, Rect};
 use piet_common::{Color, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
+use druid_shell::application::Application;
 use druid_shell::keyboard::KeyEvent;
 use druid_shell::runloop;
 use druid_shell::window::{WinCtx, WinHandler, WindowBuilder, WindowHandle};
@@ -109,7 +110,7 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    druid_shell::init();
+    Application::init();
 
     let mut run_loop = runloop::RunLoop::new();
     let mut builder = WindowBuilder::new();

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -113,7 +113,7 @@ impl WinHandler for HelloState {
 }
 
 fn main() {
-    druid_shell::init();
+    Application::init();
 
     let mut file_menu = Menu::new();
     file_menu.add_item(

--- a/druid-shell/src/application.rs
+++ b/druid-shell/src/application.rs
@@ -23,6 +23,11 @@ use crate::platform::application as platform;
 pub struct Application;
 
 impl Application {
+    /// Initialize the app. At the moment, this is mostly needed for hi-dpi.
+    pub fn init() {
+        platform::Application::init()
+    }
+
     /// Terminate the application.
     pub fn quit() {
         platform::Application::quit()
@@ -49,5 +54,14 @@ impl Application {
     /// Sets the contents of the system clipboard.
     pub fn set_clipboard_contents(item: ClipboardItem) {
         platform::Application::set_clipboard_contents(item)
+    }
+
+    /// Returns the current locale string.
+    ///
+    /// This should a [Unicode language identifier].
+    ///
+    /// [Unicode language identifier]: https://unicode.org/reports/tr35/#Unicode_language_identifier
+    pub fn get_locale() -> String {
+        platform::Application::get_locale()
     }
 }

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -50,5 +50,3 @@ pub mod window;
 
 pub use error::Error;
 pub use window::WindowBuilder;
-//TODO: move these to Application?
-pub use platform::util::{self, get_locale, init};

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -19,6 +19,10 @@ use crate::clipboard::ClipboardItem;
 pub struct Application;
 
 impl Application {
+    pub fn init() {
+        gtk::init().expect("GTK initialization failed");
+    }
+
     pub fn quit() {
         // Nothing to do: if this is called, we're already shutting down and GTK will pick it up (I hope?)
     }
@@ -36,5 +40,10 @@ impl Application {
 
     pub fn set_clipboard_contents(_item: ClipboardItem) {
         log::warn!("set_clipboard_contents is unimplemented on GTK");
+    }
+
+    pub fn get_locale() -> String {
+        //TODO ahem
+        "en-US".into()
     }
 }

--- a/druid-shell/src/platform/gtk/runloop.rs
+++ b/druid-shell/src/platform/gtk/runloop.rs
@@ -19,7 +19,7 @@ use std::cell::RefCell;
 use gio::{ApplicationExt, ApplicationExtManual, ApplicationFlags, Cancellable};
 use gtk::{Application, GtkApplicationExt};
 
-use crate::util::assert_main_thread;
+use super::util::assert_main_thread;
 
 // XXX: The application needs to be global because WindowBuilder::build wants
 // to construct an ApplicationWindow, which needs the application, but

--- a/druid-shell/src/platform/gtk/util.rs
+++ b/druid-shell/src/platform/gtk/util.rs
@@ -14,15 +14,6 @@
 
 //! Utilities, GTK specific.
 
-pub fn init() {
-    gtk::init().expect("GTK initialization failed");
-}
-
-pub fn assert_main_thread() {
+pub(crate) fn assert_main_thread() {
     assert!(gtk::is_initialized_main_thread());
-}
-
-pub fn get_locale() -> String {
-    //TODO ahem
-    "en-US".into()
 }

--- a/druid-shell/src/platform/mac/application.rs
+++ b/druid-shell/src/platform/mac/application.rs
@@ -23,6 +23,8 @@ use cocoa::foundation::NSInteger;
 pub struct Application;
 
 impl Application {
+    pub fn init() {}
+
     pub fn quit() {
         unsafe {
             let () = msg_send![NSApp(), terminate: nil];
@@ -83,6 +85,19 @@ impl Application {
                 }
                 other => log::warn!("unhandled clipboard data {:?}", other),
             }
+        }
+    }
+
+    pub fn get_locale() -> String {
+        unsafe {
+            let nslocale_class = class!(NSLocale);
+            let locale: id = msg_send![nslocale_class, currentLocale];
+            let ident: id = msg_send![locale, localeIdentifier];
+            let mut locale = util::from_nsstring(ident);
+            if let Some(idx) = locale.chars().position(|c| c == '@') {
+                locale.truncate(idx);
+            }
+            locale
         }
     }
 }

--- a/druid-shell/src/platform/mac/util.rs
+++ b/druid-shell/src/platform/mac/util.rs
@@ -17,14 +17,12 @@
 use cocoa::base::{id, nil, BOOL, YES};
 use cocoa::foundation::{NSAutoreleasePool, NSString};
 
-pub fn init() {}
-
 /// Panic if not on the main thread.assert_main_thread()
 ///
 /// Many Cocoa operations are only valid on the main thread, and (I think)
 /// undefined behavior is possible if invoked from other threads. If so,
 /// failing on non main thread is necessary for safety.
-pub fn assert_main_thread() {
+pub(crate) fn assert_main_thread() {
     unsafe {
         let is_main_thread: BOOL = msg_send!(class!(NSThread), isMainThread);
         assert_eq!(is_main_thread, YES);
@@ -41,23 +39,5 @@ pub(crate) fn from_nsstring(s: id) -> String {
         let slice = std::slice::from_raw_parts(s.UTF8String() as *const _, s.len());
         let result = std::str::from_utf8_unchecked(slice);
         result.into()
-    }
-}
-
-/// Returns the current locale string.
-///
-/// This should a [Unicode language identifier].
-///
-/// [Unicode language identifier]: https://unicode.org/reports/tr35/#Unicode_language_identifier
-pub fn get_locale() -> String {
-    unsafe {
-        let nslocale_class = class!(NSLocale);
-        let locale: id = msg_send![nslocale_class, currentLocale];
-        let ident: id = msg_send![locale, localeIdentifier];
-        let mut locale = from_nsstring(ident);
-        if let Some(idx) = locale.chars().position(|c| c == '@') {
-            locale.truncate(idx);
-        }
-        locale
     }
 }

--- a/druid-shell/src/platform/windows/dcomp.rs
+++ b/druid-shell/src/platform/windows/dcomp.rs
@@ -43,7 +43,7 @@ use direct2d::{self, RenderTarget};
 
 use log::error;
 
-use crate::util::OPTIONAL_FUNCTIONS;
+use super::util::OPTIONAL_FUNCTIONS;
 
 unsafe fn wrap<T, U, F>(hr: HRESULT, ptr: *mut T, f: F) -> Result<U, HRESULT>
 where

--- a/druid-shell/src/platform/windows/dialog.rs
+++ b/druid-shell/src/platform/windows/dialog.rs
@@ -33,8 +33,8 @@ use winapi::um::shtypes::COMDLG_FILTERSPEC;
 use winapi::Interface;
 use wio::com::ComPtr;
 
+use super::util::{as_result, FromWide, ToWide};
 use crate::dialog::{FileDialogOptions, FileDialogType, FileSpec};
-use crate::util::{as_result, FromWide, ToWide};
 use crate::Error;
 use std::ffi::OsString;
 use std::ptr::null_mut;

--- a/druid-shell/src/platform/windows/menu.rs
+++ b/druid-shell/src/platform/windows/menu.rs
@@ -21,8 +21,8 @@ use winapi::shared::basetsd::*;
 use winapi::shared::windef::*;
 use winapi::um::winuser::*;
 
+use super::util::ToWide;
 use crate::hotkey::HotKey;
-use crate::util::ToWide;
 
 /// A menu object, which can be either a top-level menubar or a
 /// submenu.

--- a/druid-shell/src/platform/windows/paint.rs
+++ b/druid-shell/src/platform/windows/paint.rs
@@ -39,7 +39,7 @@ use direct2d;
 use direct2d::enums::{AlphaMode, RenderTargetType};
 use direct2d::render_target::{DxgiSurfaceRenderTarget, GenericRenderTarget, HwndRenderTarget};
 
-use crate::util::as_result;
+use super::util::as_result;
 use crate::Error;
 
 /// Context for painting by app into window.

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -53,6 +53,7 @@ use super::dialog::get_file_dialog_path;
 use super::menu::Menu;
 use super::paint;
 use super::timers::TimerSlots;
+use super::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 
 use crate::application::Application;
 use crate::clipboard::ClipboardItem;
@@ -60,7 +61,6 @@ use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType};
 use crate::keyboard::{KeyCode, KeyEvent, KeyModifiers};
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
-use crate::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
 
@@ -786,7 +786,7 @@ impl WindowBuilder {
             // Maybe separate registration in build api? Probably only need to
             // register once even for multiple window creation.
 
-            let class_name = crate::util::CLASS_NAME.to_wide();
+            let class_name = super::util::CLASS_NAME.to_wide();
             let dwrite_factory = directwrite::Factory::new().unwrap();
             let dw_clone = clone_dwrite(&dwrite_factory);
             let wndproc = MyWndProc {

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -19,8 +19,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::kurbo::Size;
+use crate::shell::application::Application;
 use crate::shell::window::WindowHandle;
-use crate::shell::{init, runloop, Error as PlatformError, WindowBuilder};
+use crate::shell::{runloop, Error as PlatformError, WindowBuilder};
 use crate::win_handler::AppState;
 use crate::window::{Window, WindowId};
 use crate::{theme, AppDelegate, Data, DruidHandler, Env, LocalizedString, MenuDesc, Widget};
@@ -94,7 +95,7 @@ impl<T: Data + 'static> AppLauncher<T> {
     /// Returns an error if a window cannot be instantiated. This is usually
     /// a fatal error.
     pub fn launch(mut self, data: T) -> Result<(), PlatformError> {
-        init();
+        Application::init();
         let mut main_loop = runloop::RunLoop::new();
         let mut env = theme::init();
         if let Some(f) = self.env_setup.take() {

--- a/druid/src/localization.rs
+++ b/druid/src/localization.rs
@@ -42,7 +42,7 @@ use log::{debug, error, warn};
 
 use crate::data::Data;
 use crate::env::Env;
-use crate::shell::get_locale;
+use crate::shell::application::Application;
 
 use fluent_bundle::{
     FluentArgs, FluentBundle, FluentError, FluentMessage, FluentResource, FluentValue,
@@ -211,7 +211,7 @@ impl L10nManager {
 
         let default_locale: LanguageIdentifier =
             "en-US".parse().expect("failed to parse default locale");
-        let current_locale = get_locale()
+        let current_locale = Application::get_locale()
             .parse()
             .unwrap_or_else(|_| default_locale.clone());
         let locales = get_available_locales(base_dir).unwrap_or_default();


### PR DESCRIPTION
This moves various utility methods into `Application`, following the
new wrapper pattern.

It also cleans up imports a bit, because I have ADHD


-----

functions in `util.rs` were the only remaining place where we were directly exposing a platform implementation in the public API. this moves the two relevant functions in `Application`.
