### PR TITLE
Implement 'save as' dialog, tweak open/save API

### DIFF
--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -54,7 +54,7 @@ mod window;
 
 pub use application::Application;
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
-pub use dialog::{FileDialogOptions, FileDialogType, FileInfo, FileSpec};
+pub use dialog::{FileDialogOptions, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};
 pub use keyboard::{KeyEvent, KeyModifiers};

--- a/druid-shell/src/platform/gtk/dialog.rs
+++ b/druid-shell/src/platform/gtk/dialog.rs
@@ -16,20 +16,12 @@
 
 use std::ffi::OsString;
 
-use crate::dialog::FileDialogOptions;
+use crate::dialog::{FileDialogOptions, FileDialogType};
 use gtk::{FileChooserAction, FileChooserExt, NativeDialogExt, Window};
 
 use crate::Error;
 
-/// Type of file dialog.
-pub enum FileDialogType {
-    /// File open dialog.
-    Open,
-    /// File save dialog.
-    Save,
-}
-
-pub(crate) fn open_file_sync(
+pub(crate) fn get_file_dialog_path(
     window: &Window,
     ty: FileDialogType,
     options: FileDialogOptions,

--- a/druid-shell/src/platform/mac/dialog.rs
+++ b/druid-shell/src/platform/mac/dialog.rs
@@ -22,45 +22,51 @@ use cocoa::base::{id, nil, YES};
 use cocoa::foundation::{NSArray, NSInteger};
 
 use super::util::{from_nsstring, make_nsstring};
-use crate::dialog::FileDialogOptions;
+use crate::dialog::{FileDialogOptions, FileDialogType};
 
 const NSModalResponseOK: NSInteger = 1;
 const NSModalResponseCancel: NSInteger = 0;
 
-pub(crate) unsafe fn show_open_file_dialog_sync(options: FileDialogOptions) -> Option<OsString> {
-    let nsopenpanel = class!(NSOpenPanel);
-    let panel: id = msg_send![nsopenpanel, openPanel];
+pub(crate) fn get_file_dialog_path(
+    ty: FileDialogType,
+    options: FileDialogOptions,
+) -> Option<OsString> {
+    unsafe {
+        let panel: id = match ty {
+            FileDialogType::Open => msg_send![class!(NSOpenPanel), openPanel],
+            FileDialogType::Save => msg_send![class!(NSSavePanel), savePanel],
+        };
 
-    // set options
-
-    if options.show_hidden {
-        let () = msg_send![panel, setShowsHiddenFiles: YES];
-    }
-
-    // A vector of NSStrings. this must outlive `nsarray_allowed_types`.
-    let allowed_types = options.allowed_types.as_ref().map(|specs| {
-        specs
-            .iter()
-            .flat_map(|spec| spec.extensions.iter().map(|s| make_nsstring(s)))
-            .collect::<Vec<_>>()
-    });
-
-    let nsarray_allowed_types = allowed_types
-        .as_ref()
-        .map(|types| NSArray::arrayWithObjects(nil, types.as_slice()));
-    if let Some(nsarray) = nsarray_allowed_types {
-        let () = msg_send![panel, setAllowedFileTypes: nsarray];
-    }
-
-    let result: NSInteger = msg_send![panel, runModal];
-    match result {
-        NSModalResponseOK => {
-            let url: id = msg_send![panel, URL];
-            let path: id = msg_send![url, path];
-            let path: OsString = from_nsstring(path).into();
-            Some(path)
+        // set options
+        if options.show_hidden {
+            let () = msg_send![panel, setShowsHiddenFiles: YES];
         }
-        NSModalResponseCancel => None,
-        _ => unreachable!(),
+
+        // A vector of NSStrings. this must outlive `nsarray_allowed_types`.
+        let allowed_types = options.allowed_types.as_ref().map(|specs| {
+            specs
+                .iter()
+                .flat_map(|spec| spec.extensions.iter().map(|s| make_nsstring(s)))
+                .collect::<Vec<_>>()
+        });
+
+        let nsarray_allowed_types = allowed_types
+            .as_ref()
+            .map(|types| NSArray::arrayWithObjects(nil, types.as_slice()));
+        if let Some(nsarray) = nsarray_allowed_types {
+            let () = msg_send![panel, setAllowedFileTypes: nsarray];
+        }
+
+        let result: NSInteger = msg_send![panel, runModal];
+        match result {
+            NSModalResponseOK => {
+                let url: id = msg_send![panel, URL];
+                let path: id = msg_send![url, path];
+                let path: OsString = from_nsstring(path).into();
+                Some(path)
+            }
+            NSModalResponseCancel => None,
+            _ => unreachable!(),
+        }
     }
 }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -43,7 +43,7 @@ use super::dialog;
 use super::menu::Menu;
 use super::util::{assert_main_thread, make_nsstring};
 use crate::common_util::IdleCallback;
-use crate::dialog::{FileDialogOptions, FileInfo};
+use crate::dialog::{FileDialogOptions, FileDialogType, FileInfo};
 use crate::keyboard::{KeyEvent, KeyModifiers};
 use crate::keycodes::KeyCode;
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
@@ -748,7 +748,13 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
     }
 
     fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
-        unsafe { dialog::show_open_file_dialog_sync(options).map(|s| FileInfo { path: s.into() }) }
+        dialog::get_file_dialog_path(FileDialogType::Open, options)
+            .map(|s| FileInfo { path: s.into() })
+    }
+
+    fn save_as_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
+        dialog::get_file_dialog_path(FileDialogType::Save, options)
+            .map(|s| FileInfo { path: s.into() })
     }
 }
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -199,6 +199,11 @@ pub trait WinCtx<'a> {
     ///
     /// Blocks while the user picks the file.
     fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo>;
+
+    /// Prompt the user to chose a path for saving.
+    ///
+    /// Blocks while the user picks a file.
+    fn save_as_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo>;
 }
 
 /// App behavior, supplied by the app.

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -92,16 +92,33 @@ pub mod sys {
     pub const NEW_FILE: Selector = Selector::new("druid-builtin.menu-file-new");
 
     /// System command. A file picker dialog will be shown to the user, and an
-    /// Open Event will be sent if a file is chosen.
+    /// `OPEN_FILE` command will be sent if a file is chosen.
     ///
-    /// The argument should be a `FileDialogOptions` struct.
-    pub const OPEN_FILE: Selector = Selector::new("druid-builtin.menu-file-open");
+    /// The argument should be a [`FileDialogOptions`] struct.
+    ///
+    /// [`FileDialogOptions`]: struct.FileDialogOptions.html
+    pub const SHOW_OPEN_PANEL: Selector = Selector::new("druid-builtin.menu-file-open");
+
+    /// Open a file.
+    ///
+    /// The argument must be a [`FileInfo`] object for the file to be opened.
+    ///
+    /// [`FileInfo`]: struct.FileInfo.html
+    pub const OPEN_FILE: Selector = Selector::new("druid-builtin.open-file-path");
+
+    /// Special command. When issued, the system will show the 'save as' panel,
+    /// and if a path is selected the system will issue a `SAVE_FILE` command
+    /// with the selected path as the argument.
+    ///
+    /// The argument should be a [`FileDialogOptions`] object.
+    ///
+    /// [`FileDialogOptions`]: struct.FileDialogOptions.html
+    pub const SHOW_SAVE_PANEL: Selector = Selector::new("druid-builtin.menu-file-save-as");
 
     /// Save the current file.
+    ///
+    /// The argument, if present, should be the path where the file should be saved.
     pub const SAVE_FILE: Selector = Selector::new("druid-builtin.menu-file-save");
-
-    /// Show the 'save as' dialog.
-    pub const SAVE_FILE_AS: Selector = Selector::new("druid-builtin.menu-file-save-as");
 
     /// Show the print-setup window.
     pub const PRINT_SETUP: Selector = Selector::new("druid-builtin.menu-file-print-setup");

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -16,7 +16,7 @@
 
 use crate::kurbo::{Rect, Shape, Size, Vec2};
 
-use druid_shell::{Clipboard, FileInfo, KeyEvent, KeyModifiers, TimerToken};
+use druid_shell::{Clipboard, KeyEvent, KeyModifiers, TimerToken};
 
 use crate::mouse::MouseEvent;
 use crate::Command;
@@ -46,11 +46,6 @@ use crate::Command;
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Debug, Clone)]
 pub enum Event {
-    /// Called when the system has a file the application should open.
-    ///
-    /// Most commonly this is in response to a request to show the file
-    /// picker.
-    OpenFile(FileInfo),
     /// Called on the root widget when the window size changes.
     ///
     /// Discussion: it's not obvious this should be propagated to user

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -46,9 +46,9 @@ use piet::{Piet, RenderContext};
 
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::{
-    Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileDialogType, FileInfo,
-    FileSpec, FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods,
-    Text, TimerToken, WinCtx, WindowHandle,
+    Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileInfo, FileSpec,
+    FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods, Text,
+    TimerToken, WinCtx, WindowHandle,
 };
 
 pub use app::{AppLauncher, WindowDesc};
@@ -556,10 +556,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut recurse = true;
         let mut hot_changed = None;
         let child_event = match event {
-            Event::OpenFile(file) => {
-                recurse = ctx.is_root;
-                Event::OpenFile(file.clone())
-            }
             Event::Size(size) => {
                 recurse = ctx.is_root;
                 Event::Size(*size)

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -576,7 +576,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    commands::SAVE_FILE_AS,
+                    commands::SHOW_SAVE_PANEL,
                 )
                 .hotkey(RawMods::CtrlShift, "s")
             }
@@ -780,7 +780,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    commands::SAVE_FILE_AS,
+                    commands::SHOW_SAVE_PANEL,
                 )
                 .hotkey(RawMods::MetaShift, "s")
             }


### PR DESCRIPTION
This gets the 'save as' dialog working in a similar fashion to
the 'open' dialog.

The API isn't great. In druid-shell, open and save_as are exposed
as two different methods on WinCtx. They could be unified, now,
at the cost of a slightly less ergonomic API; the caller would
have to bring the FileDialogType enum into scope and pass it
directly.

In druid, the API is also slightly different. The Event::Open variant
has been removed, and both open and save are now fully Command based.

The basic idea is that there are two 'special' commands,
SHOW_SAVE_PANEL and SHOW_OPEN_PANEL, that are handled by the framework.
When these commands are received, the framework handles showing the
appropriate panel, and getting the input. If this succeeds,
the framework then sends either the SAVE_FILE or OPEN_FILE command,
which is expected to be handled by the framework author.