### PR TITLE
Add UnknownKeyMap trait, Fix numpad events on gtk

### DIFF
--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -132,6 +132,12 @@ impl HotKey {
     }
 }
 
+impl std::cmp::PartialEq<(KeyModifiers, KeyCode)> for HotKey {
+    fn eq(&self, other: &(KeyModifiers, KeyCode)) -> bool {
+        (*self).mods == (*other).0 && (*self).key == (*other).1.into()
+    }
+}
+
 /// A platform-agnostic representation of keyboard modifiers, for command handling.
 ///
 /// This does one thing: it allows specifying hotkeys that use the Command key

--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -84,6 +84,18 @@ impl KeyEvent {
         }
     }
 
+    /// Map a `KeyEvent`'s `key_code` to by calling f.
+    /// The `KeyEvent` returned leaves all other fields unmodified.
+    pub fn map_keycode(&self, f: fn(KeyCode) -> KeyCode) -> Self {
+        KeyEvent {
+            is_repeat: self.is_repeat,
+            mods: self.mods,
+            key_code: f(self.key_code),
+            text: self.text,
+            unmodified_text: self.unmodified_text,
+        }
+    }
+
     /// For creating `KeyEvent`s during testing.
     #[doc(hidden)]
     pub fn for_test(mods: impl Into<KeyModifiers>, text: &'static str, code: KeyCode) -> Self {

--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -84,18 +84,6 @@ impl KeyEvent {
         }
     }
 
-    /// Map a `KeyEvent`'s `key_code` to by calling f.
-    /// The `KeyEvent` returned leaves all other fields unmodified.
-    pub fn map_keycode(&self, f: fn(KeyCode) -> KeyCode) -> Self {
-        KeyEvent {
-            is_repeat: self.is_repeat,
-            mods: self.mods,
-            key_code: f(self.key_code),
-            text: self.text,
-            unmodified_text: self.unmodified_text,
-        }
-    }
-
     /// For creating `KeyEvent`s during testing.
     #[doc(hidden)]
     pub fn for_test(mods: impl Into<KeyModifiers>, text: &'static str, code: KeyCode) -> Self {

--- a/druid-shell/src/keycodes.rs
+++ b/druid-shell/src/keycodes.rs
@@ -165,3 +165,26 @@ impl KeyCode {
         }
     }
 }
+
+/// This trait produces a mapping from KeyCodes, for physical and logical
+/// keyboard function for keys such as those on the Numpad, where the notion of
+/// modifier doesn't quite fit.
+///
+/// These functions are modeled loosely the `code` and `key`
+/// fields KeyboardEvent Web API.
+///
+/// All platforms should implement this trait for KeyCode.
+/// Callers can access this through druid_shell::UnknownKeyMap.
+pub trait UnknownKeyMap {
+    /// This is similar to the KeyboardEvent Web API code field.
+    /// but produces a mapping from Unknown(platform::RawKeyCode), to physical KeyCodes.
+    /// For example if passed an unknown keycode which correlates to
+    /// Numpad0 with numlock off, it will return Numpad0.
+    fn to_physical(self) -> Self;
+
+    /// This is similar to the KeyboardEvent Web API key field.
+    /// but produces a mapping from "Unknown keys", to logical KeyCode buttons.
+    /// For example if passed an unknown keycode which correlates to
+    /// Numpad0 with numlock off, it will return KeyCode::Insert.
+    fn to_logical(self) -> Self;
+}

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -58,7 +58,7 @@ pub use dialog::{FileDialogOptions, FileDialogType, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};
 pub use keyboard::{KeyEvent, KeyModifiers};
-pub use keycodes::KeyCode;
+pub use keycodes::{KeyCode, UnknownKeyMap};
 pub use menu::Menu;
 pub use mouse::{Cursor, MouseButton, MouseEvent};
 pub use runloop::RunLoop;

--- a/druid-shell/src/platform/gtk/keycodes.rs
+++ b/druid-shell/src/platform/gtk/keycodes.rs
@@ -16,9 +16,45 @@
 
 use gdk::enums::key::*;
 
-use crate::keycodes::KeyCode;
+use crate::keycodes::{KeyCode, UnknownKeyMap};
 
 pub type RawKeyCode = u32;
