### PR TITLE
Remove `lenses` module from derived lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To use the lens, wrap your widget with `LensWrap` (note the conversion of
 CamelCase to snake_case):
 
 ```rust
-LensWrap::new(WidgetThatExpectsf64::new(), lenses::app_state::value);
+LensWrap::new(WidgetThatExpectsf64::new(), app_state::value);
 ```
 
 ## Using druid

--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -87,15 +87,12 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
     });
 
     let expanded = quote! {
-        pub mod lenses {
-            pub mod #twizzled_name {
-                use super::super::*;
+        pub mod #twizzled_name {
+            use super::*;
 
-                use druid::Lens;
-                #(#structs)*
-                #(#impls)*
-            }
-
+            use druid::Lens;
+            #(#structs)*
+            #(#impls)*
         }
     };
 

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -152,7 +152,7 @@ fn build_calc() -> impl Widget<CalcState> {
     let mut column = Flex::column();
     let display = LensWrap::new(
         DynLabel::new(|data: &String, _env| data.clone()),
-        lenses::calc_state::value,
+        calc_state::value,
     );
     column.add_child(pad(display), 0.0);
     column.add_child(

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -35,15 +35,12 @@ fn ui_builder() -> impl Widget<AppState> {
 
     let mut col = Flex::column();
     col.add_child(
-        Padding::new(
-            5.0,
-            LensWrap::new(Checkbox::new(), lenses::app_state::which),
-        ),
+        Padding::new(5.0, LensWrap::new(Checkbox::new(), app_state::which)),
         0.0,
     );
     let either = Either::new(
         |data, _env| data.which,
-        Padding::new(5.0, LensWrap::new(Slider::new(), lenses::app_state::value)),
+        Padding::new(5.0, LensWrap::new(Slider::new(), app_state::value)),
         Padding::new(5.0, label),
     );
     col.add_child(either, 0.0);

--- a/druid/examples/slider.rs
+++ b/druid/examples/slider.rs
@@ -31,13 +31,13 @@ fn build_widget() -> impl Widget<DemoState> {
         }
     });
     let mut row = Flex::row();
-    let checkbox = LensWrap::new(Checkbox::new(), lenses::demo_state::double);
+    let checkbox = LensWrap::new(Checkbox::new(), demo_state::double);
     let checkbox_label = Label::new("double the value");
     row.add_child(checkbox, 0.0);
     row.add_child(Padding::new(5.0, checkbox_label), 1.0);
 
-    let bar = LensWrap::new(ProgressBar::new(), lenses::demo_state::value);
-    let slider = LensWrap::new(Slider::new(), lenses::demo_state::value);
+    let bar = LensWrap::new(ProgressBar::new(), demo_state::value);
+    let slider = LensWrap::new(Slider::new(), demo_state::value);
 
     let button_1 = Button::sized(
         "increment ",

--- a/druid/examples/switch.rs
+++ b/druid/examples/switch.rs
@@ -23,7 +23,7 @@ struct DemoState {
 fn build_widget() -> impl Widget<DemoState> {
     let mut col = Flex::column();
     let mut row = Flex::row();
-    let switch = LensWrap::new(Switch::new(), lenses::demo_state::value);
+    let switch = LensWrap::new(Switch::new(), demo_state::value);
     let switch_label = Label::new("Setting label");
 
     row.add_child(Padding::new(5.0, switch_label), 0.0);


### PR DESCRIPTION
Allows lenses to be derived for multiple structs in a single module without generating illegal duplicate module definitions.

I'd have preferred to make the lenses associated types, but there's no current way to accomplish that without also introducing ugly generated type names into the namespace that would inevitably pop up in error messages.