### PR TITLE
Cleanup druid exports

### DIFF
--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -14,7 +14,7 @@
 
 //! This example shows how to construct a basic layout.
 
-use druid::shell::piet::Color;
+use druid::piet::Color;
 use druid::widget::{Button, Column, Label, Row, SizedBox, WidgetExt};
 use druid::{AppLauncher, Widget, WindowDesc};
 

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -14,11 +14,10 @@
 
 //! Opening and closing windows and using window and context menus.
 
-use druid::menu::{ContextMenu, MenuDesc, MenuItem};
 use druid::widget::{Align, Button, Column, Label, Padding, Row};
 use druid::{
-    AppDelegate, AppLauncher, Command, Data, DelegateCtx, Env, Event, EventCtx, LocalizedString,
-    Selector, Widget, WindowDesc, WindowId,
+    AppDelegate, AppLauncher, Command, ContextMenu, Data, DelegateCtx, Env, Event, EventCtx,
+    LocalizedString, MenuDesc, MenuItem, Selector, Widget, WindowDesc, WindowId,
 };
 
 use log::info;
@@ -49,14 +48,14 @@ trait EventCtxExt {
 
 impl EventCtxExt for EventCtx<'_, '_> {
     fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>) {
-        let cmd = Command::new(druid::command::sys::SET_MENU, menu);
+        let cmd = Command::new(druid::commands::SET_MENU, menu);
         self.submit_command(cmd, None);
     }
 }
 
 impl EventCtxExt for DelegateCtx<'_> {
     fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>) {
-        let cmd = Command::new(druid::command::sys::SET_MENU, menu);
+        let cmd = Command::new(druid::commands::SET_MENU, menu);
         self.submit_command(cmd, None);
     }
 }
