### PR TITLE
Multi-format copy and paste

### DIFF
--- a/druid-shell/src/application.rs
+++ b/druid-shell/src/application.rs
@@ -14,7 +14,7 @@
 
 //! The top-level application type.
 
-use crate::clipboard::ClipboardItem;
+use crate::clipboard::Clipboard;
 use crate::platform::application as platform;
 
 //TODO: we may want to make the user create an instance of this (Application::global()?)
@@ -46,14 +46,9 @@ impl Application {
         platform::Application::hide_others()
     }
 
-    /// Returns the contents of the clipboard, if any.
-    pub fn get_clipboard_contents() -> Option<ClipboardItem> {
-        platform::Application::get_clipboard_contents()
-    }
-
-    /// Sets the contents of the system clipboard.
-    pub fn set_clipboard_contents(item: ClipboardItem) {
-        platform::Application::set_clipboard_contents(item)
+    /// Returns a handle to the system clipboard.
+    pub fn clipboard() -> Clipboard {
+        platform::Application::clipboard().into()
     }
 
     /// Returns the current locale string.

--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -13,28 +13,210 @@
 // limitations under the License.
 
 //! Interacting with the system pasteboard/clipboard.
+pub use crate::platform::clipboard as platform;
 
-/// An item on the system clipboard.
+/// A handle to the system clipboard.
+///
+/// To get access to the global clipboard, call [`Application::clipboard()`].
+///
+///
+/// # Working with text
+///
+/// Copying and pasting text is simple, using [`Clipboard::put_string`] and
+/// [`Clipboard::get_string`]. If this is all you need, you're in luck.
+///
+/// # Advanced useage
+///
+/// When working with data more complicated than plaintext, you will generally
+/// want to make that data available in multiple formats.
+///
+/// For instance, if you are writing an image editor, you may have a preferred
+/// private format, that preserves metadata or layer information; but in order
+/// to interoperate with your user's other programs, you might also make your
+/// data available as an SVG, for other editors, and a bitmap image for applications
+/// that can accept general image data.
+///
+/// ## `FormatId`entifiers
+///
+/// In order for other applications to find data we put on the clipboard,
+/// (and for us to use data from other applications) we need to use agreed-upon
+/// identifiers for our data types. On macOS, these should be
+/// [`Universal Type Identifier`]s; on other platforms they appear to be
+/// mostly [MIME types]. Several common types are exposed as constants on
+/// [`ClipboardFormat`], these `const`s are set per-platform.
+///
+/// When defining custom formats, you should use the correct identifier for
+/// the current platform.
+///
+/// ## Setting custom data
+///
+/// To put custom data on the clipboard, you create a [`ClipboardFormat`] for
+/// each type of data you support. You are responsible for ensuring that the
+/// data is already correctly serialized.
+///
+///
+/// ### `ClipboardFormat` for text
+///
+/// If you wish to put text on the clipboard in addition to other formats,
+/// take special care to use `ClipboardFormat::TEXT` as the [`FormatId`]. On
+/// windows, we treat this identifier specially, and make sure the data is
+/// encoded as a wide string; all other data going into and out of the
+/// clipboard is treated as an array of bytes.
+///
+/// # Examples
+///
+/// ## Getting and setting text:
+///
+/// ```no_run
+/// use druid_shell::{Application, Clipboard};
+///
+/// let mut clipboard = Application::clipboard();
+/// clipboard.put_string("watch it there pal");
+/// if let Some(contents) = clipboard.get_string() {
+///     assert_eq!("what it there pal", contents.as_str());
+/// }
+///
+/// ```
+///
+///  ## Copying multi-format data
+///
+///  ```no_run
+/// use druid_shell::{Application, Clipboard, ClipboardFormat};
+///
+/// let mut clipboard = Application::clipboard();
+///
+/// let custom_type_id = "io.xieditor.path-clipboard-type";
+///
+/// let formats = [
+///     ClipboardFormat::new(custom_type_id, make_custom_data()),
+///     ClipboardFormat::new(ClipboardFormat::SVG, make_svg_data()),
+///     ClipboardFormat::new(ClipboardFormat::PDF, make_pdf_data()),
+/// ];
+///
+/// clipboard.put_formats(&formats);
+///
+/// # fn make_custom_data() -> Vec<u8> { unimplemented!() }
+/// # fn make_svg_data() -> Vec<u8> { unimplemented!() }
+/// # fn make_pdf_data() -> Vec<u8> { unimplemented!() }
+///  ```
+/// ## Supporting multi-format paste
+///
+/// ```no_run
+/// use druid_shell::{Application, Clipboard, ClipboardFormat};
+///
+/// let clipboard = Application::clipboard();
+///
+/// let custom_type_id = "io.xieditor.path-clipboard-type";
+/// let supported_types = &[custom_type_id, ClipboardFormat::SVG, ClipboardFormat::PDF];
+/// let best_available_type = clipboard.preferred_format(supported_types);
+///
+/// if let Some(format) = best_available_type {
+///     let data = clipboard.get_format(format).expect("I promise not to unwrap in production");
+///     do_something_with_data(format, data)
+/// }
+///
+/// # fn do_something_with_data(_: &str, _: Vec<u8>) {}
+/// ```
+///
+/// [`Application::clipboard()`]: struct.Application.html#method.clipboard
+/// [`Clipboard::put_string`]: struct.Clipboard.html#method.put_string
+/// [`Clipboard::get_string`]: struct.Clipboard.html#method.get_string
+/// [`FormatId`]: type.FormatId.html
+/// [`Universal Type Identifier`]: https://escapetech.eu/manuals/qdrop/uti.html
+/// [MIME types]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+/// [`ClipboardFormat`]: struct.ClipboardFormat.html
 #[derive(Debug, Clone)]
-pub enum ClipboardItem {
-    Text(String),
-    #[doc(hidden)]
-    __NotExhaustive,
-    // other things
-}
+pub struct Clipboard(platform::Clipboard);
 
-impl ClipboardItem {
-    /// Create a new `ClipboardItem`.
-    pub fn new(item: impl Into<ClipboardItem>) -> Self {
-        item.into()
+impl Clipboard {
+    /// Put a string onto the system clipboard.
+    pub fn put_string(&mut self, s: impl AsRef<str>) {
+        self.0.put_string(s);
+    }
+
+    /// Put multi-format data on the system clipboard.
+    pub fn put_formats(&mut self, formats: &[ClipboardFormat]) {
+        self.0.put_formats(formats)
+    }
+
+    /// Get a string from the system clipboard, if one is available.
+    pub fn get_string(&self) -> Option<String> {
+        self.0.get_string()
+    }
+
+    /// Given a list of supported clipboard types, returns the supported type which has
+    /// highest priority on the system clipboard, or `None` if no types are supported.
+    pub fn preferred_format(&self, formats: &[FormatId]) -> Option<FormatId> {
+        self.0.preferred_format(formats)
+    }
+
+    /// Return data in a given format, if available.
+    ///
+    /// It is recommended that the [`FormatId`] argument be a format returned by
+    /// [`Clipboard::preferred_format`].
+    ///
+    /// [`Clipboard::preferred_format`]: struct.Clipboard.html#method.preferred_format
+    /// [`FormatId`]: type.FormatId.html
+    pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
+        self.0.get_format(format)
     }
 }
 
-impl<T: Into<String>> From<T> for ClipboardItem {
-    fn from(src: T) -> ClipboardItem {
-        ClipboardItem::Text(src.into())
+/// A type identifer for the system clipboard.
+///
+/// These should be [`UTI` strings] on macOS, and (by convention?) [MIME types] elsewhere.
+///
+/// [`UTI` strings]: https://escapetech.eu/manuals/qdrop/uti.html
+/// [MIME types]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+pub type FormatId = &'static str;
+
+/// Data coupled with a type identifier.
+#[derive(Debug, Clone)]
+pub struct ClipboardFormat {
+    pub(crate) identifier: FormatId,
+    pub(crate) data: Vec<u8>,
+}
+
+impl ClipboardFormat {
+    /// Create a new `ClipboardFormat` with the given `FormatId` and byes.
+    ///
+    /// You are responsible for ensuring that this data can be interpreted
+    /// as the provided format.
+    pub fn new(identifier: FormatId, data: impl Into<Vec<u8>>) -> Self {
+        let data = data.into();
+        ClipboardFormat { identifier, data }
     }
 }
 
-//TODO: custom formats.
-// https://docs.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#registered-clipboard-formats
+impl From<String> for ClipboardFormat {
+    fn from(src: String) -> ClipboardFormat {
+        let data = src.into_bytes();
+        ClipboardFormat::new(ClipboardFormat::TEXT, data)
+    }
+}
+
+impl From<&str> for ClipboardFormat {
+    fn from(src: &str) -> ClipboardFormat {
+        src.to_string().into()
+    }
+}
+
+impl From<platform::Clipboard> for Clipboard {
+    fn from(src: platform::Clipboard) -> Clipboard {
+        Clipboard(src)
+    }
+}
+
+#[cfg(all(target_os = "macos", not(feature = "use_gtk")))]
+impl ClipboardFormat {
+    pub const PDF: &'static str = "com.adobe.pdf";
+    pub const TEXT: &'static str = "public.utf8-plain-text";
+    pub const SVG: &'static str = "public.svg-image";
+}
+
+#[cfg(any(not(target_os = "macos"), feature = "use_gtk"))]
+impl ClipboardFormat {
+    pub const PDF: &'static str = "application/pdf";
+    pub const TEXT: &'static str = "text/plain";
+    pub const SVG: &'static str = "image/svg+xml";
+}

--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -160,6 +160,13 @@ impl Clipboard {
     pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
         self.0.get_format(format)
     }
+
+    /// For debugging: print the resolved identifiers for each type currently
+    /// on the clipboard.
+    #[doc(hidden)]
+    pub fn available_type_names(&self) -> Vec<String> {
+        self.0.available_type_names()
+    }
 }
 
 /// A type identifer for the system clipboard.
@@ -178,7 +185,7 @@ pub struct ClipboardFormat {
 }
 
 impl ClipboardFormat {
-    /// Create a new `ClipboardFormat` with the given `FormatId` and byes.
+    /// Create a new `ClipboardFormat` with the given `FormatId` and bytes.
     ///
     /// You are responsible for ensuring that this data can be interpreted
     /// as the provided format.

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -53,7 +53,7 @@ mod runloop;
 mod window;
 
 pub use application::Application;
-pub use clipboard::ClipboardItem;
+pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use dialog::{FileDialogOptions, FileDialogType, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -16,9 +16,9 @@
 
 use gtk::GtkApplicationExt;
 
+use super::clipboard::Clipboard;
 use super::runloop;
 use super::util;
-use crate::clipboard::ClipboardItem;
 
 pub struct Application;
 
@@ -42,19 +42,8 @@ impl Application {
         });
     }
 
-    pub fn get_clipboard_contents() -> Option<ClipboardItem> {
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_default(&display).unwrap();
-
-        if let Some(gstring) = clipboard.wait_for_text() {
-            Some(ClipboardItem::Text(gstring.to_string()))
-        } else {
-            None
-        }
-    }
-
-    pub fn set_clipboard_contents(_item: ClipboardItem) {
-        log::warn!("set_clipboard_contents is unimplemented on GTK");
+    pub fn clipboard() -> Clipboard {
+        Clipboard
     }
 
     pub fn get_locale() -> String {

--- a/druid-shell/src/platform/gtk/clipboard.rs
+++ b/druid-shell/src/platform/gtk/clipboard.rs
@@ -1,0 +1,99 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interactions with the system pasteboard on GTK+.
+
+use crate::clipboard::{ClipboardFormat, FormatId};
+use gdk::Atom;
+use gtk::{TargetEntry, TargetFlags};
+
+/// The system clipboard.
+#[derive(Debug, Clone)]
+pub struct Clipboard;
+
+impl Clipboard {
+    /// Put a string onto the system clipboard.
+    pub fn put_string(&mut self, s: impl AsRef<str>) {
+        let display = gdk::Display::get_default().unwrap();
+        let clipboard = gtk::Clipboard::get_default(&display).unwrap();
+        clipboard.set_text(s.as_ref())
+    }
+
+    /// Put multi-format data on the system clipboard.
+    pub fn put_formats(&mut self, formats: &[ClipboardFormat]) {
+        let entries = make_entries(formats);
+        let display = gdk::Display::get_default().unwrap();
+        let clipboard = gtk::Clipboard::get_default(&display).unwrap();
+        // this is gross: we need to reclone all the data in formats in order
+        // to move it into the closure. :/
+        let formats = formats.to_owned();
+        if !clipboard.set_with_data(&entries, move |_, sel, idx| {
+            let idx = idx as usize;
+            if idx < formats.len() {
+                let item = &formats[idx];
+                let atom = Atom::intern(item.identifier);
+                let stride = 8;
+                sel.set(&atom, stride, item.data.as_slice());
+            }
+        }) {
+            log::warn!("failed to set clipboard data.");
+        }
+    }
+
+    /// Get a string from the system clipboard, if one is available.
+    pub fn get_string(&self) -> Option<String> {
+        let display = gdk::Display::get_default().unwrap();
+        let clipboard = gtk::Clipboard::get_default(&display).unwrap();
+        clipboard.wait_for_text().map(|s| s.to_string())
+    }
+
+    /// Given a list of supported clipboard types, returns the supported type which has
+    /// highest priority on the system clipboard, or `None` if no types are supported.
+    pub fn preferred_format(&self, formats: &[FormatId]) -> Option<FormatId> {
+        let display = gdk::Display::get_default().unwrap();
+        let clipboard = gtk::Clipboard::get_default(&display).unwrap();
+        let targets = clipboard.wait_for_targets()?;
+        let format_atoms = formats
+            .iter()
+            .map(|fmt| Atom::intern(fmt))
+            .collect::<Vec<_>>();
+        for atom in targets.iter() {
+            if let Some(idx) = format_atoms.iter().position(|fmt| fmt == atom) {
+                return Some(formats[idx]);
+            }
+        }
+        None
+    }
+
+    /// Return data in a given format, if available.
+    ///
+    /// It is recommended that the `fmt` argument be a format returned by
+    /// [`Clipboard::preferred_format`]
+    pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
+        let display = gdk::Display::get_default().unwrap();
+        let clipboard = gtk::Clipboard::get_default(&display).unwrap();
+        let atom = Atom::intern(format);
+        clipboard
+            .wait_for_contents(&atom)
+            .map(|data| data.get_data())
+    }
+}
+
+fn make_entries(formats: &[ClipboardFormat]) -> Vec<TargetEntry> {
+    formats
+        .iter()
+        .enumerate()
+        .map(|(i, fmt)| TargetEntry::new(fmt.identifier, TargetFlags::empty(), i as u32))
+        .collect()
+}

--- a/druid-shell/src/platform/gtk/mod.rs
+++ b/druid-shell/src/platform/gtk/mod.rs
@@ -15,6 +15,7 @@
 //! GTK-based platform support
 
 pub mod application;
+pub mod clipboard;
 pub mod dialog;
 pub mod error;
 pub mod keycodes;

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -36,7 +36,6 @@ use super::menu::Menu;
 use super::runloop::with_application;
 use super::util::assert_main_thread;
 
-use crate::clipboard::ClipboardItem;
 use crate::common_util::IdleCallback;
 use crate::dialog::FileDialogOptions;
 use crate::keyboard;
@@ -585,17 +584,6 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
                 .map(|s| FileInfo { path: s.into() })
         } else {
             None
-        }
-    }
-    fn set_clipboard_contents(&mut self, item: ClipboardItem) {
-        let display = gdk::Display::get_default().unwrap();
-        let clipboard = gtk::Clipboard::get_default(&display).unwrap();
-
-        match item {
-            ClipboardItem::Text(text) => {
-                clipboard.set_text(&text);
-            }
-            other => log::warn!("unhandled clipboard data {:?}", other),
         }
     }
 

--- a/druid-shell/src/platform/mac/clipboard.rs
+++ b/druid-shell/src/platform/mac/clipboard.rs
@@ -124,4 +124,15 @@ impl Clipboard {
             }
         }
     }
