### PR TITLE
Add default file extension for the file dialog in Windows.

### DIFF
--- a/druid-shell/src/dialog.rs
+++ b/druid-shell/src/dialog.rs
@@ -35,6 +35,7 @@ pub enum FileDialogType {
 pub struct FileDialogOptions {
     pub show_hidden: bool,
     pub allowed_types: Option<Vec<FileSpec>>,
+    pub default_type: Option<FileSpec>,
     // we don't want a library user to be able to construct this type directly
     __non_exhaustive: (),
     // multi selection
@@ -49,7 +50,7 @@ pub struct FileDialogOptions {
 /// struct.
 ///
 /// [`COMDLG_FILTERSPEC`]: https://docs.microsoft.com/en-ca/windows/win32/api/shtypes/ns-shtypes-comdlg_filterspec
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FileSpec {
     /// A human readable name, describing this filetype.
     ///
@@ -85,9 +86,17 @@ impl FileDialogOptions {
         self
     }
 
-    /// Set the filetypes the user is allowed to select.
+    /// Set the file types the user is allowed to select.
     pub fn allowed_types(mut self, types: Vec<FileSpec>) -> Self {
         self.allowed_types = Some(types);
+        self
+    }
+
+    /// Set the default file type.
+    /// If it's `None` or not present in [`allowed_types`](#method.allowed_types)
+    /// then the first entry in [`allowed_types`](#method.allowed_types) will be used as default.
+    pub fn default_type(mut self, default_type: FileSpec) -> Self {
+        self.default_type = Some(default_type);
         self
     }
 }


### PR DESCRIPTION
This PR adds the `default_type: Option<FileSpec>` property to the `FileDialogOptions` struct. If set to a `FileSpec` which matches one in `allowed_types` then that specific allowed type is chosen as the default in the file dialog. If it's `None` or a `FileSpec` which isn't actually in `allowed_types` then the default is the first item in `allowed_types`, like before.

As I currently only have easy access to a Windows machine I only implemented it for Windows. I'm not sure what the situation is for other platforms. Probably a good idea to create an issue to track that if this PR gets accepted.

Regarding the Windows implementation, choosing the default primarily depends on [IFileDialog::SetFileTypeIndex](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setfiletypeindex) which was previously hardcoded to the first entry but now respects `default_type`. However it's crucial to also call [IFileDialog::SetDefaultExtension](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultextension), at least on Windows 7, because otherwise later on [IShellItem::GetDisplayName](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishellitem-getdisplayname) won't contain any extension unless the user manually entered it. Currently when a user types *myfile* there won't be any extension added by Windows, regardless of the choice of allowed type in the dialog. With this PR an extension gets added by Windows, based on the choice, i.e. *myfile.ext*.

Interestingly the actual string passed to [IFileDialog::SetDefaultExtension](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultextension) doesn't seem to have any effect. It can be *foobar*, some extension present in `allowed_types`, weirdly formatted garbage, or even an empty string! The actual default choice is determined by [IFileDialog::SetFileTypeIndex](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setfiletypeindex). However unless [IFileDialog::SetDefaultExtension](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultextension) gets called, even if with an empty string, Windows 7 won't append the extensions.

I'm not sure how universal the irrelevance of the [IFileDialog::SetDefaultExtension](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultextension) string is, so this PR implements it according to spec and uses only the first extension of `default_type`.