### PR TITLE
[mac] Don't manually call finishLaunching()

### DIFF
--- a/druid-shell/src/platform/mac/runloop.rs
+++ b/druid-shell/src/platform/mac/runloop.rs
@@ -32,7 +32,6 @@ impl RunLoop {
 
             let ns_app = NSApp();
             ns_app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
-            ns_app.finishLaunching();
             RunLoop { ns_app }
         }
     }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -142,12 +142,6 @@ impl WindowBuilder {
                 NO,
             );
 
-            // TODO:
-            // I'm not actually sure if this call is necessary.
-            // I believe this should really be
-            // window.setLevel_(CGWindowLevelForKey(CGWindowLevelKey::normalWindow));
-            // But the rust bindings seem to lack both the function and constant
-            window.setLevel_(0);
             window.cascadeTopLeftFromPoint_(NSPoint::new(20.0, 20.0));
             window.setTitle_(make_nsstring(&self.title));
             // TODO: this should probably be a tracking area instead


### PR DESCRIPTION
According to the NSApplication docs, this is called automatically
when the `run()` method is called.

@raphlinus I might be missing something here, but it this call seems out of place, and nothing seems broken with it removed.