+
+    pub fn available_type_names(&self) -> Vec<String> {
+        unsafe {
+            let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
+            let types: id = msg_send![pasteboard, types];
+            let types_len = types.count() as usize;
+            (0..types_len)
+                .map(|i| util::from_nsstring(types.objectAtIndex(i as NSUInteger)))
+                .collect()
+        }
+    }
 }

--- a/druid-shell/src/platform/mac/clipboard.rs
+++ b/druid-shell/src/platform/mac/clipboard.rs
@@ -1,0 +1,127 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interactions with the system pasteboard on macOS.
+
+use cocoa::appkit::NSPasteboardTypeString;
+use cocoa::base::{id, nil, BOOL, YES};
+use cocoa::foundation::{NSArray, NSInteger, NSUInteger};
+
+use super::util;
+use crate::clipboard::{ClipboardFormat, FormatId};
+
+#[derive(Debug, Clone, Default)]
+pub struct Clipboard;
+
+impl Clipboard {
+    /// Put a string onto the system clipboard.
+    pub fn put_string(&mut self, s: impl AsRef<str>) {
+        let s = s.as_ref();
+        put_string_impl(s);
+
+        fn put_string_impl(s: &str) {
+            unsafe {
+                let nsstring = util::make_nsstring(s);
+                let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
+                let result: BOOL =
+                    msg_send![pasteboard, setString: nsstring forType: NSPasteboardTypeString];
+                if result != YES {
+                    log::warn!("failed to set clipboard");
+                }
+            }
+        }
+    }
+
+    /// Put multi-format data on the system clipboard.
+    pub fn put_formats(&mut self, formats: &[ClipboardFormat]) {
+        unsafe {
+            let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
+            let _: NSInteger = msg_send![pasteboard, clearContents];
+            let idents = formats
+                .iter()
+                .map(|f| util::make_nsstring(f.identifier))
+                .collect::<Vec<_>>();
+            let array = NSArray::arrayWithObjects(nil, &idents);
+            let _: NSInteger = msg_send![pasteboard, declareTypes: array owner: nil];
+            for (i, format) in formats.iter().enumerate() {
+                let data = util::make_nsdata(&format.data);
+                let data_type = idents[i];
+                let result: BOOL = msg_send![pasteboard, setData: data forType: data_type];
+                if result != YES {
+                    log::warn!(
+                        "failed to set clipboard contents for type '{}'",
+                        format.identifier
+                    );
+                }
+            }
+        }
+    }
+
+    /// Get a string from the system clipboard, if one is available.
+    pub fn get_string(&self) -> Option<String> {
+        unsafe {
+            let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
+            let contents: id = msg_send![pasteboard, stringForType: NSPasteboardTypeString];
+            if contents.is_null() {
+                None
+            } else {
+                Some(util::from_nsstring(contents))
+            }
+        }
+    }
+
+    /// Given a list of supported clipboard types, returns the supported type which has
+    /// highest priority on the system clipboard, or `None` if no types are supported.
+    pub fn preferred_format(&self, formats: &[FormatId]) -> Option<FormatId> {
+        unsafe {
+            let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
+            let nsstrings = formats
+                .iter()
+                .map(|s| util::make_nsstring(s))
+                .collect::<Vec<_>>();
+            let array = NSArray::arrayWithObjects(nil, &nsstrings);
+            let available: id = msg_send![pasteboard, availableTypeFromArray: array];
+            if available.is_null() {
+                None
+            } else {
+                let idx: NSUInteger = msg_send![array, indexOfObject: available];
+                let idx = idx as usize;
+                if idx > formats.len() {
+                    log::error!("clipboard object not found");
+                    None
+                } else {
+                    Some(formats[idx])
+                }
+            }
+        }
+    }
+
+    /// Return data in a given format, if available.
+    ///
+    /// It is recommended that the `fmt` argument be a format returned by
+    /// [`Clipboard::preferred_format`]
+    pub fn get_format(&self, fmt: FormatId) -> Option<Vec<u8>> {
+        unsafe {
+            let pb_type = util::make_nsstring(fmt);
+            let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
+            let data: id = msg_send![pasteboard, dataForType: pb_type];
+            if !data.is_null() {
+                let data = util::from_nsdata(data);
+                Some(data)
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/druid-shell/src/platform/mac/mod.rs
+++ b/druid-shell/src/platform/mac/mod.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::let_unit_value)]
 
 pub mod application;
+pub mod clipboard;
 pub mod dialog;
 pub mod error;
 pub mod keycodes;

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -42,13 +42,11 @@ use crate::piet::{Piet, RenderContext};
 use super::dialog;
 use super::menu::Menu;
 use super::util::{assert_main_thread, make_nsstring};
-use crate::clipboard::ClipboardItem;
 use crate::common_util::IdleCallback;
 use crate::dialog::FileDialogOptions;
 use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::keycodes::KeyCode;
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
-use crate::platform::application::Application;
 use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
 
@@ -754,10 +752,6 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
 
     fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
         unsafe { dialog::show_open_file_dialog_sync(options).map(|s| FileInfo { path: s.into() }) }
-    }
-
-    fn set_clipboard_contents(&mut self, contents: ClipboardItem) {
-        Application::set_clipboard_contents(contents);
     }
 }
 

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -14,25 +14,16 @@
 
 //! Windows implementation of features at the application scope.
 