@@ -94,11 +93,11 @@ impl AppDelegate<State> for Delegate {
         ctx: &mut DelegateCtx,
     ) -> Option<Event> {
         match event {
-            Event::Command(ref cmd) if cmd.selector == druid::command::sys::NEW_FILE => {
+            Event::Command(ref cmd) if cmd.selector == druid::commands::NEW_FILE => {
                 let new_win = WindowDesc::new(ui_builder)
                     .menu(make_menu(data))
                     .window_size((data.selected as f64 * 100.0 + 300.0, 500.0));
-                let command = Command::new(druid::command::sys::NEW_WINDOW, new_win);
+                let command = Command::new(druid::commands::NEW_WINDOW, new_win);
                 ctx.submit_command(command, None);
                 None
             }
@@ -121,7 +120,7 @@ impl AppDelegate<State> for Delegate {
             }
             Event::MouseDown(ref mouse) if mouse.button.is_right() => {
                 let menu = ContextMenu::new(make_context_menu::<State>(), mouse.pos);
-                let cmd = Command::new(druid::command::sys::SHOW_CONTEXT_MENU, menu);
+                let cmd = Command::new(druid::commands::SHOW_CONTEXT_MENU, menu);
                 ctx.submit_command(cmd, None);
                 None
             }
@@ -153,11 +152,11 @@ fn make_menu<T: Data>(state: &State) -> MenuDesc<T> {
     let mut base = MenuDesc::empty();
     #[cfg(target_os = "macos")]
     {
-        base = druid::menu::sys::mac::menu_bar();
+        base = druid::platform_menus::mac::menu_bar();
     }
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     {
-        base = base.append(druid::menu::sys::win::file::default());
+        base = base.append(druid::platform_menus::win::file::default());
     }
     if state.menu_count != 0 {
         base = base.append(

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -14,7 +14,7 @@
 
 //! This example allows to play with scroll bars over different color tones.
 
-use druid::shell::piet::Color;
+use druid::piet::Color;
 use druid::widget::{Column, Container, Row, Scroll, SizedBox};
 use druid::{AppLauncher, Widget, WindowDesc};
 

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -14,7 +14,7 @@
 
 //! This example demonstrates the `Split` widget
 
-use druid::shell::piet::Color;
+use druid::piet::Color;
 use druid::widget::{Align, Container, Label, Padding, Split};
 use druid::{AppLauncher, Widget, WindowDesc};
 

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -56,9 +56,9 @@ fn build_widget() -> impl Widget<String> {
 
 fn make_main_menu<T: Data>() -> MenuDesc<T> {
     let edit_menu = MenuDesc::new(LocalizedString::new("common-menu-edit-menu"))
-        .append(druid::menu::sys::common::cut())
-        .append(druid::menu::sys::common::copy())
-        .append(druid::menu::sys::common::paste());
+        .append(druid::platform_menus::common::cut())
+        .append(druid::platform_menus::common::copy())
+        .append(druid::platform_menus::common::paste());
 
     MenuDesc::platform_default()
         .unwrap_or(MenuDesc::empty())

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -42,7 +42,9 @@ pub struct Command {
     object: Option<Arc<dyn Any>>,
 }
 
-/// Commands with special meaning.
+/// [`Command`]s with special meaning, defined by druid.
+///
+/// [`Command`]: struct.Command.html
 pub mod sys {
     use super::Selector;
 

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -159,7 +159,7 @@ impl Env {
     /// resources.
     ///
     /// [`L10nManager`]: struct.L10nManager.html
-    pub fn localization_manager(&self) -> &L10nManager {
+    pub(crate) fn localization_manager(&self) -> &L10nManager {
         &self.0.l10n
     }
 }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -17,17 +17,18 @@
 #![deny(intra_doc_link_resolution_failure, unsafe_code)]
 #![allow(clippy::new_ret_no_self)]
 
-pub use druid_shell::{self as shell, kurbo, piet};
+use druid_shell as shell;
+pub use druid_shell::{kurbo, piet};
 
 mod app;
 mod app_delegate;
-pub mod command;
+mod command;
 mod data;
 mod env;
 mod event;
 mod lens;
-pub mod localization;
-pub mod menu;
+mod localization;
+mod menu;
 mod mouse;
 pub mod theme;
 pub mod widget;
@@ -36,7 +37,6 @@ mod window;
 
 use std::collections::VecDeque;
 use std::ops::{Deref, DerefMut};
-
 use std::time::Instant;
 
 use log::{error, warn};
@@ -44,22 +44,22 @@ use log::{error, warn};
 use kurbo::{Affine, Point, Rect, Shape, Size, Vec2};
 use piet::{Piet, RenderContext};
 
-pub use unicode_segmentation;
-
+// these are the types from shell that we expose; others we only use internally.
 pub use shell::{
-    Clipboard, Cursor, FileDialogOptions, FileDialogType, HotKey, KeyCode, KeyEvent, KeyModifiers,
-    MouseButton, RawMods, SysMods, Text, TimerToken, WinCtx, WindowHandle,
+    Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileDialogType, FileSpec,
+    FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods, Text,
+    TimerToken, WinCtx, WindowHandle,
 };
 
 pub use app::{AppLauncher, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};
-pub use command::{Command, Selector};
+pub use command::{sys as commands, Command, Selector};
 pub use data::Data;
 pub use env::{Env, Key, Value};
 pub use event::{Event, WheelEvent};
 pub use lens::{Lens, LensWrap};
 pub use localization::LocalizedString;
-pub use menu::MenuDesc;
+pub use menu::{sys as platform_menus, ContextMenu, MenuDesc, MenuItem};
 pub use mouse::MouseEvent;
 pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};

--- a/druid/src/localization.rs
+++ b/druid/src/localization.rs
@@ -59,10 +59,12 @@ static FALLBACK_STRINGS: &str = include_str!("../resources/i18n/en-US/builtin.ft
 
 /// Provides access to the localization strings for the current locale.
 #[allow(dead_code)]
-pub struct L10nManager {
+pub(crate) struct L10nManager {
+    // these two are not currently used; will be used when we let the user
+    // add additional localization files.
     res_mgr: ResourceManager,
-    current_bundle: BundleStack,
     resources: Vec<String>,
+    current_bundle: BundleStack,
     current_locale: LanguageIdentifier,
 }
 
@@ -97,7 +99,7 @@ pub struct LocalizedString<T> {
 }
 
 /// A stack of localization resources, used for fallback.
-pub struct BundleStack(Vec<FluentBundle<Arc<FluentResource>>>);
+struct BundleStack(Vec<FluentBundle<Arc<FluentResource>>>);
 
 impl BundleStack {
     fn get_message(&self, id: &str) -> Option<FluentMessage> {

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -47,21 +47,20 @@
 //! Creating the default Application menu for macOS:
 //!
 //! ```
-//! use druid::{Data, LocalizedString, RawMods};
-//! use druid::command;
-//! use druid::menu::{MenuDesc, MenuItem};
+//! use druid::{Data, LocalizedString, MenuDesc, MenuItem, RawMods};
+//! use druid::commands;
 //!
 //! fn macos_application_menu<T: Data>() -> MenuDesc<T> {
 //!     MenuDesc::new(LocalizedString::new("macos-menu-application-menu"))
 //!         .append(MenuItem::new(
 //!             LocalizedString::new("macos-menu-about-app"),
-//!             command::sys::SHOW_ABOUT,
+//!             commands::SHOW_ABOUT,
 //!         ))
 //!         .append_separator()
 //!         .append(
 //!             MenuItem::new(
 //!                 LocalizedString::new("macos-menu-preferences"),
-//!                 command::sys::SHOW_PREFERENCES,
+//!                 commands::SHOW_PREFERENCES,
 //!             )
 //!             .hotkey(RawMods::Meta, ",")
 //!             .disabled(),
@@ -71,21 +70,21 @@
 //!         .append(
 //!             MenuItem::new(
 //!                 LocalizedString::new("macos-menu-hide-app"),
-//!                 command::sys::HIDE_APPLICATION,
+//!                 commands::HIDE_APPLICATION,
 //!             )
 //!             .hotkey(RawMods::Meta, "h"),
 //!         )
 //!         .append(
 //!             MenuItem::new(
 //!                 LocalizedString::new("macos-menu-hide-others"),
-//!                 command::sys::HIDE_OTHERS,
+//!                 commands::HIDE_OTHERS,
 //!             )
 //!             .hotkey(RawMods::AltMeta, "h"),
 //!         )
 //!         .append(
 //!             MenuItem::new(
 //!                 LocalizedString::new("macos-menu-show-all"),
-//!                 command::sys::SHOW_ALL,
+//!                 commands::SHOW_ALL,
 //!             )
 //!             .disabled(),
 //!         )
@@ -93,7 +92,7 @@
 //!         .append(
 //!             MenuItem::new(
 //!                 LocalizedString::new("macos-menu-quit-app"),
-//!                 command::sys::QUIT_APP,
+//!                 commands::QUIT_APP,
 //!             )
 //!             .hotkey(RawMods::Meta, "q"),
 //!         )
@@ -110,7 +109,7 @@ use std::num::NonZeroU32;
 
 use crate::kurbo::Point;
 use crate::shell::{HotKey, KeyCompare, Menu as PlatformMenu, RawMods, SysMods};
-use crate::{command, Command, Data, Env, KeyCode, LocalizedString, Selector};
+use crate::{commands, Command, Data, Env, KeyCode, LocalizedString, Selector};
 
 /// A platform-agnostic description of an application, window, or context
 /// menu.
@@ -153,6 +152,7 @@ pub struct MenuItem<T> {
     platform_id: MenuItemId,
 }
 
+/// A menu displayed as a pop-over.
 #[derive(Debug, Clone)]
 pub struct ContextMenu<T> {
     pub(crate) menu: MenuDesc<T>,
@@ -187,8 +187,7 @@ impl<T> MenuItem<T> {
     /// # Example
     ///
     /// ```
-    /// # use druid::{LocalizedString, MenuDesc, Selector, SysMods};
-    /// # use druid::menu::MenuItem;
+    /// # use druid::{LocalizedString, MenuDesc, MenuItem, Selector, SysMods};
     ///
     /// let item = MenuItem::new(LocalizedString::new("My Menu Item"), Selector::new("My Selector"))
     ///     .hotkey(SysMods::Cmd, "m");
@@ -266,8 +265,7 @@ impl<T: Data> MenuDesc<T> {
     /// # Examples
     ///
     /// ```
-    /// use druid::{Command, LocalizedString, MenuDesc, Selector};
-    /// use druid::menu::MenuItem;
+    /// use druid::{Command, LocalizedString, MenuDesc, MenuItem, Selector};
     ///
     /// let num_items: usize = 4;
     /// const MENU_COUNT_ACTION: Selector = Selector::new("menu-count-action");
@@ -453,7 +451,7 @@ impl<T> From<MenuDesc<T>> for MenuEntry<T> {
     }
 }
 
-/// Standard system menu items.
+/// Pre-configured, platform appropriate menus and menu items.
 pub mod sys {
     use super::*;
 
@@ -462,34 +460,31 @@ pub mod sys {
         use super::*;
         /// 'Cut'.
         pub fn cut<T: Data>() -> MenuItem<T> {
-            MenuItem::new(LocalizedString::new("common-menu-cut"), command::sys::CUT)
+            MenuItem::new(LocalizedString::new("common-menu-cut"), commands::CUT)
                 .hotkey(SysMods::Cmd, "x")
         }
 
         /// The 'Copy' menu item.
         pub fn copy<T: Data>() -> MenuItem<T> {
-            MenuItem::new(LocalizedString::new("common-menu-copy"), command::sys::COPY)
+            MenuItem::new(LocalizedString::new("common-menu-copy"), commands::COPY)
                 .hotkey(SysMods::Cmd, "c")
         }
 
         /// The 'Paste' menu item.
         pub fn paste<T: Data>() -> MenuItem<T> {
-            MenuItem::new(
-                LocalizedString::new("common-menu-paste"),
-                command::sys::PASTE,
-            )
-            .hotkey(SysMods::Cmd, "v")
+            MenuItem::new(LocalizedString::new("common-menu-paste"), commands::PASTE)
+                .hotkey(SysMods::Cmd, "v")
         }
 
         /// The 'Undo' menu item.
         pub fn undo<T: Data>() -> MenuItem<T> {
-            MenuItem::new(LocalizedString::new("common-menu-undo"), command::sys::UNDO)
+            MenuItem::new(LocalizedString::new("common-menu-undo"), commands::UNDO)
                 .hotkey(SysMods::Cmd, "z")
         }
 
         /// The 'Redo' menu item.
         pub fn redo<T: Data>() -> MenuItem<T> {
-            let item = MenuItem::new(LocalizedString::new("common-menu-redo"), command::sys::REDO);
+            let item = MenuItem::new(LocalizedString::new("common-menu-redo"), commands::REDO);
 
             #[cfg(target_os = "windows")]
             {
@@ -537,7 +532,7 @@ pub mod sys {
             pub fn new<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-new"),
-                    command::sys::NEW_FILE,
+                    commands::NEW_FILE,
                 )
                 .hotkey(RawMods::Ctrl, "n")
             }
@@ -546,7 +541,7 @@ pub mod sys {
             pub fn open<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-open"),
-                    command::sys::OPEN_FILE,
+                    commands::OPEN_FILE,
                 )
                 .hotkey(RawMods::Ctrl, "o")
             }
@@ -555,7 +550,7 @@ pub mod sys {
             pub fn close<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-close"),
-                    command::sys::CLOSE_WINDOW,
+                    commands::CLOSE_WINDOW,
                 )
             }
 
@@ -563,7 +558,7 @@ pub mod sys {
             pub fn save<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save"),
-                    command::sys::SAVE_FILE,
+                    commands::SAVE_FILE,
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }
@@ -572,7 +567,7 @@ pub mod sys {
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save"),
-                    command::sys::SAVE_FILE,
+                    commands::SAVE_FILE,
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }
@@ -581,7 +576,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    command::sys::SAVE_FILE_AS,
+                    commands::SAVE_FILE_AS,
                 )
                 .hotkey(RawMods::CtrlShift, "s")
             }
@@ -590,7 +585,7 @@ pub mod sys {
             pub fn print<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-print"),
-                    command::sys::PRINT,
+                    commands::PRINT,
                 )
                 .hotkey(RawMods::Ctrl, "p")
             }
@@ -599,7 +594,7 @@ pub mod sys {
             pub fn print_preview<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-print-preview"),
-                    command::sys::PRINT_PREVIEW,
+                    commands::PRINT_PREVIEW,
                 )
             }
 
@@ -607,7 +602,7 @@ pub mod sys {
             pub fn page_setup<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-page-setup"),
-                    command::sys::PRINT_SETUP,
+                    commands::PRINT_SETUP,
                 )
             }
 
@@ -615,7 +610,7 @@ pub mod sys {
             pub fn exit<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("win-menu-file-exit"),
-                    command::sys::QUIT_APP,
+                    commands::QUIT_APP,
                 )
                 .hotkey(RawMods::Alt, KeyCode::F4)
             }
@@ -656,7 +651,7 @@ pub mod sys {
             pub fn about<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("macos-menu-about-app"),
-                    command::sys::SHOW_ABOUT,
+                    commands::SHOW_ABOUT,
                 )
             }
 
@@ -664,7 +659,7 @@ pub mod sys {
             pub fn preferences<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("macos-menu-preferences"),
-                    command::sys::SHOW_PREFERENCES,
+                    commands::SHOW_PREFERENCES,
                 )
                 .hotkey(RawMods::Meta, ",")
             }
@@ -673,7 +668,7 @@ pub mod sys {
             pub fn hide<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("macos-menu-hide-app"),
-                    command::sys::HIDE_APPLICATION,
+                    commands::HIDE_APPLICATION,
                 )
                 .hotkey(RawMods::Meta, "h")
             }
@@ -682,7 +677,7 @@ pub mod sys {
             pub fn hide_others<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("macos-menu-hide-others"),
-                    command::sys::HIDE_OTHERS,
+                    commands::HIDE_OTHERS,
                 )
                 .hotkey(RawMods::AltMeta, "h")
             }
@@ -692,7 +687,7 @@ pub mod sys {
             pub fn show_all<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("macos-menu-show-all"),
-                    command::sys::SHOW_ALL,
+                    commands::SHOW_ALL,
                 )
             }
 
@@ -700,7 +695,7 @@ pub mod sys {
             pub fn quit<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("macos-menu-quit-app"),
-                    command::sys::QUIT_APP,
+                    commands::QUIT_APP,
                 )
                 .hotkey(RawMods::Meta, "q")
             }
@@ -738,7 +733,7 @@ pub mod sys {
             pub fn new_file<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-new"),
-                    command::sys::NEW_FILE,
+                    commands::NEW_FILE,
                 )
                 .hotkey(RawMods::Meta, "n")
             }
@@ -747,7 +742,7 @@ pub mod sys {
             pub fn open_file<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-open"),
-                    command::sys::OPEN_FILE,
+                    commands::OPEN_FILE,
                 )
                 .hotkey(RawMods::Meta, "o")
             }
@@ -756,7 +751,7 @@ pub mod sys {
             pub fn close<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-close"),
-                    command::sys::CLOSE_WINDOW,
+                    commands::CLOSE_WINDOW,
                 )
                 .hotkey(RawMods::Meta, "w")
             }
@@ -765,7 +760,7 @@ pub mod sys {
             pub fn save<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save"),
-                    command::sys::SAVE_FILE,
+                    commands::SAVE_FILE,
                 )
                 .hotkey(RawMods::Meta, "s")
             }
