### PR TITLE
Numpad keycodes take3

### DIFF
--- a/druid-shell/src/hotkey.rs
+++ b/druid-shell/src/hotkey.rs
@@ -19,7 +19,7 @@ use std::borrow::Borrow;
 use log::warn;
 
 use crate::keyboard::{KeyEvent, KeyModifiers};
-use crate::keycodes::KeyCode;
+use crate::keycodes::{KeyCode, Special};
 
 /// A description of a keyboard shortcut.
 ///
@@ -65,6 +65,7 @@ pub struct HotKey {
 pub enum KeyCompare {
     Code(KeyCode),
     Text(&'static str),
+    Special(Special),
 }
 
 impl HotKey {
@@ -128,6 +129,7 @@ impl HotKey {
             && match self.key {
                 KeyCompare::Code(code) => code == event.key_code,
                 KeyCompare::Text(text) => Some(text) == event.text(),
+                KeyCompare::Special(special) => Some(special) == event.special(),
             }
     }
 }
@@ -260,6 +262,12 @@ impl From<SysMods> for RawMods {
 impl From<KeyCode> for KeyCompare {
     fn from(src: KeyCode) -> KeyCompare {
         KeyCompare::Code(src)
+    }
+}
+
+impl From<Special> for KeyCompare {
+    fn from(src: Special) -> KeyCompare {
+        KeyCompare::Special(src)
     }
 }
 

--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -33,7 +33,7 @@ pub struct KeyEvent {
 impl KeyEvent {
     /// Create a new `KeyEvent` struct. This accepts either &str or char for the last
     /// two arguments.
-    pub(crate) fn new(
+    pub(crate) fn new_text(
         key_code: impl Into<KeyCode>,
         is_repeat: bool,
         mods: KeyModifiers,
@@ -57,6 +57,21 @@ impl KeyEvent {
                 text,
                 unmodified_text,
             },
+        }
+    }
+
+    /// Create a new `KeyEvent` struct from a `Special` as the last argument.
+    pub(crate) fn new_special(
+        key_code: impl Into<KeyCode>,
+        is_repeat: bool,
+        mods: KeyModifiers,
+        special: Special,
+    ) -> Self {
+        KeyEvent {
+            key_code: key_code.into(),
+            is_repeat,
+            mods,
+            key: Key::Special(special),
         }
     }
 
@@ -95,10 +110,17 @@ impl KeyEvent {
         }
     }
 
+    pub fn special(&self) -> Option<Special> {
+        match self.key {
+            Key::Special(special) => Some(special),
+            _ => None,
+        }
+    }
+
     /// For creating `KeyEvent`s during testing.
     #[doc(hidden)]
     pub fn for_test(mods: impl Into<KeyModifiers>, text: &'static str, code: KeyCode) -> Self {
-        KeyEvent::new(code, false, mods.into(), text, text)
+        KeyEvent::new_text(code, false, mods.into(), text, text)
     }
 }
 
@@ -220,15 +242,6 @@ impl From<char> for StrOrChar {
     }
 }
 
-impl From<Option<char>> for StrOrChar {
-    fn from(src: Option<char>) -> StrOrChar {
-        match src {
-            Some(c) => StrOrChar::Char(c),
-            None => StrOrChar::Str(""),
-        }
-    }
-}
-
 impl fmt::Display for TinyStr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())
@@ -238,12 +251,6 @@ impl fmt::Display for TinyStr {
 impl fmt::Debug for TinyStr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TinyStr(\"{}\")", self.as_str())
-    }
-}
-
-impl Default for TinyStr {
-    fn default() -> Self {
-        TinyStr::new("")
     }
 }
 

