### PR TITLE
Standardize window closing API

### DIFF
--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -351,12 +351,25 @@ impl<T: Data + 'static> AppState<T> {
         self.windows.add(id, window);
     }
 
-    fn remove_window(&mut self, id: WindowId) -> Option<WindowHandle> {
-        let res = self.windows.remove(id);
-        self.with_delegate(id, |del, data, env, ctx| {
-            del.window_removed(id, data, env, ctx)
+    /// Called after this window has been closed by the platform.
+    ///
+    /// We clean up resources and notifiy the delegate, if necessary.
+    fn remove_window(&mut self, window_id: WindowId, _ctx: &mut dyn WinCtx) {
+        self.with_delegate(window_id, |del, data, env, ctx| {
+            del.window_removed(window_id, data, env, ctx)
         });
-        res
+        self.windows.remove(window_id);
+    }
+
+    /// triggered by a menu item or other command.
+    ///
+    /// This doesn't close the window; it calls the close method on the platform
+    /// window handle; the platform should close the window, and then call
+    /// our handlers `destroy()` method, at which point we can do our cleanup.
+    fn request_close_window(&mut self, window_id: WindowId) {
+        if let Some(state) = self.windows.state.get_mut(&window_id) {
+            state.handle.close();
+        }
     }
 
     fn show_window(&mut self, id: WindowId) {
@@ -504,7 +517,7 @@ impl<T: Data + 'static> DruidHandler<T> {
         match &cmd.selector {
             &sys_cmd::OPEN_FILE => self.open_file(cmd, window_id, win_ctx),
             &sys_cmd::NEW_WINDOW => self.new_window(cmd),
-            &sys_cmd::CLOSE_WINDOW => self.close_window(cmd, window_id),
+            &sys_cmd::CLOSE_WINDOW => self.request_close_window(cmd, window_id),
             &sys_cmd::SHOW_WINDOW => self.show_window(cmd),
             &sys_cmd::QUIT_APP => self.quit(),
             &sys_cmd::HIDE_APPLICATION => self.hide_app(),
@@ -553,12 +566,9 @@ impl<T: Data + 'static> DruidHandler<T> {
         window.show();
     }
 
-    fn close_window(&mut self, cmd: Command, window_id: WindowId) {
+    fn request_close_window(&mut self, cmd: Command, window_id: WindowId) {
         let id = cmd.get_object().unwrap_or(&window_id);
-        let handle = self.app_state.borrow_mut().remove_window(*id);
-        if let Some(handle) = handle {
-            handle.close();
-        }
+        self.app_state.borrow_mut().request_close_window(*id);
     }
 
     fn show_window(&mut self, cmd: Command) {
@@ -649,6 +659,12 @@ impl<T: Data + 'static> WinHandler for DruidHandler<T> {
 
     fn as_any(&mut self) -> &mut dyn Any {
         self
+    }
+
+    fn destroy(&mut self, ctx: &mut dyn WinCtx) {
+        self.app_state
+            .borrow_mut()
+            .remove_window(self.window_id, ctx);
     }
 }
 


### PR DESCRIPTION
We want to be notified when a window closes. For this to work we need
to handle the destroy() method in WinHandler.

After making this change, we ended up with two code paths for closing
windows: one for when we were closing the window ourselves (for
instance, when manually handling a menu command) and a second for when
we were closed by the system, such as when the user clicked on the
window's 'close' button. (all examples macOS).

This unifies these two cases; when we want to close a window we
call the WindowHandle's close method, which begins the platform
close routine; as part of this we are called back (at destroy())
and then we have a single place to handle cleaning up state
and posting the appropriate events.

-----
- this was motivated by runebender stuff; I only want a glyph open in a single window at once, which means i need to accurately know when a window has closed.

- This will likely require work on win and gtk; I'm not sure if either of those platforms is correctly posting `destroy()`.
