### PR TITLE
Add basic life cycle events

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -384,6 +384,9 @@ impl WindowBuilder {
             .borrow_mut()
             .connect(&handle.clone().into());
 
+        let mut ctx = WinCtxImpl::from(&handle);
+        win_state.handler.borrow_mut().connected(&mut ctx);
+
         Ok(handle)
     }
 }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -170,6 +170,7 @@ impl WindowBuilder {
                 nsview: &handle.nsview,
                 text: Text::new(),
             };
+            (*view_state).handler.connected(&mut ctx);
             (*view_state)
                 .handler
                 .size(frame.size.width as u32, frame.size.height as u32, &mut ctx);

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -299,6 +299,10 @@ impl WndProc for MyWndProc {
         *self.handle.borrow_mut() = handle.clone();
         state.handler.connect(&handle.clone().into());
         *self.state.borrow_mut() = Some(state);
+        if let Ok(mut s) = self.state.try_borrow_mut() {
+            let mut ctx = WinCtxOwner::new(self.handle.borrow(), &self.dwrite_factory);
+            s.as_mut().unwrap().handler.connected(&mut ctx.ctx());
+        }
     }
 
     #[allow(clippy::cognitive_complexity)]

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -215,7 +215,16 @@ pub trait WinCtx<'a> {
 pub trait WinHandler {
     /// Provide the handler with a handle to the window so that it can
     /// invalidate or make other requests.
+    ///
+    /// This method passes the `WindowHandle` directly, because the handler may
+    /// wish to stash it.
     fn connect(&mut self, handle: &WindowHandle);
+
+    /// Called immediately after `connect`.
+    ///
+    /// The handler can implement this method to perform initial setup.
+    #[allow(unused_variables)]
+    fn connected(&mut self, ctx: &mut dyn WinCtx) {}
 
     /// Called when the size of the window is changed. Note that size
     /// is in physical pixels.

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -93,6 +93,10 @@ impl AppDelegate<State> for Delegate {
         ctx: &mut DelegateCtx,
     ) -> Option<Event> {
         match event {
+            Event::LifeCycle(event) => {
+                log::info!("{:?}", event);
+                Some(Event::LifeCycle(event))
+            }
             Event::Command(ref cmd) if cmd.selector == druid::commands::NEW_FILE => {
                 let new_win = WindowDesc::new(ui_builder)
                     .menu(make_menu(data))

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -46,6 +46,12 @@ use crate::Command;
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Debug, Clone)]
 pub enum Event {
+    /// Called when certain application and window lifecycle events occur.
+    ///
+    /// For the various possible events, see the [`LifeCycle`] enum.
+    ///
+    /// [`LifeCycle`]: enum.LifeCycle.html
+    LifeCycle(LifeCycle),
     /// Called on the root widget when the window size changes.
     ///
     /// Discussion: it's not obvious this should be propagated to user
@@ -129,6 +135,15 @@ pub enum Event {
     /// [`Widget`]: trait.Widget.html
     /// [`EventCtx::submit_command`]: struct.EventCtx.html#method.submit_command
     Command(Command),
+}
+
+/// Application life cycle events.
+#[derive(Debug, Clone, Copy)]
+pub enum LifeCycle {
+    /// Sent to all widgets in a given window when that window is first instantiated.
+    ///
+    /// This is guaranteed to be the first event a window receives.
+    WindowConnected,
 }
 
 /// A mouse wheel event.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -56,7 +56,7 @@ pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use command::{sys as commands, Command, Selector};
 pub use data::Data;
 pub use env::{Env, Key, Value};
-pub use event::{Event, WheelEvent};
+pub use event::{Event, LifeCycle, WheelEvent};
 pub use lens::{Lens, LensExt, LensWrap};
 pub use localization::LocalizedString;
 pub use menu::{sys as platform_menus, ContextMenu, MenuDesc, MenuItem};
@@ -556,6 +556,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut recurse = true;
         let mut hot_changed = None;
         let child_event = match event {
+            Event::LifeCycle(event) => Event::LifeCycle(*event),
             Event::Size(size) => {
                 recurse = ctx.is_root;
                 Event::Size(*size)

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -33,8 +33,8 @@ use crate::menu::ContextMenu;
 use crate::theme;
 use crate::window::Window;
 use crate::{
-    BaseState, Command, Data, Env, Event, EventCtx, KeyEvent, KeyModifiers, LayoutCtx, MenuDesc,
-    PaintCtx, TimerToken, UpdateCtx, WheelEvent, WindowDesc, WindowId,
+    BaseState, Command, Data, Env, Event, EventCtx, KeyEvent, KeyModifiers, LayoutCtx, LifeCycle,
+    MenuDesc, PaintCtx, TimerToken, UpdateCtx, WheelEvent, WindowDesc, WindowId,
 };
 
 use crate::command::sys as sys_cmd;
@@ -617,9 +617,16 @@ impl<T: Data + 'static> DruidHandler<T> {
 
 impl<T: Data + 'static> WinHandler for DruidHandler<T> {
     fn connect(&mut self, handle: &WindowHandle) {
+        //NOTE: this method predates `connected`, and we call delegate methods here.
+        //it's possible that we should move those calls to occur in connected?
         self.app_state
             .borrow_mut()
             .connect(self.window_id, handle.clone());
+    }
+
+    fn connected(&mut self, ctx: &mut dyn WinCtx) {
+        let event = Event::LifeCycle(LifeCycle::WindowConnected);
+        self.do_event(event, ctx);
     }
 
     fn paint(&mut self, piet: &mut Piet, ctx: &mut dyn WinCtx) -> bool {


### PR DESCRIPTION
This adds Event::LifeCycle, and the LifeCycle enum, which for now
has two variants: ApplicationStarted and WindowConnected.

The first of these is sent only once, when the application starts;
the second is sent to a window each time a window is added.

ApplicationLaunched is kind of fiddly; if we want to send that message
to a window, we need to track which windows exist at launch time,
and then send it to each of those windows when they actually connect.

It may be that we only really want to send this message to the top-level
application delegate, which would require tracking less state and
be generally cleaner.