-use std::ptr;
-
-use winapi::shared::minwindef::{FALSE, HINSTANCE, UINT};
-use winapi::shared::ntdef::{LPCWSTR, LPWSTR, WCHAR};
+use winapi::shared::minwindef::HINSTANCE;
+use winapi::shared::ntdef::LPCWSTR;
 use winapi::shared::windef::HCURSOR;
-use winapi::shared::winerror::ERROR_SUCCESS;
-use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::shellscalingapi::PROCESS_SYSTEM_DPI_AWARE;
-use winapi::um::winbase::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
 use winapi::um::wingdi::CreateSolidBrush;
-use winapi::um::winuser::{
-    CloseClipboard, EmptyClipboard, EnumClipboardFormats, GetClipboardData, LoadIconW,
-    OpenClipboard, PostQuitMessage, RegisterClassW, SetClipboardData, CF_UNICODETEXT,
-    IDI_APPLICATION, WNDCLASSW,
-};
+use winapi::um::winuser::{LoadIconW, PostQuitMessage, RegisterClassW, IDI_APPLICATION, WNDCLASSW};
 
-use super::util::{self, FromWide, ToWide, CLASS_NAME, OPTIONAL_FUNCTIONS};
+use super::clipboard::Clipboard;
+use super::util::{self, ToWide, CLASS_NAME, OPTIONAL_FUNCTIONS};
 use super::window::win_proc_dispatch;
