### PR TITLE
Declarative lens macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,15 @@ CamelCase to snake_case):
 LensWrap::new(WidgetThatExpectsf64::new(), AppState::value);
 ```
 
+Alternatively, lenses for structs, tuples, and indexable containers can be
+constructed on-demand with the `lens` macro:
+
+```rust
+LensWrap::new(WidgetThatExpectsf64::new(), lens!(AppState, value));
+```
+
+This is particularly useful when working with types defined in another crate.
+
 ## Using druid
 
 An explicit goal of druid is to be easy to build, so please open an issue if you

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -141,3 +141,62 @@ where
         }
     }
 }
+
+/// Lens accessing a member of some type using accessor functions
+///
+/// See also the `lens` macro.
+///
+/// ```
+/// let lens = druid::Field::new(|x: &Vec<u32>| &x[42], |x| &mut x[42]);
+/// ```
+pub struct Field<Get, GetMut> {
+    get: Get,
+    get_mut: GetMut,
+}
+
+impl<Get, GetMut> Field<Get, GetMut> {
+    /// Construct a lens from a pair of getter functions
+    pub fn new<T: ?Sized, U: ?Sized>(get: Get, get_mut: GetMut) -> Self
+    where
+        Get: Fn(&T) -> &U,
+        GetMut: Fn(&mut T) -> &mut U,
+    {
+        Self { get, get_mut }
+    }
+}
+
+impl<T, U, Get, GetMut> Lens<T, U> for Field<Get, GetMut>
+where
+    T: ?Sized,
+    U: ?Sized,
+    Get: Fn(&T) -> &U,
+    GetMut: Fn(&mut T) -> &mut U,
+{
+    fn with<V, F: FnOnce(&U) -> V>(&self, data: &T, f: F) -> V {
+        f((self.get)(data))
+    }
+
+    fn with_mut<V, F: FnOnce(&mut U) -> V>(&self, data: &mut T, f: F) -> V {
+        f((self.get_mut)(data))
+    }
+}
+
+/// Construct a lens accessing a type's field
+///
+/// This is a convenience macro for constructing `Field` lenses for fields or indexable elements.
+///
+/// ```
+/// struct Foo { x: u32 }
+/// let lens = druid::lens!(Foo, x);
+/// let lens = druid::lens!((u32, bool), 1);
+/// let lens = druid::lens!([u8], [4]);
+/// ```
+#[macro_export]
+macro_rules! lens {
+    ($ty:ty, [$index:expr]) => {
+        $crate::Field::new::<$ty, _>(|x| &x[$index], |x| &mut x[$index])
+    };
+    ($ty:ty, $field:tt) => {
+        $crate::Field::new::<$ty, _>(|x| &x.$field, |x| &mut x.$field)
+    };
+}

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -57,7 +57,7 @@ pub use command::{sys as commands, Command, Selector};
 pub use data::Data;
 pub use env::{Env, Key, Value};
 pub use event::{Event, WheelEvent};
-pub use lens::{Lens, LensWrap};
+pub use lens::{Field, Lens, LensWrap};
 pub use localization::LocalizedString;
 pub use menu::{sys as platform_menus, ContextMenu, MenuDesc, MenuItem};
 pub use mouse::MouseEvent;


### PR DESCRIPTION
This makes it possible to access fields of foreign types with lenses, and reduces magic and namespace clutter. The main downside is that the resulting types aren't nameable (at least until type alias impl trait comes along); if that's important we might want to retain the derive for those cases.