### PR TITLE
Fix typos.

### DIFF
--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -53,7 +53,7 @@ pub trait AppDelegate<T: Data> {
     /// before they are passed down the tree.
     ///
     /// The return value of this function will be passed down the tree. This can
-    /// be the even that was passed in, a different event, or no event. In all cases,
+    /// be the event that was passed in, a different event, or no event. In all cases,
     /// the `update` method will be called as usual.
     fn event(
         &mut self,

--- a/druid/src/mouse.rs
+++ b/druid/src/mouse.rs
@@ -19,7 +19,7 @@ use crate::{KeyModifiers, MouseButton};
 
 /// The state of the mouse for a click, mouse-up, or move event.
 ///
-/// In `druid`, unlike in druid_shell`, we treat the widget's coordinate
+/// In `druid`, unlike in `druid_shell`, we treat the widget's coordinate
 /// space and the window's coordinate space separately.
 #[derive(Debug, Clone)]
 pub struct MouseEvent {


### PR DESCRIPTION
This PR addresses two minor typos in the documentation.