### PR TITLE
Unify Label and DynLabel

### DIFF
--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -16,7 +16,7 @@
 
 use druid::{AppLauncher, Data, Lens, LensWrap, Widget, WindowDesc};
 
-use druid::widget::{Button, DynLabel, Flex, Padding};
+use druid::widget::{Button, Flex, Label, Padding};
 
 #[derive(Clone, Data, Lens)]
 struct CalcState {
@@ -149,7 +149,7 @@ fn flex_row<T: Data>(
 
 fn build_calc() -> impl Widget<CalcState> {
     let display = LensWrap::new(
-        DynLabel::new(|data: &String, _env| data.clone()),
+        Label::new(|data: &String, _env: &_| data.clone()),
         CalcState::value,
     );
     Flex::column()

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use druid::piet::Color;
 
-use druid::widget::{Button, Container, DynLabel, Flex, List, Padding, Scroll, SizedBox};
+use druid::widget::{Button, Container, Flex, Label, List, Padding, Scroll, SizedBox};
 use druid::{AppLauncher, Widget, WindowDesc};
 
 type AppData = Arc<Vec<u32>>;
@@ -49,7 +49,7 @@ fn ui_builder() -> impl Widget<AppData> {
             SizedBox::new(
                 Container::new(Padding::new(
                     10.0,
-                    DynLabel::new(|d, _| format!("List item #{}", d)),
+                    Label::new(|d: &u32, _env: &_| format!("List item #{}", d)),
                 ))
                 .background(Color::rgb(0.5, 0.5, 0.5)),
             )

--- a/druid/examples/parse.rs
+++ b/druid/examples/parse.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::widget::{Align, DynLabel, Flex, Padding, Parse, TextBox};
+use druid::widget::{Align, Flex, Label, Padding, Parse, TextBox};
 use druid::{AppLauncher, Widget, WindowDesc};
 
 fn main() {
@@ -25,7 +25,7 @@ fn main() {
 }
 
 fn ui_builder() -> impl Widget<Option<u32>> {
-    let label = DynLabel::new(|data: &Option<u32>, _env| {
+    let label = Label::new(|data: &Option<u32>, _env: &_| {
         data.map_or_else(|| "Invalid input".into(), |x| x.to_string())
     });
     let input = Parse::new(TextBox::new());

--- a/druid/examples/slider.rs
+++ b/druid/examples/slider.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::widget::{Align, Button, Checkbox, DynLabel, Flex, Label, Padding, ProgressBar, Slider};
+use druid::widget::{Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider};
 use druid::{AppLauncher, Data, Lens, LensWrap, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
@@ -22,7 +22,7 @@ struct DemoState {
 }
 
 fn build_widget() -> impl Widget<DemoState> {
-    let label = DynLabel::new(|data: &DemoState, _env| {
+    let label = Label::new(|data: &DemoState, _env: &_| {
         if data.double {
             format!("2x the value: {0:.2}", data.value * 2.0)
         } else {

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -15,7 +15,7 @@
 //! Demos the textbox widget, as well as menu creation and overriding theme settings.
 
 use druid::piet::Color;
-use druid::widget::{DynLabel, EnvScope, Flex, Padding, TextBox};
+use druid::widget::{EnvScope, Flex, Label, Padding, TextBox};
 use druid::{theme, AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
 
 fn main() {
@@ -44,7 +44,7 @@ fn build_widget() -> impl Widget<String> {
         },
         TextBox::new(),
     );
-    let label = DynLabel::new(|data: &String, _env| format!("value: {}", data));
+    let label = Label::new(|data: &String, _env: &_| format!("value: {}", data));
 
     Flex::column()
         .with_child(Padding::new(5.0, textbox), 1.0)

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -41,7 +41,7 @@ impl<T: Data + 'static> Button<T> {
         action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static,
     ) -> Button<T> {
         Button {
-            label: Label::aligned(text, UnitPoint::CENTER),
+            label: Label::new(text).align(UnitPoint::CENTER),
             action: Box::new(action),
         }
     }
@@ -56,7 +56,7 @@ impl<T: Data + 'static> Button<T> {
         Align::vertical(
             UnitPoint::CENTER,
             SizedBox::new(Button {
-                label: Label::aligned(text, UnitPoint::CENTER),
+                label: Label::new(text).align(UnitPoint::CENTER),
                 action: Box::new(action),
             })
             .width(width)

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -47,6 +47,21 @@ pub struct Label<T> {
 
 impl<T: Data> Label<T> {
     /// Construct a new Label widget.
+    ///
+    /// ```
+    /// use druid::LocalizedString;
+    /// use druid::widget::Label;
+    ///
+    /// // Construct a new Label using static string.
+    /// let _: Label<u32> = Label::new("Hello world");
+    ///
+    /// // Construct a new Label using localized string.
+    /// let text = LocalizedString::new("hello-counter").with_arg("count", |data: &u32, _env| (*data).into());
+    /// let _: Label<u32> = Label::new(text);
+    ///
+    /// // Construct a new dynamic Label. Text will be updated when data changes.
+    /// let _: Label<u32> = Label::new(|data: &u32, _env: &_| format!("Hello world: {}", data));
+    /// ```
     pub fn new(text: impl Into<LabelText<T>>) -> Self {
         let text = text.into();
         Self {

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -14,8 +14,6 @@
 
 //! A label widget.
 
-use std::marker::PhantomData;
-
 use crate::{
     BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Size, UpdateCtx,
     Widget,
@@ -30,10 +28,15 @@ use crate::localization::LocalizedString;
 use crate::theme;
 use crate::{Point, RenderContext};
 
-/// The text for the label; either a localized or a specific string.
+/// The text for the label
 pub enum LabelText<T> {
+    /// Localized string that will be resolved through `Env`.
     Localized(LocalizedString<T>),
+    /// Specific text
     Specific(String),
+    /// The provided closure is called on update, and its return
+    /// value is used as the text for the label.
+    Dynamic(Box<dyn Fn(&T, &Env) -> String>),
 }
 
 /// A label that displays some text.
@@ -42,39 +45,54 @@ pub struct Label<T> {
     align: UnitPoint,
 }
 
-/// A label with dynamic text.
-///
-/// The provided closure is called on update, and its return
-/// value is used as the text for the label.
-pub struct DynLabel<T: Data> {
-    label_closure: Box<dyn FnMut(&T, &Env) -> String>,
-    phantom: PhantomData<T>,
-}
-
 impl<T: Data> Label<T> {
-    /// Discussion question: should this return Label or a wrapped
-    /// widget (with WidgetPod)?
+    /// Construct a new Label widget.
     pub fn new(text: impl Into<LabelText<T>>) -> Self {
-        Label {
-            text: text.into(),
+        let text = text.into();
+        Self {
+            text,
             align: UnitPoint::LEFT,
         }
     }
 
-    pub fn aligned(text: impl Into<LabelText<T>>, align: UnitPoint) -> Self {
-        Label {
-            text: text.into(),
-            align,
+    /// Set text alignment.
+    pub fn align(mut self, align: UnitPoint) -> Self {
+        self.align = align;
+        self
+    }
+
+    fn get_layout(&mut self, t: &mut PietText, env: &Env, data: &T) -> PietTextLayout {
+        let font_name = env.get(theme::FONT_NAME);
+        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
+
+        // TODO: caching of both the format and the layout
+        let font = t.new_font_by_name(font_name, font_size).build().unwrap();
+        self.text.with_display_text(data, env, |text| {
+            t.new_text_layout(&font, &text).build().unwrap()
+        })
+    }
+}
+
+impl<T: Data> LabelText<T> {
+    /// Call callback with the text that should be displayed.
+    pub fn with_display_text<V>(&self, data: &T, env: &Env, mut cb: impl FnMut(&str) -> V) -> V {
+        match self {
+            LabelText::Specific(s) => cb(s.as_str()),
+            LabelText::Localized(s) => cb(s.localized_str()),
+            LabelText::Dynamic(f) => cb((f)(data, env).as_str()),
         }
     }
 
-    fn get_layout(&self, t: &mut PietText, env: &Env) -> PietTextLayout {
-        let font_name = env.get(theme::FONT_NAME);
-        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
-        let text = self.text.display_text();
-        // TODO: caching of both the format and the layout
-        let font = t.new_font_by_name(font_name, font_size).build().unwrap();
-        t.new_text_layout(&font, text).build().unwrap()
+    /// Update the localization, if necessary.
+    /// This ensures that localized strings are up to date.
+    ///
+    /// Returns `true` if the string has changed.
+    pub fn resolve(&mut self, data: &T, env: &Env) -> bool {
+        match self {
+            LabelText::Specific(_) => false,
+            LabelText::Localized(s) => s.resolve(data, env),
+            LabelText::Dynamic(_s) => false,
+        }
     }
 }
 
@@ -91,21 +109,20 @@ impl<T: Data> Widget<T> for Label<T> {
         &mut self,
         layout_ctx: &mut LayoutCtx,
         bc: &BoxConstraints,
-        _data: &T,
+        data: &T,
         env: &Env,
     ) -> Size {
         bc.debug_check("Label");
 
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
-        let text_layout = self.get_layout(layout_ctx.text(), env);
+        let text_layout = self.get_layout(layout_ctx.text(), env, data);
         // This magical 1.2 constant helps center the text vertically in the rect it's given
-        bc.constrain((text_layout.width(), font_size * 1.2))
+        bc.constrain(Size::new(text_layout.width(), font_size * 1.2))
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, _data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
-
-        let text_layout = self.get_layout(paint_ctx.text(), env);
+        let text_layout = self.get_layout(paint_ctx.text(), env, data);
 
         // Find the origin for the text
         let mut origin = self.align.resolve(Rect::from_origin_size(
@@ -119,86 +136,6 @@ impl<T: Data> Widget<T> for Label<T> {
         //Make sure we don't draw the text too low
         origin.y = origin.y.min(base_state.size().height);
 
-        paint_ctx.draw_text(&text_layout, origin, &env.get(theme::LABEL_COLOR));
-    }
-}
-
-impl<T: Data> LabelText<T> {
-    /// The text that should be displayed. This ensures that localized
-    /// strings are up to date.
-    pub fn display_text(&self) -> &str {
-        match self {
-            LabelText::Specific(s) => s.as_str(),
-            LabelText::Localized(s) => s.localized_str(),
-        }
-    }
-
-    /// Update the localization, if necessary.
-    ///
-    /// Returns `true` if the string has changed.
-    pub fn resolve(&mut self, data: &T, env: &Env) -> bool {
-        match self {
-            LabelText::Specific(_) => false,
-            LabelText::Localized(s) => s.resolve(data, env),
-        }
-    }
-}
-
-impl<T: Data> DynLabel<T> {
-    pub fn new(label_closure: impl FnMut(&T, &Env) -> String + 'static) -> DynLabel<T> {
-        DynLabel {
-            label_closure: Box::new(label_closure),
-            phantom: Default::default(),
-        }
-    }
-
-    fn get_layout(&mut self, t: &mut PietText, env: &Env, data: &T) -> PietTextLayout {
-        let text = (self.label_closure)(data, env);
-
-        let font_name = env.get(theme::FONT_NAME);
-        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
-
-        // TODO: caching of both the format and the layout
-        let font = t.new_font_by_name(font_name, font_size).build().unwrap();
-        t.new_text_layout(&font, &text).build().unwrap()
-    }
-}
-
-impl<T: Data> Widget<T> for DynLabel<T> {
-    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
-
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {
-        ctx.invalidate();
-    }
-
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
-        bc.debug_check("DynLabel");
-
-        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
-        let text_layout = self.get_layout(layout_ctx.text(), env, data);
-        // This magical 1.2 constant helps center the text vertically in the rect it's given
-        bc.constrain(Size::new(text_layout.width(), font_size * 1.2))
-    }
-
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
-        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
-
-        let align = UnitPoint::LEFT;
-        let origin = align.resolve(Rect::from_origin_size(
-            Point::ORIGIN,
-            Size::new(
-                base_state.size().width,
-                base_state.size().height + (font_size * 1.2) / 2.,
-            ),
-        ));
-
-        let text_layout = self.get_layout(paint_ctx.text(), env, data);
         paint_ctx.draw_text(&text_layout, origin, &env.get(theme::LABEL_COLOR));
     }
 }
@@ -218,5 +155,11 @@ impl<T> From<&str> for LabelText<T> {
 impl<T> From<LocalizedString<T>> for LabelText<T> {
     fn from(src: LocalizedString<T>) -> LabelText<T> {
         LabelText::Localized(src)
+    }
+}
+
+impl<T, F: Fn(&T, &Env) -> String + 'static> From<F> for LabelText<T> {
+    fn from(src: F) -> LabelText<T> {
+        LabelText::Dynamic(Box::new(src))
     }
 }

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -21,7 +21,7 @@ mod button;
 pub use crate::widget::button::Button;
 
 mod label;
-pub use crate::widget::label::{DynLabel, Label, LabelText};
+pub use crate::widget::label::{Label, LabelText};
 
 mod either;
 pub use crate::widget::either::Either;


### PR DESCRIPTION
One annoying thing is that you have to specify that closure arguments are references. Otherwise, compiler will complain:

```diff
diff --git a/druid/examples/textbox.rs b/druid/examples/textbox.rs
index 7a5f918..55e0b65 100644
--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -44,7 +44,7 @@ fn build_widget() -> impl Widget<String> {
         },
         TextBox::new(),
     );
-    let label = Label::new(|data: &String, _env: &_| format!("value: {}", data));
+    let label = Label::new(|data: &String, _env| format!("value: {}", data));

     Flex::column()
         .with_child(Padding::new(5.0, textbox), 1.0)
```

Error:

```
error[E0271]: type mismatch resolving `for<'r, 's> <[closure@druid/examples/textbox.rs:47:28: 47:76] as std::ops::FnOnce<(&'r _, &'s druid::env::Env)>>::Output == std::string::String`
  --> druid/examples/textbox.rs:47:17
   |
47 |     let label = Label::new(|data: &String, _env| format!("value: {}", data));
   |                 ^^^^^^^^^^ expected bound lifetime parameter, found concrete lifetime
   |
   = note: required because of the requirements on the impl of `std::convert::From<[closure@druid/examples/textbox.rs:47:28: 47:76]>` for `druid::widget::label::LabelText<std::string::String>`
   = note: required because of the requirements on the impl of `std::convert::Into<druid::widget::label::LabelText<std::string::String>>` for `[closure@druid/examples/textbox.rs:47:28: 47:76]`
   = note: required by `druid::widget::label::Label::<T>::new`

error[E0631]: type mismatch in closure arguments
  --> druid/examples/textbox.rs:47:17
   |
47 |     let label = Label::new(|data: &String, _env| format!("value: {}", data));
   |                 ^^^^^^^^^^ ------------------------------------- found signature of `for<'r> fn(&'r std::string::String, _) -> _`
   |                 |
   |                 expected signature of `for<'r, 's> fn(&'r _, &'s druid::env::Env) -> _`
   |
   = note: required because of the requirements on the impl of `std::convert::From<[closure@druid/examples/textbox.rs:47:28: 47:76]>` for `druid::widget::label::LabelText<_>`
   = note: required because of the requirements on the impl of `std::convert::Into<druid::widget::label::LabelText<_>>` for `[closure@druid/examples/textbox.rs:47:28: 47:76]`
   = note: required by `druid::widget::label::Label::<T>::new`

error: aborting due to 2 previous errors
```