+
+impl UnknownKeyMap for KeyCode {
+    #[allow(non_upper_case_globals)]
+    fn to_physical(self) -> Self {
+        match self {
+            KeyCode::Unknown(KP_Insert) => KeyCode::Numpad0,
+            KeyCode::Unknown(KP_End) => KeyCode::Numpad1,
+            KeyCode::Unknown(KP_Down) => KeyCode::Numpad2,
+            KeyCode::Unknown(KP_Page_Down) => KeyCode::Numpad3,
+            KeyCode::Unknown(KP_Left) => KeyCode::Numpad4,
+            KeyCode::Unknown(KP_Begin) => KeyCode::Numpad5,
+            KeyCode::Unknown(KP_Right) => KeyCode::Numpad6,
+            KeyCode::Unknown(KP_Home) => KeyCode::Numpad7,
+            KeyCode::Unknown(KP_Up) => KeyCode::Numpad8,
+            KeyCode::Unknown(KP_Page_Up) => KeyCode::Numpad9,
+            _ => self,
+        }
+    }
+
+    #[allow(non_upper_case_globals)]
+    fn to_logical(self) -> Self {
+        match self {
+            KeyCode::Unknown(KP_Insert) => KeyCode::Home,
+            KeyCode::Unknown(KP_End) => KeyCode::End,
+            KeyCode::Unknown(KP_Down) => KeyCode::ArrowDown,
+            KeyCode::Unknown(KP_Page_Down) => KeyCode::PageDown,
+            KeyCode::Unknown(KP_Left) => KeyCode::ArrowLeft,
+            // Fall through for Unknown(KP_Begin) -- numlock off Numpad5.
+            KeyCode::Unknown(KP_Right) => KeyCode::ArrowRight,
+            KeyCode::Unknown(KP_Home) => KeyCode::Home,
+            KeyCode::Unknown(KP_Up) => KeyCode::ArrowUp,
+            KeyCode::Unknown(KP_Page_Up) => KeyCode::PageUp,
+            _ => self,
+        }
+    }
+}
 
 impl From<u32> for KeyCode {
     #[allow(clippy::just_underscores_and_digits, non_upper_case_globals)]

--- a/druid-shell/src/platform/mac/keycodes.rs
+++ b/druid-shell/src/platform/mac/keycodes.rs
@@ -14,9 +14,20 @@
 
 //! macOS keycode handling.
 
-use crate::keycodes::KeyCode;
+use crate::keycodes::{KeyCode, UnknownKeyMap};
 
 pub type RawKeyCode = u16;
+
+impl UnknownKeyMap for KeyCode {
+    // TODO implement
+    fn to_physical(self) -> Self {
+        self
+    }
+    // TODO implement
+    fn to_logical(self) -> Self {
+        self
+    }
+}
 
 impl From<u16> for KeyCode {
     fn from(raw: u16) -> KeyCode {

--- a/druid-shell/src/platform/windows/keycodes.rs
+++ b/druid-shell/src/platform/windows/keycodes.rs
@@ -17,7 +17,7 @@
 use win_vks::*;
 use winapi::um::winuser::*;
 
-use crate::keycodes::KeyCode;
+use crate::keycodes::{KeyCode, UnknownKeyMap};
 
 pub type RawKeyCode = i32;
 
@@ -63,6 +63,17 @@ mod win_vks {
     pub const VK_X: i32 = 0x58;
     pub const VK_Y: i32 = 0x59;
     pub const VK_Z: i32 = 0x5A;
+}
+
+impl UnknownKeyMap for KeyCode {
+    // TODO implement
+    fn to_physical(self) -> Self {
+        self
+    }
+    // TODO implement
+    fn to_logical(self) -> Self {
+        self
+    }
 }
 
 impl From<i32> for KeyCode {

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -202,29 +202,27 @@ impl Widget<CalcState> for KeyboardHandler<CalcState> {
         match event {
             Event::KeyDown(key_event) => {
                 // map to physical keys since we want numbers with numlock both on and off.
-                let key_event = key_event.map_keycode(UnknownKeyMap::to_physical);
-                if key_event.is_repeat
-                    || !key_event.key_code.is_printable()
-                    || key_event.key_code == Space
-                {
+                let phys_key = key_event.key_code.to_physical();
+
+                if key_event.is_repeat || !phys_key.is_printable() || phys_key == Space {
                     return;
                 }
 
-                let calc_input = match key_event {
-                    k_e if (HotKey::new(Shift, Key8).matches(k_e)
-                        || HotKey::new(None, NumpadMultiply).matches(k_e)) =>
+                let calc_input = match (key_event.mods, phys_key) {
+                    key if (HotKey::new(Shift, Key8) == key
+                        || HotKey::new(None, NumpadMultiply) == key) =>
                     {
                         Some(Op('×'))
                     }
-                    k_e if (HotKey::new(Shift, Equals).matches(k_e)
-                        || HotKey::new(None, NumpadAdd).matches(k_e)) =>
+                    key if (HotKey::new(Shift, Equals) == key
+                        || HotKey::new(None, NumpadAdd) == key) =>
                     {
                         Some(Op('+'))
                     }
-                    k_e if (HotKey::new(Shift, KeyC).matches(k_e)) => Some(Op('C')),
+                    key if (HotKey::new(Shift, KeyC) == key) => Some(Op('C')),
                     // TODO Not really sure a good key for this.
-                    k_e if (HotKey::new(Shift, Backtick).matches(k_e)) => Some(Op('±')),
-                    k_e if k_e.mods == RawMods::None => match k_e.key_code {
+                    key if (HotKey::new(Shift, Backtick) == key) => Some(Op('±')),
+                    (mods, key_code) if mods == RawMods::None => match key_code {
                         Numpad0 | Key0 => Some(Digit(0)),
                         Numpad1 | Key1 => Some(Digit(1)),
                         Numpad2 | Key2 => Some(Digit(2)),


### PR DESCRIPTION
Since the hardware mapping treats numlock as off
This patch makes make_key_event return KP_0..KP_9 when numlock is on on the
gtk platform,

When Numlock is off, Numpad events will result in Unknown(...),

Further, it adds a new trait UnknownKeyMap to druid_shell which allows you to
map from Unknown(...) KeyCodes with the to_logical() and to_physical().

These functions can be used to map unknown KeyCodes e.g:
Unknown(Home).to_logical() -> Home,
Unknown(Home).to_physical() -> Numpad7,

With these in place it is possible to differentiate the different keys
without having to add any new KeyCodes or modifiers.

These functions are intended to loosely correlate to the 'key', and 'code' fields
of the KeyEvent structure of the WebAPI.