@@ -776,7 +771,7 @@ pub mod sys {
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),
-                    command::sys::SAVE_FILE,
+                    commands::SAVE_FILE,
                 )
                 .hotkey(RawMods::Meta, "s")
             }
@@ -785,7 +780,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    command::sys::SAVE_FILE_AS,
+                    commands::SAVE_FILE_AS,
                 )
                 .hotkey(RawMods::MetaShift, "s")
             }
@@ -794,7 +789,7 @@ pub mod sys {
             pub fn page_setup<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-page-setup"),
-                    command::sys::PRINT_SETUP,
+                    commands::PRINT_SETUP,
                 )
                 .hotkey(RawMods::MetaShift, "p")
             }
@@ -803,7 +798,7 @@ pub mod sys {
             pub fn print<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-print"),
-                    command::sys::PRINT,
+                    commands::PRINT,
                 )
                 .hotkey(RawMods::Meta, "p")
             }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -17,13 +17,12 @@
 use std::cmp::{max, min};
 use std::ops::Range;
 use std::time::{Duration, Instant};
+use unicode_segmentation::GraphemeCursor;
 
 use crate::{
-    BaseState, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx, PaintCtx,
-    RawMods, SysMods, TimerToken, UpdateCtx, Widget,
+    Application, BaseState, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode,
+    LayoutCtx, PaintCtx, RawMods, SysMods, TimerToken, UpdateCtx, Widget,
 };
