### PR TITLE
Fix #43, again (🤞)

### DIFF
--- a/druid-shell/src/platform/mac/runloop.rs
+++ b/druid-shell/src/platform/mac/runloop.rs
@@ -15,7 +15,7 @@
 //! macOS implementation of runloop.
 
 use cocoa::appkit::{NSApp, NSApplication, NSApplicationActivationPolicyRegular};
-use cocoa::base::{id, nil};
+use cocoa::base::{id, nil, YES};
 use cocoa::foundation::NSAutoreleasePool;
 
 use super::util::assert_main_thread;
@@ -39,6 +39,7 @@ impl RunLoop {
 
     pub fn run(&mut self) {
         unsafe {
+            let () = msg_send![self.ns_app, activateIgnoringOtherApps: YES];
             self.ns_app.run();
         }
     }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -23,9 +23,9 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::Instant;
 
 use cocoa::appkit::{
-    NSApp, NSApplication, NSApplicationActivateIgnoringOtherApps, NSAutoresizingMaskOptions,
-    NSBackingStoreBuffered, NSEvent, NSEventModifierFlags, NSRunningApplication, NSView,
-    NSViewHeightSizable, NSViewWidthSizable, NSWindow, NSWindowStyleMask,
+    NSApp, NSApplication, NSAutoresizingMaskOptions, NSBackingStoreBuffered, NSEvent,
+    NSEventModifierFlags, NSView, NSViewHeightSizable, NSViewWidthSizable, NSWindow,
+    NSWindowStyleMask,
 };
 use cocoa::base::{id, nil, BOOL, NO, YES};
 use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
@@ -602,8 +602,6 @@ extern "C" fn window_did_become_key(this: &mut Object, _: Sel, _notification: id
 impl WindowHandle {
     pub fn show(&self) {
         unsafe {
-            let current_app = NSRunningApplication::currentApplication(nil);
-            current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
             let window: id = msg_send![*self.nsview.load(), window];
             // register our view class to be alerted when it becomes the key view.
             let notif_center_class = class!(NSNotificationCenter);


### PR DESCRIPTION
My main strategy here was to create a minimal single-window objective-c
application (based on [1]) and then to trace our executation
and compare that against the execution of the objective-c app.

There were a few places where our behaviour differed, but changing
those had no apparent effect on application behaviour; but in
the course of that work I found the actual bug, which was much sneaker.

TL;DR: We were using [NSRunningApplication activateWithOptions:],
when we should have been using [NSApplication  activateIgnoringOtherApps:].
The NSRunningApplication API is intended for controlling other running
applications; we were likely sending the msg to nil.

[1]: https://www.cocoawithlove.com/2010/09/minimalist-cocoa-programming.html