--- a/druid-shell/src/keyboard.rs
+++ b/druid-shell/src/keyboard.rs
@@ -79,10 +79,7 @@ impl KeyEvent {
     /// e.g. the `chars` on macOS for opt+s is 'ß'.
     pub fn text(&self) -> Option<&str> {
         match &self.key {
-            Key::Text {
-                text,
-                unmodified_text: _,
-            } => {
+            Key::Text { text, .. } => {
                 if text.len == 0 {
                     None
                 } else {
@@ -97,8 +94,7 @@ impl KeyEvent {
     pub fn unmod_text(&self) -> Option<&str> {
         match &self.key {
             Key::Text {
-                text: _,
-                unmodified_text,
+                unmodified_text, ..
             } => {
                 if unmodified_text.len == 0 {
                     None

--- a/druid-shell/src/keycodes.rs
+++ b/druid-shell/src/keycodes.rs
@@ -183,13 +183,6 @@ impl KeyCode {
 /// of key form. Providing the basis for a platform specific mapping.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Special {
-    Add,
-    Subtract,
-    Multiply,
-    Divide,
-
-    Return,
-
     Alt,
     Control,
     Shift,
@@ -206,4 +199,8 @@ pub enum Special {
     Left,
     Right,
     Up,
+
+    // w3c keyboard API names this Unidentified
+    // it should probably match Unknown above?
+    Unidentified,
 }

--- a/druid-shell/src/keycodes.rs
+++ b/druid-shell/src/keycodes.rs
@@ -165,3 +165,45 @@ impl KeyCode {
         }
     }
 }
+
+/// For `KeyCode`s with duplicate variants of keys, For example `LeftShift` and
+/// `RightShift` There exists single resolved key, `Shift` in this case.
+/// `Special` exists in parallel to KeyCode and Takes Modifiers into account.
+/// It does not however represent keys that result in textual characters.
+///
+/// A more complex example is `KeyCode::Numpad4` on platforms with `NumLock`
+///
+/// With the `NumLock` in the on state:
+///     * `KeyCode::Numpad4` has a textual representation of the form "1",
+///       So it does not have a `Special` representation.
+/// When the `Numlock` is off:
+///     * `KeyCode::Numpad4` might resolve to `Special::Left`.
+///
+/// In particular `Special` represents a logical mapping to the Platonic ideal
+/// of key form. Providing the basis for a platform specific mapping.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Special {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+
+    Return,
+
+    Alt,
+    Control,
+    Shift,
+    Meta,
+
+    Insert,
+    Home,
+    End,
+    Delete,
+    PageUp,
+    PageDown,
+
+    Down,
+    Left,
+    Right,
+    Up,
+}

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -58,7 +58,7 @@ pub use dialog::{FileDialogOptions, FileDialogType, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};
 pub use keyboard::{KeyEvent, KeyModifiers};
-pub use keycodes::KeyCode;
+pub use keycodes::{KeyCode, Special};
 pub use menu::Menu;
 pub use mouse::{Cursor, MouseButton, MouseEvent};
 pub use runloop::RunLoop;

--- a/druid-shell/src/platform/gtk/keycodes.rs
+++ b/druid-shell/src/platform/gtk/keycodes.rs
@@ -314,3 +314,34 @@ impl From<KeyCode> for Special {
         }
     }
 }
+
+// I Don't think we actually want this, as it must make a choice to map to one of the
+// Left or Right keys in many cases, don't see much of a solution besides
+// Special::Control(keycode)?.
+//
+// But it's currently used in `menu::register_accelerator`.
+impl From<Special> for u32 {
+    #[allow(non_upper_case_globals)]
+    fn from(src: Special) -> u32 {
+        match src {
+            Special::Home => Home,
+            Special::Left => Left,
+            Special::Up => Up,
+            Special::Right => Right,
+            Special::Down => Down,
+            Special::PageUp => Page_Up,
+            Special::PageDown => Page_Down,
+            Special::End => End,
+            Special::Insert => Insert,
+            Special::Delete => Delete,
+            Special::Control => Control_R,
+            Special::Alt => Alt_R,
+            Special::Shift => Shift_R,
+            Special::Meta => Super_R,
+            Special::Unidentified => unreachable!(
+                "Unreachable: converting unknown Special {:?} to a keyval",
+                src
+            ),
+        }
+    }
+}

--- a/druid-shell/src/platform/gtk/keycodes.rs
+++ b/druid-shell/src/platform/gtk/keycodes.rs
@@ -16,7 +16,7 @@
 
 use gdk::enums::key::*;
 
-use crate::keycodes::KeyCode;
+use crate::keycodes::{KeyCode, Special};
 
 pub type RawKeyCode = u32;
 
@@ -270,6 +270,47 @@ impl From<KeyCode> for u32 {
                 "Unreachable: converting unknown KeyCode {:?} to a keyval",
                 src
             ),
+        }
+    }
+}
+
+impl From<KeyCode> for Special {
+    #[allow(non_upper_case_globals)]
+    fn from(src: KeyCode) -> Special {
+        //        use KeyCode::*;
+        match src {
+            KeyCode::Home | KeyCode::Unknown(KP_Home) => Special::Home,
+            KeyCode::ArrowLeft | KeyCode::Unknown(KP_Left) => Special::Left,
+            KeyCode::ArrowUp | KeyCode::Unknown(KP_Up) => Special::Up,
+            KeyCode::ArrowRight | KeyCode::Unknown(KP_Right) => Special::Right,
+            KeyCode::ArrowDown | KeyCode::Unknown(KP_Down) => Special::Down,
+            KeyCode::PageUp | KeyCode::Unknown(KP_Page_Up) => Special::PageUp,
+            KeyCode::PageDown | KeyCode::Unknown(KP_Page_Down) => Special::PageDown,
+            KeyCode::End | KeyCode::Unknown(KP_End) => Special::End,
+            // Numpad 5 with numlock off, this behavior matches w3c keyboard event api.
+            KeyCode::Unknown(KP_Begin) => Special::Unidentified,
+            KeyCode::Insert | KeyCode::Unknown(KP_Insert) => Special::Insert,
+            KeyCode::Delete | KeyCode::Unknown(KP_Delete) => Special::Delete,
+            KeyCode::LeftControl
+            | KeyCode::RightControl
+            | KeyCode::Unknown(Control_L)
+            | KeyCode::Unknown(Control_R) => Special::Control,
+            KeyCode::LeftAlt
+            | KeyCode::RightAlt
+            | KeyCode::Unknown(Alt_L)
+            | KeyCode::Unknown(Alt_R) => Special::Alt,
+            KeyCode::LeftShift
+            | KeyCode::RightShift
+            | KeyCode::Unknown(Shift_L)
+            | KeyCode::Unknown(Shift_R) => Special::Shift,
+            KeyCode::LeftMeta
+            | KeyCode::RightMeta
+            | KeyCode::Unknown(Super_L)
+            | KeyCode::Unknown(Super_R) => Special::Meta,
+            _ => {
+                log::warn!("Warning: unknown special keycode {:?}", src);
+                Special::Unidentified
+            }
         }
     }
 }

--- a/druid-shell/src/platform/gtk/menu.rs
+++ b/druid-shell/src/platform/gtk/menu.rs
@@ -134,6 +134,7 @@ fn register_accelerator(item: &GtkMenuItem, accel_group: &AccelGroup, menu_key: 
     let wc = match menu_key.key {
         KeyCompare::Code(key_code) => key_code.into(),
         KeyCompare::Text(text) => text.chars().next().unwrap() as u32,
+        KeyCompare::Special(special) => special.into(),
     };
 
     item.add_accelerator(

--- a/druid-shell/src/platform/mac/menu.rs
+++ b/druid-shell/src/platform/mac/menu.rs
@@ -22,7 +22,7 @@ use super::util::make_nsstring;
 use crate::common_util::strip_access_key;
 use crate::hotkey::{HotKey, KeyCompare};
 use crate::keyboard::KeyModifiers;
-use crate::keycodes::KeyCode;
+use crate::keycodes::{KeyCode, Special};
 
 pub struct Menu {
     pub menu: id,
@@ -113,6 +113,20 @@ impl HotKey {
     fn key_equivalent(&self) -> &str {
         match self.key {
             KeyCompare::Text(t) => t,
+            KeyCompare::Special(Special::Home) => "\u{F729}",
+            KeyCompare::Special(Special::End) => "\u{F72B}",
+            KeyCompare::Special(Special::Insert) => "\u{F727}",
+            KeyCompare::Special(Special::Delete) => "\u{007f}",
+            KeyCompare::Special(Special::PageUp) => "\u{F72C}",
+            KeyCompare::Special(Special::PageDown) => "\u{F72D}",
+            KeyCompare::Special(Special::Up) => "\u{F700}",
+            KeyCompare::Special(Special::Down) => "\u{F701}",
+            KeyCompare::Special(Special::Left) => "\u{F702}",
+            KeyCompare::Special(Special::Right) => "\u{F703}",
+            KeyCompare::Special(other) => {
+                eprintln!("no key equivalent for {:?}", other);
+                ""
+            }
 
             // from NSText.h
             KeyCompare::Code(KeyCode::Return) => "\u{0003}",

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -47,8 +47,8 @@ use piet::{Piet, RenderContext};
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileDialogType, FileInfo,
-    FileSpec, FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods,
-    Text, TimerToken, WinCtx, WindowHandle,
+    FileSpec, FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, Special,
+    SysMods, Text, TimerToken, WinCtx, WindowHandle,
 };
 
 pub use app::{AppLauncher, WindowDesc};


### PR DESCRIPTION
This is undoubtedly not going to pass CI without work on the windows and Mac backends,

I'm not too keen on the way this platform/gtk/window.rs stuff was handled.
But I couldn't come up with another solution that actually worked.

There are some comments inline about Text and whitespace/control characters, for now I tried to match the macOS backend which emits text for these.

There are some interim back and forth changes here which could use a squashing,
Where I had added some characters with Text, to the Special enum.