-
-use crate::shell::Application;
 
 use crate::kurbo::{Affine, Line, Point, RoundedRect, Size, Vec2};
 use crate::piet::{
@@ -32,8 +31,6 @@ use crate::piet::{
 };
 use crate::theme;
 use crate::widget::Align;
-
-use crate::unicode_segmentation::GraphemeCursor;
 
 const BORDER_WIDTH: f64 = 1.;
 const PADDING_TOP: f64 = 5.;
@@ -360,13 +357,13 @@ impl Widget<String> for TextBox {
             }
             Event::Command(ref cmd)
                 if ctx.has_focus()
-                    && (cmd.selector == crate::command::sys::COPY
-                        || cmd.selector == crate::command::sys::CUT) =>
+                    && (cmd.selector == crate::commands::COPY
+                        || cmd.selector == crate::commands::CUT) =>
             {
                 if let Some(text) = data.get(self.selection.range()) {
                     Application::clipboard().put_string(text);
                 }
-                if !self.selection.is_caret() && cmd.selector == crate::command::sys::CUT {
+                if !self.selection.is_caret() && cmd.selector == crate::commands::CUT {
                     self.backspace(data);
                 }
                 ctx.set_handled();


### PR DESCRIPTION
This is a bunch of cleanup around what we export from druid.

- We no longer expose `druid_shell`, instead selectively exposing
the types that that are intended to be used directly.
- We are more selective about what modules we expose at the top
level, trying only to do this for modules that expose constants
like `theme`.
- For submodules that expose constants, like `command::sys` and
`menu::sys` we reexport these directly at the top level.
- Other types and reexports that were unnecessarily public are removed.