### PR TITLE
Take a closure returning a concrete widget in List

### DIFF
--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -46,17 +46,15 @@ fn ui_builder() -> impl Widget<AppData> {
 
     root.add_child(
         Scroll::new(List::new(|| {
-            Box::new(
-                SizedBox::new(
-                    Container::new(Padding::new(
-                        10.0,
-                        DynLabel::new(|d, _| format!("List item #{}", d)),
-                    ))
-                    .background(Color::rgb(0.5, 0.5, 0.5)),
-                )
-                .expand()
-                .height(50.0),
+            SizedBox::new(
+                Container::new(Padding::new(
+                    10.0,
+                    DynLabel::new(|d, _| format!("List item #{}", d)),
+                ))
+                .background(Color::rgb(0.5, 0.5, 0.5)),
             )
+            .expand()
+            .height(50.0)
         }))
         .vertical(),
         1.0,

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -32,9 +32,9 @@ pub struct List<T: Data> {
 impl<T: Data> List<T> {
     /// Create a new list widget. Closure will be called every time when a new child
     /// needs to be constructed.
-    pub fn new(closure: impl Fn() -> Box<dyn Widget<T>> + 'static) -> Self {
+    pub fn new<W: Widget<T> + 'static>(closure: impl Fn() -> W + 'static) -> Self {
         List {
-            closure: Box::new(closure),
+            closure: Box::new(move || Box::new(closure())),
             children: Vec::new(),
         }
     }


### PR DESCRIPTION
This is a marginal ergonomics improvement consistent with existing conventions (no need for the caller to box explicitly) and clarifies the intent of the interface, assuming it is actually the intention of the interface that lists be homogeneous.