### PR TITLE
Expose derived lenses as associated constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ struct AppState {
 ### lens
 
 The [Lens datatype] gives access to a part of a larger data structure. Like
-`Data`, This can be derived.
+`Data`, this can be derived. Derived lenses are accessed as associated constants
+with the same name as the field.
 
 ```rust
 #[derive(Clone, Data, Lens)]
@@ -202,7 +203,7 @@ To use the lens, wrap your widget with `LensWrap` (note the conversion of
 CamelCase to snake_case):
 
 ```rust
-LensWrap::new(WidgetThatExpectsf64::new(), app_state::value);
+LensWrap::new(WidgetThatExpectsf64::new(), AppState::value);
 ```
 
 ## Using druid

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -31,6 +31,10 @@ pub fn derive_data(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Generates lenses to access the fields of a struct
+///
+/// An associated constant is defined on the struct for each field,
+/// having the same name as the field.
 #[proc_macro_derive(Lens)]
 pub fn derive_lens(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -152,7 +152,7 @@ fn build_calc() -> impl Widget<CalcState> {
     let mut column = Flex::column();
     let display = LensWrap::new(
         DynLabel::new(|data: &String, _env| data.clone()),
-        calc_state::value,
+        CalcState::value,
     );
     column.add_child(pad(display), 0.0);
     column.add_child(

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -35,12 +35,12 @@ fn ui_builder() -> impl Widget<AppState> {
 
     let mut col = Flex::column();
     col.add_child(
-        Padding::new(5.0, LensWrap::new(Checkbox::new(), app_state::which)),
+        Padding::new(5.0, LensWrap::new(Checkbox::new(), AppState::which)),
         0.0,
     );
     let either = Either::new(
         |data, _env| data.which,
-        Padding::new(5.0, LensWrap::new(Slider::new(), app_state::value)),
+        Padding::new(5.0, LensWrap::new(Slider::new(), AppState::value)),
         Padding::new(5.0, label),
     );
     col.add_child(either, 0.0);

--- a/druid/examples/slider.rs
+++ b/druid/examples/slider.rs
@@ -31,13 +31,13 @@ fn build_widget() -> impl Widget<DemoState> {
         }
     });
     let mut row = Flex::row();
-    let checkbox = LensWrap::new(Checkbox::new(), demo_state::double);
+    let checkbox = LensWrap::new(Checkbox::new(), DemoState::double);
     let checkbox_label = Label::new("double the value");
     row.add_child(checkbox, 0.0);
     row.add_child(Padding::new(5.0, checkbox_label), 1.0);
 
-    let bar = LensWrap::new(ProgressBar::new(), demo_state::value);
-    let slider = LensWrap::new(Slider::new(), demo_state::value);
+    let bar = LensWrap::new(ProgressBar::new(), DemoState::value);
+    let slider = LensWrap::new(Slider::new(), DemoState::value);
 
     let button_1 = Button::sized(
         "increment ",

--- a/druid/examples/switch.rs
+++ b/druid/examples/switch.rs
@@ -23,7 +23,7 @@ struct DemoState {
 fn build_widget() -> impl Widget<DemoState> {
     let mut col = Flex::column();
     let mut row = Flex::row();
-    let switch = LensWrap::new(Switch::new(), demo_state::value);
+    let switch = LensWrap::new(Switch::new(), DemoState::value);
     let switch_label = Label::new("Setting label");
 
     row.add_child(Padding::new(5.0, switch_label), 0.0);


### PR DESCRIPTION
Generates lens type definitions inside a private module with an unlikely-to-collide name, then uses those to populate associated constants on the type for extremely ergonomic access. The main drawback here is that the private `__Foo_druid_lenses` module name pops up in error messages.