### PR TITLE
s/Meta/Super/ in GTK

### DIFF
--- a/druid-shell/src/platform/gtk/keycodes.rs
+++ b/druid-shell/src/platform/gtk/keycodes.rs
@@ -85,8 +85,8 @@ impl From<u32> for KeyCode {
             Alt_R => KeyCode::RightAlt,
             Shift_L => KeyCode::LeftShift,
             Shift_R => KeyCode::RightShift,
-            Meta_L => KeyCode::LeftMeta,
-            Meta_R => KeyCode::RightMeta,
+            Super_L => KeyCode::LeftMeta,
+            Super_R => KeyCode::RightMeta,
 
             space => KeyCode::Space,
             Caps_Lock => KeyCode::CapsLock,
@@ -212,8 +212,8 @@ impl From<KeyCode> for u32 {
             KeyCode::RightAlt => Alt_R,
             KeyCode::LeftShift => Shift_L,
             KeyCode::RightShift => Shift_R,
-            KeyCode::LeftMeta => Meta_L,
-            KeyCode::RightMeta => Meta_R,
+            KeyCode::LeftMeta => Super_L,
+            KeyCode::RightMeta => Super_R,
 
             KeyCode::Space => space,
             KeyCode::CapsLock => Caps_Lock,


### PR DESCRIPTION
On Linux, the windows key is Super; Meta is an ancient and unused relic.

There's a case for renaming the druid-shell keycode, but that would be substantially more invasive and I don't personally care what it's called so long as it's not spitting errors into the console.