### PR TITLE
[shell] Clean up exports

### DIFF
--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -19,10 +19,9 @@ use time::get_time;
 use piet_common::kurbo::{Line, Rect};
 use piet_common::{Color, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
-use druid_shell::application::Application;
-use druid_shell::keyboard::KeyEvent;
-use druid_shell::runloop;
-use druid_shell::window::{WinCtx, WinHandler, WindowBuilder, WindowHandle};
+use druid_shell::{
+    Application, KeyEvent, RunLoop, WinCtx, WinHandler, WindowBuilder, WindowHandle,
+};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
@@ -101,7 +100,7 @@ impl WinHandler for PerfTest {
     }
 
     fn destroy(&mut self, _ctx: &mut dyn WinCtx) {
-        runloop::request_quit();
+        Application::quit()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {
@@ -112,7 +111,7 @@ impl WinHandler for PerfTest {
 fn main() {
     Application::init();
 
-    let mut run_loop = runloop::RunLoop::new();
+    let mut run_loop = RunLoop::new();
     let mut builder = WindowBuilder::new();
     let perf_test = PerfTest {
         size: Default::default(),

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -17,14 +17,10 @@ use std::any::Any;
 use druid_shell::kurbo::{Line, Rect, Vec2};
 use druid_shell::piet::{Color, RenderContext};
 
-use druid_shell::application::Application;
-use druid_shell::dialog::{FileDialogOptions, FileSpec};
-use druid_shell::hotkey::{HotKey, SysMods};
-use druid_shell::keyboard::{KeyEvent, KeyModifiers};
-use druid_shell::menu::Menu;
-use druid_shell::mouse::{Cursor, MouseEvent};
-use druid_shell::runloop;
-use druid_shell::window::{TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle};
+use druid_shell::{
+    Application, Cursor, FileDialogOptions, FileSpec, HotKey, KeyEvent, KeyModifiers, Menu,
+    MouseEvent, RunLoop, SysMods, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle,
+};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
@@ -104,7 +100,7 @@ impl WinHandler for HelloState {
     }
 
     fn destroy(&mut self, _ctx: &mut dyn WinCtx) {
-        runloop::request_quit();
+        Application::quit()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {
@@ -134,7 +130,7 @@ fn main() {
     menubar.add_dropdown(Menu::new(), "Application", true);
     menubar.add_dropdown(file_menu, "&File", true);
 
-    let mut run_loop = runloop::RunLoop::new();
+    let mut run_loop = RunLoop::new();
     let mut builder = WindowBuilder::new();
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");

--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -31,9 +31,7 @@ use crate::keycodes::KeyCode;
 /// [`SysMods`] matches the Command key on macOS and Ctrl elsewhere:
 ///
 /// ```
-/// use druid_shell::hotkey::{HotKey, RawMods, SysMods};
-/// use druid_shell::keyboard::KeyEvent;
-/// use druid_shell::keycodes::KeyCode;
+/// use druid_shell::{HotKey, KeyEvent, KeyCode, RawMods, SysMods};
 ///
 /// let hotkey = HotKey::new(SysMods::Cmd, "a");
 ///
@@ -47,9 +45,7 @@ use crate::keycodes::KeyCode;
 /// `None` matches only the key without modifiers:
 ///
 /// ```
-/// use druid_shell::hotkey::{HotKey, RawMods, SysMods};
-/// use druid_shell::keyboard::KeyEvent;
-/// use druid_shell::keycodes::KeyCode;
+/// use druid_shell::{HotKey, KeyEvent, KeyCode, RawMods, SysMods};
 ///
 /// let hotkey = HotKey::new(None, KeyCode::ArrowLeft);
 ///
@@ -88,9 +84,7 @@ impl HotKey {
     ///
     /// # Examples
     /// ```
-    /// use druid_shell::hotkey::{HotKey, RawMods, SysMods};
-    /// use druid_shell::keyboard::KeyEvent;
-    /// use druid_shell::keycodes::KeyCode;
+    /// use druid_shell::{HotKey, KeyEvent, KeyCode, RawMods, SysMods};
     ///
     /// let select_all = HotKey::new(SysMods::Cmd, "a");
     /// let esc = HotKey::new(None, KeyCode::Escape);

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 //! Platform abstraction for druid toolkit.
+//!
+//! `druid-shell` is an abstraction around a given platform UI & application
+//! framework. It provides common types, which then defer to a platform-defined
+//! implementation.
 
 #![deny(intra_doc_link_resolution_failure)]
 #![allow(clippy::new_without_default)]
@@ -32,21 +36,30 @@ extern crate objc;
 #[macro_use]
 extern crate lazy_static;
 
-pub mod application;
-pub mod clipboard;
+mod application;
+mod clipboard;
 mod common_util;
-pub mod dialog;
-pub mod error;
-pub mod hotkey;
-pub mod keyboard;
-pub mod keycodes;
-pub mod menu;
-pub mod mouse;
+mod dialog;
+mod error;
+mod hotkey;
+mod keyboard;
+mod keycodes;
+mod menu;
+mod mouse;
 //TODO: don't expose this directly? currently making this private causes
 //a bunch of compiler warnings, so let's revisit that later.
 pub mod platform;
-pub mod runloop;
-pub mod window;
+mod runloop;
+mod window;
 
+pub use application::Application;
+pub use clipboard::ClipboardItem;
+pub use dialog::{FileDialogOptions, FileDialogType, FileSpec};
 pub use error::Error;
-pub use window::WindowBuilder;
+pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};
+pub use keyboard::{KeyEvent, KeyModifiers};
+pub use keycodes::KeyCode;
+pub use menu::Menu;
+pub use mouse::{Cursor, MouseButton, MouseEvent};
+pub use runloop::RunLoop;
+pub use window::{FileInfo, Text, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle};

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -14,6 +14,10 @@
 
 //! GTK implementation of features at the application scope.
 
+use gtk::GtkApplicationExt;
+
+use super::runloop;
+use super::util;
 use crate::clipboard::ClipboardItem;
 
 pub struct Application;
@@ -24,7 +28,18 @@ impl Application {
     }
 
     pub fn quit() {
-        // Nothing to do: if this is called, we're already shutting down and GTK will pick it up (I hope?)
+        util::assert_main_thread();
+        runloop::with_application(|app| {
+            match app.get_active_window() {
+                None => {
+                    // no application is running, main is not running
+                }
+                Some(_) => {
+                    // we still have an active window, close the runLo
+                    gtk::main_quit();
+                }
+            }
+        });
     }
 
     pub fn get_clipboard_contents() -> Option<ClipboardItem> {

--- a/druid-shell/src/platform/gtk/runloop.rs
+++ b/druid-shell/src/platform/gtk/runloop.rs
@@ -17,7 +17,7 @@
 use std::cell::RefCell;
 
 use gio::{ApplicationExt, ApplicationExtManual, ApplicationFlags, Cancellable};
-use gtk::{Application, GtkApplicationExt};
+use gtk::Application;
 
 use super::util::assert_main_thread;
 
@@ -66,22 +66,6 @@ impl RunLoop {
                 .run(&[])
         });
     }
-}
-
-/// Request to quit the application, exiting the runloop.
-pub fn request_quit() {
-    assert_main_thread();
-    with_application(|app| {
-        match app.get_active_window() {
-            None => {
-                // no application is running, main is not running
-            }
-            Some(_) => {
-                // we still have an active window, close the runLo
-                gtk::main_quit();
-            }
-        }
-    });
 }
 
 #[inline]

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -26,7 +26,8 @@ use winapi::um::winbase::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
 use winapi::um::wingdi::CreateSolidBrush;
 use winapi::um::winuser::{
     CloseClipboard, EmptyClipboard, EnumClipboardFormats, GetClipboardData, LoadIconW,
-    OpenClipboard, RegisterClassW, SetClipboardData, CF_UNICODETEXT, IDI_APPLICATION, WNDCLASSW,
+    OpenClipboard, PostQuitMessage, RegisterClassW, SetClipboardData, CF_UNICODETEXT,
+    IDI_APPLICATION, WNDCLASSW,
 };
 
 use super::util::{self, FromWide, ToWide, CLASS_NAME, OPTIONAL_FUNCTIONS};
@@ -70,7 +71,9 @@ impl Application {
     }
 
     pub fn quit() {
-        crate::runloop::request_quit();
+        unsafe {
+            PostQuitMessage(0);
+        }
     }
 
     /// Returns the contents of the clipboard, if any.

--- a/druid-shell/src/platform/windows/runloop.rs
+++ b/druid-shell/src/platform/windows/runloop.rs
@@ -110,13 +110,6 @@ impl RunLoop {
     }
 }
 
-/// Request to quit the application, exiting the runloop.
-pub fn request_quit() {
-    unsafe {
-        PostQuitMessage(0);
-    }
-}
-
 impl RunLoopHandle {
     /// Add a listener for a Windows handle. Considered unsafe because the
     /// handle must be valid. Also unsafe because it is not thread safe.

--- a/druid-shell/src/runloop.rs
+++ b/druid-shell/src/runloop.rs
@@ -36,9 +36,3 @@ impl RunLoop {
         self.0.run()
     }
 }
-
-//TODO: deprecate this in favor of methods on `Application`? This functionality is duplicated
-/// Request to quit the application, exiting the runloop.
-pub fn request_quit() {
-    platform::request_quit()
-}

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -33,11 +33,9 @@ pub type MouseEvent = crate::mouse::MouseEvent;
 #[deprecated(since = "0.4.0", note = "Moved to druid_shell::mouse::Cursor")]
 pub type Cursor = crate::mouse::Cursor;
 
-#[deprecated(since = "0.4.0", note = "Use druid_shell::mouse::MouseButton")]
-pub type MouseButton = crate::mouse::MouseButton;
-
 // It's possible we'll want to make this type alias at a lower level,
 // see https://github.com/linebender/piet/pull/37 for more discussion.
+/// The platform text factory, reexported from piet.
 pub type Text<'a> = <piet_common::Piet<'a> as piet_common::RenderContext>::Text;
 
 /// A token that uniquely identifies a running timer.

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -19,9 +19,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::kurbo::Size;
-use crate::shell::application::Application;
-use crate::shell::window::WindowHandle;
-use crate::shell::{runloop, Error as PlatformError, WindowBuilder};
+use crate::shell::{Application, Error as PlatformError, RunLoop, WindowBuilder, WindowHandle};
 use crate::win_handler::AppState;
 use crate::window::{Window, WindowId};
 use crate::{theme, AppDelegate, Data, DruidHandler, Env, LocalizedString, MenuDesc, Widget};
@@ -96,7 +94,7 @@ impl<T: Data + 'static> AppLauncher<T> {
     /// a fatal error.
     pub fn launch(mut self, data: T) -> Result<(), PlatformError> {
         Application::init();
-        let mut main_loop = runloop::RunLoop::new();
+        let mut main_loop = RunLoop::new();
         let mut env = theme::init();
         if let Some(f) = self.env_setup.take() {
             f(&mut env);

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -16,9 +16,7 @@
 
 use crate::kurbo::{Rect, Shape, Size, Vec2};
 
-use druid_shell::clipboard::ClipboardItem;
-use druid_shell::keyboard::{KeyEvent, KeyModifiers};
-use druid_shell::window::{FileInfo, TimerToken};
+use druid_shell::{ClipboardItem, FileInfo, KeyEvent, KeyModifiers, TimerToken};
 
 use crate::mouse::MouseEvent;
 use crate::Command;

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -46,14 +46,10 @@ use piet::{Piet, RenderContext};
 
 pub use unicode_segmentation;
 
-pub use druid_shell::clipboard::ClipboardItem;
-pub use druid_shell::dialog::{FileDialogOptions, FileDialogType};
-pub use druid_shell::keyboard::{KeyEvent, KeyModifiers};
-pub use druid_shell::keycodes::KeyCode;
-pub use druid_shell::mouse::{Cursor, MouseButton};
-pub use druid_shell::window::TimerToken;
-use druid_shell::window::{Text, WinCtx, WindowHandle};
-pub use shell::hotkey::{HotKey, RawMods, SysMods};
+pub use shell::{
+    ClipboardItem, Cursor, FileDialogOptions, FileDialogType, HotKey, KeyCode, KeyEvent,
+    KeyModifiers, MouseButton, RawMods, SysMods, Text, TimerToken, WinCtx, WindowHandle,
+};
 
 pub use app::{AppLauncher, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};

--- a/druid/src/localization.rs
+++ b/druid/src/localization.rs
@@ -42,7 +42,7 @@ use log::{debug, error, warn};
 
 use crate::data::Data;
 use crate::env::Env;
-use crate::shell::application::Application;
+use crate::shell::Application;
 
 use fluent_bundle::{
     FluentArgs, FluentBundle, FluentError, FluentMessage, FluentResource, FluentValue,

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -109,8 +109,7 @@
 use std::num::NonZeroU32;
 
 use crate::kurbo::Point;
-use crate::shell::hotkey::{HotKey, KeyCompare, RawMods, SysMods};
-use crate::shell::menu::Menu as PlatformMenu;
+use crate::shell::{HotKey, KeyCompare, Menu as PlatformMenu, RawMods, SysMods};
 use crate::{command, Command, Data, Env, KeyCode, LocalizedString, Selector};
 
 /// A platform-agnostic description of an application, window, or context

--- a/druid/src/mouse.rs
+++ b/druid/src/mouse.rs
@@ -37,9 +37,9 @@ pub struct MouseEvent {
     pub button: MouseButton,
 }
 
-impl From<druid_shell::mouse::MouseEvent> for MouseEvent {
-    fn from(src: druid_shell::mouse::MouseEvent) -> MouseEvent {
-        let druid_shell::mouse::MouseEvent {
+impl From<druid_shell::MouseEvent> for MouseEvent {
+    fn from(src: druid_shell::MouseEvent) -> MouseEvent {
+        let druid_shell::MouseEvent {
             pos,
             mods,
             count,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -24,10 +24,9 @@ use log::{error, info, warn};
 
 use crate::kurbo::{Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
-use crate::shell::application::Application;
-use crate::shell::dialog::FileDialogOptions;
-use crate::shell::mouse::{Cursor, MouseEvent};
-use crate::shell::window::{WinCtx, WinHandler, WindowHandle};
+use crate::shell::{
+    Application, Cursor, FileDialogOptions, MouseEvent, WinCtx, WinHandler, WindowHandle,
+};
 
 use crate::app_delegate::{AppDelegate, DelegateCtx};
 use crate::menu::ContextMenu;

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::kurbo::{Point, Rect, Size};
 
-use crate::shell::window::WindowHandle;
+use crate::shell::WindowHandle;
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LocalizedString, MenuDesc,
     PaintCtx, UpdateCtx, Widget, WidgetPod,


### PR DESCRIPTION
This changes druid-shell to just always import all of the general types from the root of the module, and keep the submodules private.

This will break most existing code, but I think, after looking at a bunch of stdlib modules and popular crates, that this is the correct pattern.