### PR TITLE
[shell] Use 'UTF8_STRING' as text clipboard type on gtk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ name = "druid-shell"
 version = "0.4.0"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -19,6 +19,7 @@ piet-common = "0.0.7"
 log = "0.4.8"
 lazy_static = "1.0"
 time = "0.1.39"
+cfg-if = "0.1.10"
 
 cairo-rs = {  version = "0.7.1", default_features = false, optional = true }
 gio = { version = "0.7.0", optional = true }

--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -214,16 +214,25 @@ impl From<platform::Clipboard> for Clipboard {
     }
 }
 
-#[cfg(all(target_os = "macos", not(feature = "use_gtk")))]
-impl ClipboardFormat {
-    pub const PDF: &'static str = "com.adobe.pdf";
-    pub const TEXT: &'static str = "public.utf8-plain-text";
-    pub const SVG: &'static str = "public.svg-image";
-}
-
-#[cfg(any(not(target_os = "macos"), feature = "use_gtk"))]
-impl ClipboardFormat {
-    pub const PDF: &'static str = "application/pdf";
-    pub const TEXT: &'static str = "text/plain";
-    pub const SVG: &'static str = "image/svg+xml";
+cfg_if::cfg_if! {
+    if #[cfg(all(target_os = "macos", not(feature = "use_gtk")))] {
+        impl ClipboardFormat {
+            pub const PDF: &'static str = "com.adobe.pdf";
+            pub const TEXT: &'static str = "public.utf8-plain-text";
+            pub const SVG: &'static str = "public.svg-image";
+        }
+    } else {
+        impl ClipboardFormat {
+            cfg_if::cfg_if! {
+                if #[cfg(any(feature = "use_gtk", target_os = "linux"))] {
+                    // trial and error; this is the most supported string type for gtk?
+                    pub const TEXT: &'static str = "UTF8_STRING";
+                } else {
+                    pub const TEXT: &'static str = "text/plain";
+                }
+            }
+            pub const PDF: &'static str = "application/pdf";
+            pub const SVG: &'static str = "image/svg+xml";
+        }
+    }
 }

--- a/druid-shell/src/platform/mod.rs
+++ b/druid-shell/src/platform/mod.rs
@@ -14,17 +14,15 @@
 
 //! Platform specific implementations.
 
-#[cfg(all(target_os = "windows", not(feature = "use_gtk")))]
-mod windows;
-#[cfg(all(target_os = "windows", not(feature = "use_gtk")))]
-pub use windows::*;
-
-#[cfg(all(target_os = "macos", not(feature = "use_gtk")))]
-mod mac;
-#[cfg(all(target_os = "macos", not(feature = "use_gtk")))]
-pub use mac::*;
-
-#[cfg(any(feature = "use_gtk", target_os = "linux"))]
-mod gtk;
-#[cfg(any(feature = "use_gtk", target_os = "linux"))]
-pub use self::gtk::*;
+cfg_if::cfg_if! {
+    if #[cfg(all(target_os = "windows", not(feature = "use_gtk")))] {
+        mod windows;
+        pub use windows::*;
+    } else if #[cfg(all(target_os = "macos", not(feature = "use_gtk")))] {
+        mod mac;
+        pub use mac::*;
+    } else if #[cfg(any(feature = "use_gtk", target_os = "linux"))] {
+        mod gtk;
+        pub use self::gtk::*;
+    }
+}


### PR DESCRIPTION
This also brings in the (very light) cfg_if dependency, because I
was finding it hard to follow the logical relationship between
various `cfg` blocks; I've used this macro for setting the
clipboard identifiers, and I've also used it for the platform
declarations in druid-shell::platform.