### PR TITLE
[gtk] set the gtk NON_UNIQUE flag on startup, to avoid connecting to a running instance

### DIFF
--- a/druid-shell/src/platform/gtk/runloop.rs
+++ b/druid-shell/src/platform/gtk/runloop.rs
@@ -38,7 +38,12 @@ impl RunLoop {
         // TODO: we should give control over the application ID to the user
         let application = Application::new(
             Some("com.github.xi-editor.druid"),
-            ApplicationFlags::FLAGS_NONE,
+            // TODO we set this to avoid connecting to an existing running instance
+            // of "com.github.xi-editor.druid" after which we would never receive
+            // the "Activate application" below. See pull request druid#384
+            // Which shows another way once we have in place a mechanism for
+            // communication with remote instances.
+            ApplicationFlags::NON_UNIQUE,
         )
         .expect("Unable to create GTK application");
 


### PR DESCRIPTION
This is pulled out of my pull request #384 as its the least astonishing/zero additional API means to fix the segfault referenced there, which I would propose for committing as a temporary fix.
While #114 is not yet, place fixing that may impact the design of the API which was sketched out in #384 and the "exit if already running" behavior seen there isn't useful until that time.

This forces the behavior that each druid application can be run multiple times, and each instance creates windows, essentially disabling the gtk remote application behavior.