### PR TITLE
[mac] Fix issue with menu not being interactive on mac

### DIFF
--- a/druid-shell/src/platform/mac/runloop.rs
+++ b/druid-shell/src/platform/mac/runloop.rs
@@ -14,11 +14,11 @@
 
 //! macOS implementation of runloop.
 
-use cocoa::appkit::{NSApp, NSApplication, NSApplicationActivationPolicyRegular};
-use cocoa::base::{id, nil, YES};
-use cocoa::foundation::NSAutoreleasePool;
-
 use super::util::assert_main_thread;
+
+use cocoa::appkit::{NSApp, NSApplication, NSApplicationActivationPolicyRegular};
+use cocoa::base::{id, nil};
+use cocoa::foundation::NSAutoreleasePool;
 
 pub struct RunLoop {
     ns_app: id,
@@ -38,7 +38,6 @@ impl RunLoop {
 
     pub fn run(&mut self) {
         unsafe {
-            let () = msg_send![self.ns_app, activateIgnoringOtherApps: YES];
             self.ns_app.run();
         }
     }


### PR DESCRIPTION
This is... fiddly.

This is related to 0fd0a97; the fix implemented there overlooked an
issue where [NSApplication activateIgnoringOtherApps:] was being called
_before_ [NSApplication run:], which doesn't work; and without actually
figuring out how to get cocoa to use a custom class as our base
application class, it's easier to just use an app delegate and then call
activateIgnoring from there, which seems to work.

This feels a bit cludgy but I don't mind it too much because I expect we will
eventually want to have an AppDelegate anyway.

This solution was inspired on this SO question:
https://stackoverflow.com/questions/33345686/cocoa-application-menu-bar-not-clickable