-use crate::clipboard::ClipboardItem;
 
 pub struct Application;
 
@@ -76,107 +67,12 @@ impl Application {
         }
     }
 
-    /// Returns the contents of the clipboard, if any.
-    pub fn get_clipboard_contents() -> Option<ClipboardItem> {
-        unsafe {
-            if OpenClipboard(ptr::null_mut()) == FALSE {
-                return None;
-            }
-
-            let result = get_clipboard_impl();
-            CloseClipboard();
-            result
-        }
-    }
-
-    pub fn set_clipboard_contents(item: ClipboardItem) {
-        unsafe {
-            if OpenClipboard(ptr::null_mut()) == FALSE {
-                return;
-            }
-            EmptyClipboard();
-            match item {
-                ClipboardItem::Text(string) => {
-                    let wstr = string.to_wide();
-                    let wstr_copy =
-                        GlobalAlloc(GMEM_MOVEABLE, wstr.len() * std::mem::size_of::<WCHAR>());
-                    let locked = GlobalLock(wstr_copy) as LPWSTR;
-                    ptr::copy_nonoverlapping(wstr.as_ptr(), locked, wstr.len());
-                    GlobalUnlock(wstr_copy);
-                    SetClipboardData(CF_UNICODETEXT, wstr_copy);
-                }
-                other => log::warn!("unhandled clipboard data {:?}", other),
-            }
-            CloseClipboard();
-        }
+    pub fn clipboard() -> Clipboard {
+        Clipboard
     }
 
     pub fn get_locale() -> String {
         //TODO ahem
         "en-US".into()
-    }
-}
-
-#[allow(clippy::single_match)] // we will support more types 'soon'
-unsafe fn get_clipboard_impl() -> Option<ClipboardItem> {
-    for format in iter_clipboard_types() {
-        match format {
-            CF_UNICODETEXT => return get_unicode_text(),
-            _ => (),
-        }
-    }
-    None
-}
-
-unsafe fn get_unicode_text() -> Option<ClipboardItem> {
-    let handle = GetClipboardData(CF_UNICODETEXT);
-    let result = if handle.is_null() {
-        let unic_str = GlobalLock(handle) as LPWSTR;
-        let result = unic_str.from_wide();
-        GlobalUnlock(handle);
-        result
-    } else {
-        None
-    };
-    result.map(Into::into)
-}
-
-pub(crate) fn iter_clipboard_types() -> impl Iterator<Item = UINT> {
-    struct ClipboardTypeIter {
-        last: UINT,
-        done: bool,
-    }
-
-    impl Iterator for ClipboardTypeIter {
-        type Item = UINT;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            if self.done {
-                return None;
-            }
-            unsafe {
-                let nxt = EnumClipboardFormats(self.last);
-                match nxt {
-                    0 => {
-                        self.done = true;
-                        match GetLastError() {
-                            ERROR_SUCCESS => (),
-                            other => {
-                                log::error!("iterating clipboard formats failed, error={}", other)
-                            }
-                        }
-                        None
-                    }
-                    nxt => {
-                        self.last = nxt;
-                        Some(nxt)
-                    }
-                }
-            }
-        }
-    }
-    ClipboardTypeIter {
-        last: 0,
-        done: false,
     }
 }

