### PR TITLE
Add a WINDOW_CREATED event command.

### DIFF
--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -48,6 +48,11 @@ pub struct Command {
 pub mod sys {
     use super::Selector;
 
+    /// Druid sends this when a window is created, e.g. at startup.
+    ///
+    /// Note that this will likely get refactored into a full lifecycle event suite later.
+    pub const WINDOW_CREATED: Selector = Selector::new("druid-builtin.window-created");
+
     /// Quit the running application. This command is handled by the druid library.
     pub const QUIT_APP: Selector = Selector::new("druid-builtin.quit-app");
 

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -33,8 +33,8 @@ use crate::menu::ContextMenu;
 use crate::theme;
 use crate::window::Window;
 use crate::{
-    BaseState, Command, Data, Env, Event, EventCtx, KeyEvent, KeyModifiers, LayoutCtx, MenuDesc,
-    PaintCtx, TimerToken, UpdateCtx, WheelEvent, WindowDesc, WindowId,
+    commands, BaseState, Command, Data, Env, Event, EventCtx, KeyEvent, KeyModifiers, LayoutCtx,
+    MenuDesc, PaintCtx, TimerToken, UpdateCtx, WheelEvent, WindowDesc, WindowId,
 };
 
 use crate::command::sys as sys_cmd;
@@ -349,6 +349,8 @@ impl<T: Data + 'static> AppState<T> {
 
     pub(crate) fn add_window(&mut self, id: WindowId, window: Window<T>) {
         self.windows.add(id, window);
+        self.command_queue
+            .push_back((id, Command::from(commands::WINDOW_CREATED)));
     }
 
     fn remove_window(&mut self, id: WindowId) -> Option<WindowHandle> {


### PR DESCRIPTION
Having a reliable early event to bootstrap animation etc is useful. This PR adds a simple `WINDOW_CREATED` event which can be used for such a purpose.

Longer term it probably makes sense to migrate this into some sort of `Event::Lifecycle` collection instead. However I think there's significant value in having a stopgap event in the meanwhile, which this PR brings.

I think this fixes #103 for now.