### PR TITLE
Fix LensWrap and Lens links in WidgetExt docs

### DIFF
--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -111,8 +111,8 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
 
     /// Wrap this widget in a [`LensWrap`] widget for the provided [`Lens`].
     ///
-    /// [`LensWrap`]: struct.LensWrap.html
-    /// [`Lens`]: trait.Lens.html
+    /// [`LensWrap`]: ../struct.LensWrap.html
+    /// [`Lens`]: ../trait.Lens.html
     fn lens<U: Data, L: Lens<T, U>>(self, lens: L) -> LensWrap<U, L, Self> {
         LensWrap::new(self, lens)
     }


### PR DESCRIPTION
`LensWrap` and `Lens` are in the crate root instead of under `widget`. This fixes the path in the docs to avoid a 404.