### PR TITLE
Add Event::Zoom and WinHandler::zoom (for pinch events)

### DIFF
--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -272,6 +272,11 @@ pub trait WinHandler {
     #[allow(unused_variables)]
     fn wheel(&mut self, delta: Vec2, mods: KeyModifiers, ctx: &mut dyn WinCtx) {}
 
+    /// Called when a platform-defined zoom gesture occurs (such as pinching
+    /// on the trackpad).
+    #[allow(unused_variables)]
+    fn zoom(&mut self, delta: f64, ctx: &mut dyn WinCtx) {}
+
     /// Called when the mouse moves.
     #[allow(unused_variables)]
     fn mouse_move(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {}

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -97,6 +97,10 @@ pub enum Event {
     Paste(Clipboard),
     /// Called when the mouse wheel or trackpad is scrolled.
     Wheel(WheelEvent),
+    /// Called when the trackpad is pinched.
+    ///
+    /// The value is a delta.
+    Zoom(f64),
     /// Called when the "hot" status changes.
     ///
     /// See [`is_hot`](struct.BaseState.html#method.is_hot) for

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -607,6 +607,10 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 recurse = had_active || child_ctx.base_state.is_hot;
                 Event::Wheel(wheel_event.clone())
             }
+            Event::Zoom(zoom) => {
+                recurse = had_active || child_ctx.base_state.is_hot;
+                Event::Zoom(*zoom)
+            }
             Event::HotChanged(is_hot) => Event::HotChanged(*is_hot),
             Event::FocusChanged(_is_focused) => {
                 let had_focus = child_ctx.base_state.has_focus;

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -671,6 +671,11 @@ impl<T: Data + 'static> WinHandler for DruidHandler<T> {
         self.do_event(event, ctx);
     }
 
+    fn zoom(&mut self, delta: f64, ctx: &mut dyn WinCtx) {
+        let event = Event::Zoom(delta);
+        self.do_event(event, ctx);
+    }
+
     fn got_focus(&mut self, ctx: &mut dyn WinCtx) {
         self.app_state
             .borrow_mut()


### PR DESCRIPTION
Pinch to zoom is a special case of gesture, which has (at least on
macOS) special treatment through NSEvent. At some point we will need
some sort of general mechanism for handling trackpad events,
but for now it seems reasonable to just handle this as a special event.

This only includes an implementation for macOS; I haven't looked into
the other platforms.