--- a/druid-shell/src/platform/windows/clipboard.rs
+++ b/druid-shell/src/platform/windows/clipboard.rs
@@ -150,6 +150,12 @@ impl Clipboard {
             }
         }
     }
+
+    pub fn available_type_names(&self) -> Vec<String> {
+        iter_clipboard_types()
+            .map(|id| format!("{}: {}", get_format_name(id), id))
+            .collect()
+    }
 }
 
 unsafe fn make_handle(format: &ClipboardFormat) -> HANDLE {
@@ -253,8 +259,7 @@ fn get_format_name(format: UINT) -> String {
         if result > 0 {
             let len = result as usize;
             let lpstr = std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
-            let name = String::from_utf8_lossy(&lpstr).into_owned();
-            name
+            String::from_utf8_lossy(&lpstr).into_owned()
         } else {
             let err = GetLastError();
             if err == 87 {

--- a/druid-shell/src/platform/windows/clipboard.rs
+++ b/druid-shell/src/platform/windows/clipboard.rs
@@ -1,0 +1,306 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interactions with the system pasteboard on Windows.
+
+use std::ffi::CString;
+use std::mem;
+use std::ptr;
+
+use winapi::shared::minwindef::{FALSE, UINT};
+use winapi::shared::ntdef::{CHAR, HANDLE, LPWSTR, WCHAR};
+use winapi::shared::winerror::ERROR_SUCCESS;
+use winapi::um::errhandlingapi::GetLastError;
+use winapi::um::winbase::{GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE};
+use winapi::um::winuser::{
+    CloseClipboard, EmptyClipboard, EnumClipboardFormats, GetClipboardData,
+    GetClipboardFormatNameA, IsClipboardFormatAvailable, OpenClipboard, RegisterClipboardFormatA,
+    SetClipboardData, CF_UNICODETEXT,
+};
+
+use super::util::{FromWide, ToWide};
+use crate::clipboard::{ClipboardFormat, FormatId};
+
+#[derive(Debug, Clone, Default)]
+pub struct Clipboard;
+
+impl Clipboard {
+    /// Put a string onto the system clipboard.
+    pub fn put_string(&mut self, s: impl AsRef<str>) {
+        let s = s.as_ref();
+        let format: ClipboardFormat = s.into();
+        self.put_formats(&[format])
+    }
+
+    /// Put multi-format data on the system clipboard.
+    pub fn put_formats(&mut self, formats: &[ClipboardFormat]) {
+        unsafe {
+            if OpenClipboard(ptr::null_mut()) == FALSE {
+                return;
+            }
+            EmptyClipboard();
+
+            for format in formats {
+                let handle = make_handle(&format);
+                let format_id = match get_format_id(&format.identifier) {
+                    Some(id) => id,
+                    None => {
+                        log::warn!("failed to register clipboard format {}", &format.identifier);
+                        continue;
+                    }
+                };
+                let result = SetClipboardData(format_id, handle);
+                if result.is_null() {
+                    log::warn!(
+                        "failed to set clipboard for fmt {}, error: {}",
+                        &format.identifier,
+                        GetLastError()
+                    );
+                }
+            }
+            CloseClipboard();
+        }
+    }
+
+    /// Get a string from the system clipboard, if one is available.
+    pub fn get_string(&self) -> Option<String> {
+        unsafe {
+            if OpenClipboard(ptr::null_mut()) == FALSE {
+                return None;
+            }
+            let handle = GetClipboardData(CF_UNICODETEXT);
+            if handle.is_null() {
+                None
+            } else {
+                let unic_str = GlobalLock(handle) as LPWSTR;
+                let result = unic_str.from_wide();
+                GlobalUnlock(handle);
+                result
+            }
+        }
+    }
+
+    /// Given a list of supported clipboard types, returns the supported type which has
+    /// highest priority on the system clipboard, or `None` if no types are supported.
+    pub fn preferred_format(&self, formats: &[FormatId]) -> Option<FormatId> {
+        unsafe {
+            if OpenClipboard(ptr::null_mut()) == FALSE {
+                return None;
+            }
+            let format_ids = formats
+                .iter()
+                .map(|id| get_format_id(id))
+                .collect::<Vec<_>>();
+
+            let first_match =
+                iter_clipboard_types().find(|available| format_ids.contains(&Some(*available)));
+            let format_idx =
+                first_match.and_then(|id| format_ids.iter().position(|i| i == &Some(id)));
+            let result = format_idx.map(|idx| formats[idx]);
+            CloseClipboard();
+            result
+        }
+    }
+
+    /// Return data in a given format, if available.
+    ///
+    /// It is recommended that the `fmt` argument be a format returned by
+    /// [`Clipboard::preferred_format`]
+    pub fn get_format(&self, format: FormatId) -> Option<Vec<u8>> {
+        if format == ClipboardFormat::TEXT {
+            return self.get_string().map(String::into_bytes);
+        }
+
+        unsafe {
+            if OpenClipboard(ptr::null_mut()) == FALSE {
+                return None;
+            }
+
+            let format_id = match get_format_id(&format) {
+                Some(id) => id,
+                None => {
+                    log::warn!("failed to register clipboard format {}", &format);
+                    return None;
+                }
+            };
+
+            if IsClipboardFormatAvailable(format_id) != 0 {
+                let handle = GetClipboardData(format_id);
+                let size = GlobalSize(handle);
+                let locked = GlobalLock(handle) as *const u8;
+                let mut dest = Vec::<u8>::with_capacity(size);
+                ptr::copy_nonoverlapping(locked, dest.as_mut_ptr(), size);
+                dest.set_len(size);
+                GlobalUnlock(handle);
+                CloseClipboard();
+                Some(dest)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+unsafe fn make_handle(format: &ClipboardFormat) -> HANDLE {
+    if format.identifier == ClipboardFormat::TEXT {
+        let s = std::str::from_utf8_unchecked(&format.data);
+        let wstr = s.to_wide();
+        let handle = GlobalAlloc(GMEM_MOVEABLE, wstr.len() * mem::size_of::<WCHAR>());
+        let locked = GlobalLock(handle) as LPWSTR;
+        ptr::copy_nonoverlapping(wstr.as_ptr(), locked, wstr.len());
+        GlobalUnlock(handle);
+        handle
+    } else {
+        let handle = GlobalAlloc(GMEM_MOVEABLE, format.data.len() * mem::size_of::<CHAR>());
+        let locked = GlobalLock(handle) as *mut u8;
+        ptr::copy_nonoverlapping(format.data.as_ptr(), locked, format.data.len());
+        GlobalUnlock(handle);
+        handle
+    }
+}
+
+fn get_format_id(format: FormatId) -> Option<UINT> {
+    match format {
+        ClipboardFormat::TEXT => Some(CF_UNICODETEXT),
+        other => register_identifier(other),
+    }
+}
+
+fn register_identifier(ident: &str) -> Option<UINT> {
+    let cstr = match CString::new(ident) {
+        Ok(s) => s,
+        Err(_) => {
+            // granted this should happen _never_, but unwrap feels bad
+            log::warn!("Null byte in clipboard identifier '{}'", ident);
+            return None;
+        }
+    };
+    unsafe {
+        let pb_format = RegisterClipboardFormatA(cstr.as_ptr());
+        if pb_format == 0 {
+            let err = GetLastError();
+            log::warn!(
+                "failed to register clipboard format '{}'; error {}.",
+                ident,
+                err
+            );
+            return None;
+        }
+        Some(pb_format)
+    }
+}
+
+fn iter_clipboard_types() -> impl Iterator<Item = UINT> {
+    struct ClipboardTypeIter {
+        last: UINT,
+        done: bool,
+    }
+
+    impl Iterator for ClipboardTypeIter {
+        type Item = UINT;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.done {
+                return None;
+            }
+            unsafe {
+                let nxt = EnumClipboardFormats(self.last);
+                match nxt {
+                    0 => {
+                        self.done = true;
+                        match GetLastError() {
+                            ERROR_SUCCESS => (),
+                            other => {
+                                log::error!("iterating clipboard formats failed, error={}", other)
+                            }
+                        }
+                        None
+                    }
+                    nxt => {
+                        self.last = nxt;
+                        Some(nxt)
+                    }
+                }
+            }
+        }
+    }
+    ClipboardTypeIter {
+        last: 0,
+        done: false,
+    }
+}
+
+fn get_format_name(format: UINT) -> String {
+    if let Some(name) = get_standard_format_name(format) {
+        return name;
+    }
+
+    const BUF_SIZE: usize = 64;
+    unsafe {
+        let mut buffer: [CHAR; BUF_SIZE] = [0; BUF_SIZE];
+        let result = GetClipboardFormatNameA(format, buffer.as_mut_ptr(), BUF_SIZE as i32);
+        if result > 0 {
+            let len = result as usize;
+            let lpstr = std::slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
+            let name = String::from_utf8_lossy(&lpstr).into_owned();
+            name
+        } else {
+            let err = GetLastError();
+            if err == 87 {
+                String::from("Unknown Format")
+            } else {
+                log::warn!(
+                    "error getting clipboard format name for format {}, errno {}",
+                    format,
+                    err
+                );
+                String::new()
+            }
+        }
+    }
+}
+
+// https://docs.microsoft.com/en-ca/windows/win32/dataxchg/standard-clipboard-formats
+fn get_standard_format_name(format: UINT) -> Option<String> {
+    let name = match format {
+        1 => "CF_TEXT",
+        2 => "CF_BITMAP",
+        3 => "CF_METAFILEPICT",
+        4 => "CF_SYLK",
+        5 => "CF_DIF",
+        6 => "CF_TIFF",
+        7 => "CF_OEMTEXT",
+        8 => "CF_DIB",
+        9 => "CF_PALETTE",
+        10 => "CF_PENDATA",
+        11 => "CF_RIFF",
+        12 => "CF_WAVE",
+        13 => "CF_UNICODETEXT",
+        14 => "CF_ENHMETAFILE",
+        15 => "CF_HDROP",
+        16 => "CF_LOCALE",
+        17 => "CF_DIBV5",
+        0x0080 => "CF_OWNERDISPLAY",
+        0x0081 => "CF_DSPTEXT",
+        0x0082 => "CF_DSPBITMAP",
+        0x0083 => "CF_DSPMETAFILEPICT",
+        0x008E => "CF_DSPENHMETAFILE",
+        0x0200 => "CF_PRIVATEFIRST",
+        0x02FF => "CF_PRIVATELAST",
+        0x0300 => "CF_GDIOBJFIRST",
+        0x03FF => "CF_GDIOBJLAST",
+        _ => return None,
+    };
+    Some(name.into())
+}

--- a/druid-shell/src/platform/windows/mod.rs
+++ b/druid-shell/src/platform/windows/mod.rs
@@ -15,6 +15,7 @@
 //! Windows implementation of druid-shell.
 
 pub mod application;
+pub mod clipboard;
 pub mod dcomp;
 pub mod dialog;
 pub mod error;

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -56,8 +56,6 @@ use super::paint;
 use super::timers::TimerSlots;
 use super::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 
-use crate::application::Application;
-use crate::clipboard::ClipboardItem;
 use crate::common_util::IdleCallback;
 use crate::dialog::{FileDialogOptions, FileDialogType};
 use crate::keyboard::{KeyEvent, KeyModifiers};
@@ -1307,10 +1305,6 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
                     path: os_str.into(),
                 })
         }
-    }
-
-    fn set_clipboard_contents(&mut self, contents: ClipboardItem) {
-        Application::set_clipboard_contents(contents);
     }
 }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -19,7 +19,6 @@
 use std::any::Any;
 use std::path::PathBuf;
 
-use crate::clipboard::ClipboardItem;
 use crate::dialog::FileDialogOptions;
 use crate::error::Error;
 use crate::keyboard::{KeyEvent, KeyModifiers};
@@ -206,9 +205,6 @@ pub trait WinCtx<'a> {
     ///
     /// Blocks while the user picks the file.
     fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo>;
-
-    /// Set clipboard contents.
-    fn set_clipboard_contents(&mut self, contents: ClipboardItem);
 }
 
 /// App behavior, supplied by the app.

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -16,7 +16,7 @@
 
 use crate::kurbo::{Rect, Shape, Size, Vec2};
 
-use druid_shell::{ClipboardItem, FileInfo, KeyEvent, KeyModifiers, TimerToken};
+use druid_shell::{Clipboard, FileInfo, KeyEvent, KeyModifiers, TimerToken};
 
 use crate::mouse::MouseEvent;
 use crate::Command;
@@ -93,7 +93,7 @@ pub enum Event {
     /// a corresponding `KeyUp` is sent.
     KeyUp(KeyEvent),
     /// Called when a paste command is received.
-    Paste(ClipboardItem),
+    Paste(Clipboard),
     /// Called when the mouse wheel or trackpad is scrolled.
     Wheel(WheelEvent),
     /// Called when the "hot" status changes.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -47,8 +47,8 @@ use piet::{Piet, RenderContext};
 pub use unicode_segmentation;
 
 pub use shell::{
-    ClipboardItem, Cursor, FileDialogOptions, FileDialogType, HotKey, KeyCode, KeyEvent,
-    KeyModifiers, MouseButton, RawMods, SysMods, Text, TimerToken, WinCtx, WindowHandle,
+    Clipboard, Cursor, FileDialogOptions, FileDialogType, HotKey, KeyCode, KeyEvent, KeyModifiers,
+    MouseButton, RawMods, SysMods, Text, TimerToken, WinCtx, WindowHandle,
 };
 
 pub use app::{AppLauncher, WindowDesc};
@@ -966,11 +966,6 @@ impl<'a, 'b> EventCtx<'a, 'b> {
     /// Get the window id.
     pub fn window_id(&self) -> WindowId {
         self.window_id
-    }
-
-    /// Set clipboard contents.
-    pub fn set_clipboard_contents(&mut self, contents: impl Into<ClipboardItem>) {
-        self.win_ctx.set_clipboard_contents(contents.into());
     }
 }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -19,9 +19,11 @@ use std::ops::Range;
 use std::time::{Duration, Instant};
 
 use crate::{
-    BaseState, BoxConstraints, ClipboardItem, Cursor, Env, Event, EventCtx, HotKey, KeyCode,
-    LayoutCtx, PaintCtx, RawMods, SysMods, TimerToken, UpdateCtx, Widget,
+    BaseState, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx, PaintCtx,
+    RawMods, SysMods, TimerToken, UpdateCtx, Widget,
 };
+
+use crate::shell::Application;
 
 use crate::kurbo::{Affine, Line, Point, RoundedRect, Size, Vec2};
 use crate::piet::{
@@ -362,7 +364,7 @@ impl Widget<String> for TextBox {
                         || cmd.selector == crate::command::sys::CUT) =>
             {
                 if let Some(text) = data.get(self.selection.range()) {
-                    ctx.set_clipboard_contents(text);
+                    Application::clipboard().put_string(text);
                 }
                 if !self.selection.is_caret() && cmd.selector == crate::command::sys::CUT {
                     self.backspace(data);
@@ -370,8 +372,8 @@ impl Widget<String> for TextBox {
                 ctx.set_handled();
             }
             Event::Paste(ref item) => {
-                if let ClipboardItem::Text(string) = item {
-                    self.insert(data, string);
+                if let Some(string) = item.get_string() {
+                    self.insert(data, &string);
                     self.reset_cursor_blink(ctx);
                 }
             }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -569,10 +569,8 @@ impl<T: Data + 'static> DruidHandler<T> {
     }
 
     fn do_paste(&mut self, window_id: WindowId, ctx: &mut dyn WinCtx) {
-        if let Some(clip_item) = Application::get_clipboard_contents() {
-            let event = Event::Paste(clip_item);
-            self.app_state.borrow_mut().do_event(window_id, event, ctx);
-        }
+        let event = Event::Paste(Application::clipboard());
+        self.app_state.borrow_mut().do_event(window_id, event, ctx);
     }
 
     fn quit(&self) {


### PR DESCRIPTION
This was very frustrating! I spent a lot of time trying to come up with a more "just works" API, but it ended up getting hairy and ultimately I ripped it out and tried to just do the simplest API I could.

In any case, this is working on mac, windows and gtk. The only bug I'm aware of is on GTK; if you put multiple formats on the clipboard, and one of them is text, the clipboard doesn't seem able to retrieve the text. I'm not totally sure what's going on there, but I'm not going to fight it right now, it's a pretty marginal case all in all.

Anyway: this covers the common case (text) and the special case required by runebender (multi-format vector data) comfortably. There may be future limitations; in particular I think doing copy/paste for images is going to be a headache and a half, but we can worry about that at some future date.