### PR TITLE
Implement KeyMatcher trait

### DIFF
--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -532,12 +532,12 @@ impl KeyMatcher for char {
         // We allow either text or unmodified text to match.
         let text = key_event.text().unwrap_or("");
         let mut chars = text.chars();
-        if chars.next() == Some(*self) && !chars.next().is_some() {
+        if chars.next() == Some(*self) && chars.next().is_none() {
             return true;
         }
         let unmod_text = key_event.unmod_text().unwrap_or("");
         let mut chars = unmod_text.chars();
-        if chars.next() == Some(*self) && !chars.next().is_some() {
+        if chars.next() == Some(*self) && chars.next().is_none() {
             return true;
         }
         false

--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -37,6 +37,37 @@ pub struct KeyEvent {
     //TODO: add time
 }
 
+/// A modifier, for the purpose of matching key events.
+pub enum Modifier {
+    Alt,
+    Ctrl,
+    Meta,
+    Shift,
+    // The command key; maps to Meta on macOS, Ctrl otherwise.
+    Cmd,
+    NoMods,
+}
+
+pub trait KeyMatcher {
+    fn matches(&self, key_event: &KeyEvent) -> bool {
+        self.matches_internal(key_event, KeyModifiers::default())
+    }
+
+    #[doc(hidden)]
+    #[allow(unused)]
+    fn matches_internal(&self, key_event: &KeyEvent, covered: KeyModifiers) -> bool {
+        false
+    }
+}
+
+#[doc(hidden)]
+pub trait ModMatcher {
+    /// Determine whether the modifiers match the spec.
+    ///
+    /// On success, return the set of modifiers "covered" by the spec.
+    fn match_mods(&self, mods: KeyModifiers) -> Option<KeyModifiers>;
+}
+
 impl KeyEvent {
     /// Create a new `KeyEvent` struct. This accepts either &str or char for the last
     /// two arguments.
@@ -82,6 +113,19 @@ impl KeyEvent {
         } else {
             Some(self.unmodified_text.as_str())
         }
+    }
+
+    /// Test whether the key matches the given pattern.
+    ///
+    /// # Examples
+    /// ```
+    /// use druid_shell::{KeyCode, Modifier};
+    /// # let key_event = druid_shell::KeyEvent::for_test(Modifier::NoMods, "a", KeyCode::KeyA);
+    /// let is_undo = key_event.matches(Modifier::Ctrl + 'z');
+    /// let is_reset = key_event.matches(Modifier::Ctrl + Modifier::Alt + KeyCode::Delete);
+    /// ```
+    pub fn matches(&self, matcher: impl KeyMatcher) -> bool {
+        matcher.matches(self)
     }
 
     /// For creating `KeyEvent`s during testing.
@@ -256,6 +300,273 @@ impl fmt::Debug for KeyModifiers {
     }
 }
 
+// Key matcher logic
+
+/// An internal matcher constructor for negating a modifier.
+pub struct NotMod(Modifier);
+
+/// An internal matcher constructor for taking the "or" of two matchers.
+pub struct OrMatcher<T, U>(T, U);
+
+pub struct AddMatcher<T, U>(T, U);
+
+macro_rules! impl_op {
+    ($tr:ident, $f:ident, $comb:ident, $lhs:ident $(< $($ltv:ident),+ >)?,
+        $rhs:ident $(< $($rtv:ident),+ >)?) =>
+    {
+        impl<$($($ltv,)*)? $($($rtv),*)?> std::ops::$tr<$rhs<$($($rtv),+)?>> for
+            $lhs$(<$($ltv),*>)?
+        {
+            type Output = $comb<Self, $rhs $(<$($rtv),+>)?>;
+            fn $f(self, rhs: $rhs $(<$($rtv),+>)?) -> Self::Output {
+                $comb(self, rhs)
+            }
+        }
+    };
+}
+
+macro_rules! impl_adds {
+    ($rhs:ident $(< $($rtv:ident),+ >)?) => {
+        impl_op!(Add, add, AddMatcher, Modifier, $rhs $(<$($rtv),+>)?);
+        impl_op!(Add, add, AddMatcher, NotMod, $rhs $(<$($rtv),+>)?);
+        impl_op!(Add, add, AddMatcher, OrMatcher<T0, T1>, $rhs $(<$($rtv),+>)?);
+        impl_op!(Add, add, AddMatcher, AddMatcher<T0, T1>, $rhs $(<$($rtv),+>)?);
+    };
+}
+
+macro_rules! impl_ors {
+    ($rhs:ident $(< $($rtv:ident),+ >)?) => {
+        impl_op!(BitOr, bitor, OrMatcher, Modifier, $rhs $(<$($rtv),+>)?);
+        impl_op!(BitOr, bitor, OrMatcher, NotMod, $rhs $(<$($rtv),+>)?);
+        impl_op!(BitOr, bitor, OrMatcher, OrMatcher<T0, T1>, $rhs $(<$($rtv),+>)?);
+        impl_op!(BitOr, bitor, OrMatcher, AddMatcher<T0, T1>, $rhs $(<$($rtv),+>)?);
+    };
+}
+
+impl_adds!(Modifier);
+impl_adds!(NotMod);
+impl_adds!(OrMatcher<T, U>);
+impl_adds!(AddMatcher<T, U>);
+impl_ors!(Modifier);
+impl_ors!(NotMod);
+impl_ors!(OrMatcher<T, U>);
+impl_ors!(AddMatcher<T, U>);
+
+impl_adds!(char);
+impl_adds!(KeyCode);
+
+impl From<Modifier> for KeyModifiers {
+    fn from(src: Modifier) -> KeyModifiers {
+        src.to_modifiers()
+    }
+}
+
+impl Modifier {
+    fn to_modifiers(&self) -> KeyModifiers {
+        let mut result = KeyModifiers::default();
+        match self {
+            Modifier::Alt => result.alt = true,
+            Modifier::Ctrl => result.ctrl = true,
+            Modifier::Meta => result.meta = true,
+            Modifier::Shift => result.shift = true,
+            Modifier::Cmd => {
+                #[cfg(target_os = "macos")]
+                {
+                    result.meta = true;
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    result.ctrl = true;
+                }
+            }
+            Modifier::NoMods => (),
+        }
+        result
+    }
+}
+
+impl ModMatcher for Modifier {
+    fn match_mods(&self, mods: KeyModifiers) -> Option<KeyModifiers> {
+        match *self {
+            Modifier::Alt => {
+                if !mods.alt {
+                    return None;
+                }
+            }
+            Modifier::Ctrl => {
+                if !mods.ctrl {
+                    return None;
+                }
+            }
+            Modifier::Meta => {
+                if !mods.meta {
+                    return None;
+                }
+            }
+            Modifier::Shift => {
+                if !mods.shift {
+                    return None;
+                }
+            }
+            Modifier::Cmd => {
+                #[cfg(target_os = "macos")]
+                {
+                    if !mods.meta {
+                        return None;
+                    }
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    if !mods.ctrl {
+                        return None;
+                    }
+                }
+            }
+            Modifier::NoMods => {
+                if mods.alt || mods.ctrl || mods.meta || mods.shift {
+                    return None;
+                }
+            }
+        }
+        Some(self.to_modifiers())
+    }
+}
+
+impl std::ops::Not for Modifier {
+    type Output = NotMod;
+    fn not(self) -> NotMod {
+        NotMod(self)
+    }
+}
+
+impl ModMatcher for NotMod {
+    fn match_mods(&self, mods: KeyModifiers) -> Option<KeyModifiers> {
+        match self.0 {
+            Modifier::Alt => {
+                if mods.alt {
+                    return None;
+                }
+            }
+            Modifier::Ctrl => {
+                if mods.ctrl {
+                    return None;
+                }
+            }
+            Modifier::Meta => {
+                if mods.meta {
+                    return None;
+                }
+            }
+            Modifier::Shift => {
+                if mods.shift {
+                    return None;
+                }
+            }
+            Modifier::Cmd => {
+                #[cfg(target_os = "macos")]
+                {
+                    if mods.meta {
+                        return None;
+                    }
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    if mods.ctrl {
+                        return None;
+                    }
+                }
+            }
+            Modifier::NoMods => {
+                if !(mods.alt || mods.ctrl || mods.meta || mods.shift) {
+                    return None;
+                } else {
+                    // Make it so !NoMods matches all non-empty modifier sets.
+                    return Some(KeyModifiers {
+                        alt: true,
+                        ctrl: true,
+                        meta: true,
+                        shift: true,
+                    });
+                }
+            }
+        }
+        Some(self.0.to_modifiers())
+    }
+}
+
+impl<T: ModMatcher, U: ModMatcher> ModMatcher for OrMatcher<T, U> {
+    fn match_mods(&self, mods: KeyModifiers) -> Option<KeyModifiers> {
+        self.0.match_mods(mods).or_else(|| self.1.match_mods(mods))
+    }
+}
+
+impl<T: ModMatcher, U: ModMatcher> ModMatcher for AddMatcher<T, U> {
+    fn match_mods(&self, mods: KeyModifiers) -> Option<KeyModifiers> {
+        if let Some(covered0) = self.0.match_mods(mods) {
+            if let Some(covered1) = self.1.match_mods(mods) {
+                // Bitwise would be nicer than struct-of-bools here.
+                return Some(KeyModifiers {
+                    alt: covered0.alt | covered1.alt,
+                    ctrl: covered0.ctrl | covered1.ctrl,
+                    meta: covered0.meta | covered1.meta,
+                    shift: covered0.shift | covered1.shift,
+                });
+            }
+        }
+        None
+    }
+}
+
+impl KeyMatcher for char {
+    fn matches_internal(&self, key_event: &KeyEvent, covered: KeyModifiers) -> bool {
+        // TODO: make "shift" handling more sophisticated. Currently, shift is allowed,
+        // because some characters need it. However, this means that Control-Shift-Z
+        // matches a spec of `Control + 'z'`, and that probably shouldn't be. To get
+        // more specificity, use `Control + !Shift + 'z'` for now.
+        if (key_event.mods.alt && !covered.alt)
+            || (key_event.mods.ctrl && !covered.ctrl)
+            || (key_event.mods.meta && !covered.meta)
+        {
+            return false;
+        }
+        // We allow either text or unmodified text to match.
+        let text = key_event.text().unwrap_or("");
+        let mut chars = text.chars();
+        if chars.next() == Some(*self) && !chars.next().is_some() {
+            return true;
+        }
+        let unmod_text = key_event.unmod_text().unwrap_or("");
+        let mut chars = unmod_text.chars();
+        if chars.next() == Some(*self) && !chars.next().is_some() {
+            return true;
+        }
+        false
+    }
+}
+
+impl KeyMatcher for KeyCode {
+    fn matches_internal(&self, key_event: &KeyEvent, covered: KeyModifiers) -> bool {
+        if (key_event.mods.alt && !covered.alt)
+            || (key_event.mods.ctrl && !covered.ctrl)
+            || (key_event.mods.meta && !covered.meta)
+            || (key_event.mods.shift && !covered.shift)
+        {
+            return false;
+        }
+        key_event.key_code == *self
+    }
+}
+
+impl<T: ModMatcher, U: KeyMatcher> KeyMatcher for AddMatcher<T, U> {
+    fn matches(&self, key_event: &KeyEvent) -> bool {
+        if let Some(covered) = self.0.match_mods(key_event.mods) {
+            self.1.matches_internal(key_event, covered)
+        } else {
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,5 +581,27 @@ mod tests {
         assert_eq!(s_16.len(), 16);
         assert!(!s_16.is_char_boundary(15));
         let _too_big = TinyStr::new("😍🥰😘😗");
+    }
+
+    #[test]
+    fn key_matching() {
+        use super::Modifier::*;
+        let key = KeyEvent::for_test(NoMods, "a", KeyCode::KeyA);
+        assert!(key.matches('a'));
+        assert!(!key.matches('b'));
+        assert!(key.matches(KeyCode::KeyA));
+        assert!(!key.matches(KeyCode::KeyB));
+        assert!(key.matches(!Shift + 'a'));
+        assert!(!key.matches(Shift + 'a'));
+
+        let ctrl_alt = KeyModifiers {
+            alt: true,
+            ctrl: true,
+            ..Default::default()
+        };
+        let tfs = KeyEvent::for_test(ctrl_alt, "", KeyCode::Delete);
+        assert!(tfs.matches(Ctrl + Alt + KeyCode::Delete));
+        assert!(tfs.matches(Ctrl + (Alt | Meta) + KeyCode::Delete));
+        assert!(!tfs.matches(KeyCode::Delete));
     }
 }

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -57,7 +57,7 @@ pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use dialog::{FileDialogOptions, FileDialogType, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};
-pub use keyboard::{KeyEvent, KeyModifiers};
+pub use keyboard::{KeyEvent, KeyModifiers, Modifier};
 pub use keycodes::KeyCode;
 pub use menu::Menu;
 pub use mouse::{Cursor, MouseButton, MouseEvent};


### PR DESCRIPTION
Adds a KeyMatcher trait, which is inhabited by nice, ergonomic combinations
of modifier specs and keys.

This is work in progress, it should be unified more with HotKeys.