### PR TITLE
Move FileInfo to dialog.rs, expose at crate root

### DIFF
--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -14,6 +14,14 @@
 
 //! File open/save dialogs.
 
+use std::path::{Path, PathBuf};
+
+/// Information about a file to be opened or saved.
+#[derive(Debug, Clone)]
+pub struct FileInfo {
+    pub(crate) path: PathBuf,
+}
+
 /// Type of file dialog.
 pub enum FileDialogType {
     /// File open dialog.
@@ -27,6 +35,8 @@ pub enum FileDialogType {
 pub struct FileDialogOptions {
     pub show_hidden: bool,
     pub allowed_types: Option<Vec<FileSpec>>,
+    // we don't want a library user to be able to construct this type directly
+    __non_exhaustive: (),
     // multi selection
     // select directories
 }
@@ -54,6 +64,13 @@ pub struct FileSpec {
     ///
     /// This should not include the leading '.'.
     pub extensions: &'static [&'static str],
+}
+
+impl FileInfo {
+    /// The file's path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 impl FileDialogOptions {

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -54,7 +54,7 @@ mod window;
 
 pub use application::Application;
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
-pub use dialog::{FileDialogOptions, FileDialogType, FileSpec};
+pub use dialog::{FileDialogOptions, FileDialogType, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};
 pub use keyboard::{KeyEvent, KeyModifiers};
@@ -62,4 +62,4 @@ pub use keycodes::KeyCode;
 pub use menu::Menu;
 pub use mouse::{Cursor, MouseButton, MouseEvent};
 pub use runloop::RunLoop;
-pub use window::{FileInfo, Text, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle};
+pub use window::{Text, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle};

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -37,10 +37,10 @@ use super::runloop::with_application;
 use super::util::assert_main_thread;
 
 use crate::common_util::IdleCallback;
-use crate::dialog::FileDialogOptions;
+use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::keyboard;
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
-use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
+use crate::window::{Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
 
 /// Taken from https://gtk-rs.org/docs-src/tutorial/closures

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -43,11 +43,11 @@ use super::dialog;
 use super::menu::Menu;
 use super::util::{assert_main_thread, make_nsstring};
 use crate::common_util::IdleCallback;
-use crate::dialog::FileDialogOptions;
+use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::keycodes::KeyCode;
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
-use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
+use crate::window::{Text, TimerToken, WinCtx, WinHandler};
 use crate::Error;
 
 #[allow(non_upper_case_globals)]

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -57,11 +57,11 @@ use super::timers::TimerSlots;
 use super::util::{as_result, FromWide, ToWide, OPTIONAL_FUNCTIONS};
 
 use crate::common_util::IdleCallback;
-use crate::dialog::{FileDialogOptions, FileDialogType};
+use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
 use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::keycodes::KeyCode;
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
-use crate::window::{FileInfo, Text, TimerToken, WinCtx, WinHandler};
+use crate::window::{Text, TimerToken, WinCtx, WinHandler};
 
 extern "system" {
     pub fn DwmFlush();

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -17,20 +17,14 @@
 #![allow(deprecated)] // for the three items that have moved
 
 use std::any::Any;
-use std::path::PathBuf;
 
-use crate::dialog::FileDialogOptions;
+use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error;
 use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::kurbo::{Point, Size, Vec2};
 use crate::menu::Menu;
+use crate::mouse::{Cursor, MouseEvent};
 use crate::platform::window as platform;
-
-#[deprecated(since = "0.4.0", note = "Moved to druid_shell::mouse::MouseEvent")]
-pub type MouseEvent = crate::mouse::MouseEvent;
-
-#[deprecated(since = "0.4.0", note = "Moved to druid_shell::mouse::Cursor")]
-pub type Cursor = crate::mouse::Cursor;
 
 // It's possible we'll want to make this type alias at a lower level,
 // see https://github.com/linebender/piet/pull/37 for more discussion.
@@ -298,12 +292,6 @@ pub trait WinHandler {
 
     /// Get a reference to the handler state. Used mostly by idle handlers.
     fn as_any(&mut self) -> &mut dyn Any;
-}
-
-/// Information about a file to be opened or saved.
-#[derive(Debug, Clone)]
-pub struct FileInfo {
-    pub path: PathBuf,
 }
 
 impl From<platform::WindowHandle> for WindowHandle {

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -46,9 +46,9 @@ use piet::{Piet, RenderContext};
 
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::{
-    Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileDialogType, FileSpec,
-    FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods, Text,
-    TimerToken, WinCtx, WindowHandle,
+    Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileDialogType, FileInfo,
+    FileSpec, FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods,
+    Text, TimerToken, WinCtx, WindowHandle,
 };
 
 pub use app::{AppLauncher, WindowDesc};


### PR DESCRIPTION
This always needed to be public; and while doing that I decided
to move it to `dialog`, where it fits in better, and dida bit of
additional cleanup.