### PR TITLE
[gtk] sketch out a few ways to bypass a segfault on startup

### DIFF
--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -61,5 +61,5 @@ pub use keyboard::{KeyEvent, KeyModifiers};
 pub use keycodes::KeyCode;
 pub use menu::Menu;
 pub use mouse::{Cursor, MouseButton, MouseEvent};
-pub use runloop::RunLoop;
+pub use runloop::{RunFlags, RunLoop};
 pub use window::{Text, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle};

--- a/druid-shell/src/runloop.rs
+++ b/druid-shell/src/runloop.rs
@@ -19,14 +19,27 @@ use crate::platform::runloop as platform;
 /// The main application loop.
 pub struct RunLoop(platform::RunLoop);
 
+#[derive(PartialEq, Eq)]
+pub enum RunFlags {
+    /// Run even if druid determines there is an existing instance of the application
+    /// already running on the platform.
+    MultipleInstances,
+}
+
 impl RunLoop {
     /// Create a new `RunLoop`.
     ///
     /// The runloop does not start until [`RunLoop::new`] is called.
     ///
     /// [`RunLoop::new`]: struct.RunLoop.html#method.run
-    pub fn new() -> RunLoop {
-        RunLoop(platform::RunLoop::new())
+    pub fn new(name: Option<&'static str>, run_flags: Option<RunFlags>) -> RunLoop {
+        RunLoop(platform::RunLoop::new(name, run_flags))
+    }
+
+    /// Returns true if this `RunLoop`
+    /// is a remote connection to an already running `Application`'s runloop.
+    pub fn is_remote_connection(&self) -> bool {
+        return self.0.is_remote_connection();
     }
 
     /// Start the runloop.

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -202,6 +202,7 @@ fn build_calc() -> impl Widget<CalcState> {
 }
 
 fn main() {
+    use druid::RunFlags;
     let window = WindowDesc::new(build_calc);
     let calc_state = CalcState {
         value: "0".to_string(),
@@ -211,6 +212,8 @@ fn main() {
     };
     AppLauncher::with_window(window)
         .use_simple_logger()
+        .name("calc")
+        //.run_flags(RunFlags::MultipleInstances)
         .launch(calc_state)
         .expect("launch failed");
 }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -47,8 +47,8 @@ use piet::{Piet, RenderContext};
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileInfo, FileSpec,
-    FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods, Text,
-    TimerToken, WinCtx, WindowHandle,
+    FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, RunFlags, SysMods,
+    Text, TimerToken, WinCtx, WindowHandle,
 };
 
 pub use app::{AppLauncher, WindowDesc};


### PR DESCRIPTION
This is all a bit ad-hoc since the API's lay across crate boundaries, and is mostly meant to be
informative rather than any actual API proposal.

when running multiple instances of druid apps,
since currently they share the same name, GTK will try to connect to the already running
instance, when it does so it never fully initializes the connection to the window system.

The remote application is already "activated", so the local application never "activated".
We sense this via the is_remote_connection() function.

In this patch there also a mechanism to "force" gtk to ignore any already running application.
This is the RunFlags::MultipleInstances flag which can be set on launch.
By setting this flag the is_remote_connection() flag never returns true.

So after this patch the behavioral changes under the assumption that
there is already a running instance of (currently any) druid program:

if RunFlags == MultipleInstances {
  both the existing and the new instance of the program will be launched.
}

if is_remote_connection() {
  exit the new instance we are in the process of launching.
}