### PR TITLE
Add BaseState to PaintCtx, remove from paint method

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -19,8 +19,8 @@ use std::f64::consts::PI;
 use druid::kurbo::{Line, Point, Size, Vec2};
 use druid::piet::{Color, RenderContext};
 use druid::{
-    AppLauncher, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,
-    Widget, WindowDesc,
+    AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
+    WindowDesc,
 };
 
 struct AnimWidget {
@@ -59,13 +59,7 @@ impl Widget<u32> for AnimWidget {
         bc.constrain((100.0, 100.0))
     }
 
-    fn paint(
-        &mut self,
-        paint_ctx: &mut PaintCtx,
-        _base_state: &BaseState,
-        _data: &u32,
-        _env: &Env,
-    ) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
         let center = Point::new(50.0, 50.0);
         let ambit = center + 45.0 * Vec2::from_angle((0.75 + self.t) * 2.0 * PI);
         paint_ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -21,8 +21,8 @@ use druid::piet::{
 };
 
 use druid::{
-    AppLauncher, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,
-    Widget, WindowDesc,
+    AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
+    WindowDesc,
 };
 
 struct CustomWidget;
@@ -58,25 +58,17 @@ impl Widget<String> for CustomWidget {
     // The paint method gets called last, after an event flow.
     // It goes event -> update -> layout -> paint, and each method can influence the next.
     // Basically, anything that changes the appearance of a widget causes a paint.
-    fn paint(
-        &mut self,
-        paint_ctx: &mut PaintCtx,
-        base_state: &BaseState,
-        data: &String,
-        _env: &Env,
-    ) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &String, _env: &Env) {
         // Let's draw a picture with Piet!
         // Clear the whole context with the color of your choice
         paint_ctx.clear(Color::WHITE);
 
         // Create an arbitrary bezier path
-        // (base_state.size() returns the size of the layout rect we're painting in)
+        // (paint_ctx.size() returns the size of the layout rect we're painting in)
+        let size = paint_ctx.size();
         let mut path = BezPath::new();
         path.move_to(Point::ORIGIN);
-        path.quad_to(
-            (80.0, 90.0),
-            (base_state.size().width, base_state.size().height),
-        );
+        path.quad_to((80.0, 90.0), (size.width, size.height));
         // Create a color
         let stroke_color = Color::rgb8(0x00, 0x80, 0x00);
         // Stroke the path with thickness 1.0
@@ -120,7 +112,7 @@ impl Widget<String> for CustomWidget {
         // The image is automatically scaled to fit the rect you pass to draw_image
         paint_ctx.draw_image(
             &image,
-            Rect::from_origin_size(Point::ORIGIN, base_state.size()),
+            Rect::from_origin_size(Point::ORIGIN, size),
             InterpolationMode::Bilinear,
         );
     }

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -19,8 +19,8 @@ use std::time::{Duration, Instant};
 use druid::kurbo::{Line, Size};
 use druid::piet::{Color, RenderContext};
 use druid::{
-    AppLauncher, BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken,
-    UpdateCtx, Widget, WindowDesc,
+    AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken, UpdateCtx,
+    Widget, WindowDesc,
 };
 
 struct TimerWidget {
@@ -61,13 +61,7 @@ impl Widget<u32> for TimerWidget {
         bc.constrain((100.0, 100.0))
     }
 
-    fn paint(
-        &mut self,
-        paint_ctx: &mut PaintCtx,
-        _base_state: &BaseState,
-        _data: &u32,
-        _env: &Env,
-    ) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
         if self.on {
             paint_ctx.stroke(Line::new((10.0, 10.0), (10.0, 50.0)), &Color::WHITE, 1.0);
         }

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -21,9 +21,7 @@ use std::sync::Arc;
 pub use druid_derive::Lens;
 
 use crate::kurbo::Size;
-use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A lens is a datatype that gives access to a part of a larger
 /// data structure.
@@ -248,10 +246,10 @@ where
             .with(data, |data| inner.layout(ctx, bc, data, env))
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         let inner = &mut self.inner;
         self.lens
-            .with(data, |data| inner.paint(paint_ctx, base_state, data, env));
+            .with(data, |data| inner.paint(paint_ctx, data, env));
     }
 }
 

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -16,8 +16,7 @@
 
 use crate::kurbo::{Rect, Size};
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 use crate::piet::UnitPoint;
@@ -126,7 +125,7 @@ impl<T: Data> Widget<T> for Align<T> {
         my_size
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint_with_offset(paint_ctx, data, env);
     }
 }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -18,9 +18,7 @@ use crate::kurbo::{Point, RoundedRect, Size};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::{Align, Label, LabelText, SizedBox};
-use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A button with a text label.
 pub struct Button<T> {
@@ -111,12 +109,12 @@ impl<T: Data> Widget<T> for Button<T> {
         self.label.layout(layout_ctx, bc, data, env)
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
-        let is_active = base_state.is_active();
-        let is_hot = base_state.is_hot();
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
+        let is_active = paint_ctx.is_active();
+        let is_hot = paint_ctx.is_hot();
 
         let rounded_rect =
-            RoundedRect::from_origin_size(Point::ORIGIN, base_state.size().to_vec2(), 4.);
+            RoundedRect::from_origin_size(Point::ORIGIN, paint_ctx.size().to_vec2(), 4.);
         let bg_gradient = if is_active {
             LinearGradient::new(
                 UnitPoint::TOP,
@@ -141,6 +139,6 @@ impl<T: Data> Widget<T> for Button<T> {
 
         paint_ctx.fill(rounded_rect, &bg_gradient);
 
-        self.label.paint(paint_ctx, base_state, data, env);
+        self.label.paint(paint_ctx, data, env);
     }
 }

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -18,9 +18,7 @@ use crate::kurbo::{BezPath, Point, RoundedRect, Size};
 use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
 use crate::theme;
 use crate::widget::Align;
-use crate::{
-    BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A checkbox that toggles a boolean
 #[derive(Debug, Clone, Default)]
@@ -78,7 +76,7 @@ impl Widget<bool> for Checkbox {
         ))
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &bool, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &bool, env: &Env) {
         let size = env.get(theme::BASIC_WIDGET_HEIGHT);
 
         let rect =
@@ -96,7 +94,7 @@ impl Widget<bool> for Checkbox {
 
         paint_ctx.fill(rect, &background_gradient);
 
-        let border_color = if base_state.is_hot() {
+        let border_color = if paint_ctx.is_hot() {
             env.get(theme::BORDER_LIGHT)
         } else {
             env.get(theme::BORDER)

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -17,8 +17,7 @@
 use crate::shell::kurbo::{Point, Rect, Size};
 use crate::shell::piet::{PaintBrush, RenderContext};
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 struct BorderState {
@@ -92,10 +91,10 @@ impl<T: Data + 'static> Widget<T> for Container<T> {
         )
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         // Paint background color
         if let Some(ref brush) = self.style.background {
-            let rect = Rect::from_origin_size(Point::ZERO, base_state.size());
+            let rect = Rect::from_origin_size(Point::ZERO, paint_ctx.size());
             paint_ctx.render_ctx.fill(rect, brush);
         }
 
@@ -103,8 +102,8 @@ impl<T: Data + 'static> Widget<T> for Container<T> {
         if let Some(ref border) = self.style.border {
             let offset = border.width / 2.0;
             let size = Size::new(
-                base_state.size().width - border.width,
-                base_state.size().height - border.width,
+                paint_ctx.size().width - border.width,
+                paint_ctx.size().height - border.width,
             );
             let rect = Rect::from_origin_size((offset, offset), size);
             paint_ctx

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -16,8 +16,7 @@
 
 use crate::kurbo::{Point, Rect, Size};
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A widget that switches between two possible child views.
@@ -90,7 +89,7 @@ impl<T: Data> Widget<T> for Either<T> {
         }
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         if self.current {
             self.true_branch.paint(paint_ctx, data, env);
         } else {

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -17,9 +17,7 @@
 use std::marker::PhantomData;
 
 use crate::kurbo::Size;
-use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A widget that accepts a closure to update the environment for its child.
 pub struct EnvScope<T: Data, W: Widget<T>> {
@@ -89,10 +87,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         self.child.layout(layout_ctx, &bc, data, &new_env)
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env);
 
-        self.child.paint(paint_ctx, base_state, data, &new_env);
+        self.child.paint(paint_ctx, data, &new_env);
     }
 }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -17,8 +17,7 @@
 use crate::kurbo::{Point, Rect, Size};
 
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A builder for a row widget that can contain flex children.
@@ -248,7 +247,7 @@ impl<T: Data> Widget<T> for Flex<T> {
         Size::new(width, height)
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         for child in &mut self.children {
             child.widget.paint_with_offset(paint_ctx, data, env);
         }

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -21,8 +21,8 @@ use crate::piet::{
 };
 use crate::theme;
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LocalizedString, PaintCtx,
-    UpdateCtx, Widget,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LocalizedString, PaintCtx, UpdateCtx,
+    Widget,
 };
 
 /// The text for the label
@@ -132,7 +132,7 @@ impl<T: Data> Widget<T> for Label<T> {
         bc.constrain(Size::new(text_layout.width(), font_size * 1.2))
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let text_layout = self.get_layout(paint_ctx.text(), env, data);
 
@@ -140,13 +140,13 @@ impl<T: Data> Widget<T> for Label<T> {
         let mut origin = self.align.resolve(Rect::from_origin_size(
             Point::ORIGIN,
             Size::new(
-                (base_state.size().width - text_layout.width()).max(0.0),
-                base_state.size().height + (font_size * 1.2) / 2.,
+                (paint_ctx.size().width - text_layout.width()).max(0.0),
+                paint_ctx.size().height + (font_size * 1.2) / 2.,
             ),
         ));
 
         //Make sure we don't draw the text too low
-        origin.y = origin.y.min(base_state.size().height);
+        origin.y = origin.y.min(paint_ctx.size().height);
 
         paint_ctx.draw_text(&text_layout, origin, &env.get(theme::LABEL_COLOR));
     }

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -19,8 +19,7 @@ use std::sync::Arc;
 use crate::kurbo::{Point, Rect, Size};
 
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A list widget for a variable-size collection of items.
@@ -190,7 +189,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         bc.constrain(Size::new(width, y))
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         let mut children = self.children.iter_mut();
         data.for_each(|child_data, _| {
             if let Some(child) = children.next() {

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -65,7 +65,7 @@ pub use widget_ext::WidgetExt;
 use std::ops::DerefMut;
 
 use crate::kurbo::Size;
-use crate::{BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx};
+use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx};
 
 /// The trait implemented by all widgets.
 ///
@@ -167,7 +167,7 @@ pub trait Widget<T> {
     /// children, or annotations (for example, scrollbars) by painting
     /// afterwards. In addition, they can apply masks and transforms on
     /// the render context, which is especially useful for scrolling.
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env);
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env);
 }
 
 // TODO: explore getting rid of this (ie be consistent about using
@@ -185,7 +185,7 @@ impl<T> Widget<T> for Box<dyn Widget<T>> {
         self.deref_mut().layout(ctx, bc, data, env)
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
-        self.deref_mut().paint(paint_ctx, base_state, data, env);
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
+        self.deref_mut().paint(paint_ctx, data, env);
     }
 }

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -16,8 +16,7 @@
 
 use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A widget that just adds padding around its child.
@@ -113,7 +112,7 @@ impl<T: Data> Widget<T> for Padding<T> {
         Size::new(size.width + hpad, size.height + vpad)
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, _base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint_with_offset(paint_ctx, data, env);
     }
 }

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -3,9 +3,7 @@ use std::mem;
 use std::str::FromStr;
 
 use crate::kurbo::Size;
-use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// Converts a `Widget<String>` to a `Widget<Option<T>>`, mapping parse errors to None
 pub struct Parse<T> {
@@ -53,13 +51,7 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
         self.widget.layout(ctx, bc, &self.state, env)
     }
 
-    fn paint(
-        &mut self,
-        paint: &mut PaintCtx,
-        base_state: &BaseState,
-        _data: &Option<T>,
-        env: &Env,
-    ) {
-        self.widget.paint(paint, base_state, &self.state, env)
+    fn paint(&mut self, paint: &mut PaintCtx, _data: &Option<T>, env: &Env) {
+        self.widget.paint(paint, &self.state, env)
     }
 }

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -18,9 +18,7 @@ use crate::kurbo::{Point, RoundedRect, Size};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::Align;
-use crate::{
-    BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A progress bar, displaying a numeric progress value.
 #[derive(Debug, Clone, Default)]
@@ -63,13 +61,13 @@ impl Widget<f64> for ProgressBar {
         }
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &f64, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &f64, env: &Env) {
         let clamped = data.max(0.0).min(1.0);
 
         let rounded_rect = RoundedRect::from_origin_size(
             Point::ORIGIN,
             (Size {
-                width: base_state.size().width,
+                width: paint_ctx.size().width,
                 height: env.get(theme::BASIC_WIDGET_HEIGHT),
             })
             .to_vec2(),

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -21,8 +21,7 @@ use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::{Align, Flex, Label, LabelText, Padding};
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A group of radio buttons
@@ -112,7 +111,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         ))
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         let size = env.get(theme::BASIC_WIDGET_HEIGHT);
 
         let circle = Circle::new((size / 2., size / 2.), 7.);
@@ -129,7 +128,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
         paint_ctx.fill(circle, &background_gradient);
 
-        let border_color = if base_state.is_hot() {
+        let border_color = if paint_ctx.is_hot() {
             env.get(theme::BORDER_LIGHT)
         } else {
             env.get(theme::BORDER)

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -22,8 +22,8 @@ use crate::kurbo::{Affine, Point, Rect, RoundedRect, Size, Vec2};
 use crate::piet::RenderContext;
 use crate::theme;
 use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken,
-    UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken, UpdateCtx, Widget,
+    WidgetPod,
 };
 
 #[derive(Debug, Clone)]
@@ -407,12 +407,12 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         self_size
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         if let Err(e) = paint_ctx.save() {
             error!("saving render context failed: {:?}", e);
             return;
         }
-        let viewport = Rect::from_origin_size(Point::ORIGIN, base_state.size());
+        let viewport = Rect::from_origin_size(Point::ORIGIN, paint_ctx.size());
         paint_ctx.clip(viewport);
         paint_ctx.transform(Affine::translate(-self.scroll_offset));
 

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -17,9 +17,7 @@
 use std::f64::INFINITY;
 
 use crate::shell::kurbo::Size;
-use crate::{
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A widget with predefined size.
 ///
@@ -121,9 +119,9 @@ impl<T: Data> Widget<T> for SizedBox<T> {
         }
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
-            inner.paint(paint_ctx, base_state, data, env);
+            inner.paint(paint_ctx, data, env);
         }
     }
 }

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -18,9 +18,7 @@ use crate::kurbo::{Circle, Point, Rect, RoundedRect, Shape, Size};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::Align;
-use crate::{
-    BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A slider, allowing interactive update of a numeric value.
 #[derive(Debug, Clone, Default)]
@@ -117,9 +115,9 @@ impl Widget<f64> for Slider {
         }
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &f64, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &f64, env: &Env) {
         let clamped = data.max(0.0).min(1.0);
-        let rect = Rect::from_origin_size(Point::ORIGIN, base_state.size());
+        let rect = Rect::from_origin_size(Point::ORIGIN, paint_ctx.size());
         let knob_size = env.get(theme::BASIC_WIDGET_HEIGHT);
         let track_thickness = 4.;
 
@@ -144,7 +142,7 @@ impl Widget<f64> for Slider {
         paint_ctx.fill(background_rect, &background_gradient);
 
         //Get ready to paint the knob
-        let is_active = base_state.is_active();
+        let is_active = paint_ctx.is_active();
         let is_hovered = self.knob_hovered;
 
         let knob_position = (rect.width() - knob_size) * clamped + knob_size / 2.;

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -18,8 +18,8 @@ use crate::kurbo::{Line, Point, Rect, Size};
 use crate::piet::RenderContext;
 use crate::widget::flex::Axis;
 use crate::{
-    theme, BaseState, BoxConstraints, Cursor, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetPod,
+    theme, BoxConstraints, Cursor, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,
+    Widget, WidgetPod,
 };
 
 ///A container containing two other widgets, splitting the area either horizontally or vertically.
@@ -258,8 +258,8 @@ impl<T: Data> Widget<T> for Split<T> {
         my_size
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &T, env: &Env) {
-        let size = base_state.size();
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
+        let size = paint_ctx.size();
         //third, because we're putting the lines at roughly third points.
         //small, because we floor, to give the extra pixel (roughly) to the middle.
         let small_third = (self.splitter_size / 3.0).floor();

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -20,9 +20,7 @@ use crate::piet::{
 };
 use crate::theme;
 use crate::widget::Align;
-use crate::{
-    BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-};
+use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 const SWITCH_PADDING: f64 = 3.;
 const SWITCH_WIDTH_RATIO: f64 = 2.75;
@@ -46,13 +44,7 @@ impl Switch {
         knob_circle.winding(mouse_pos) > 0
     }
 
-    fn paint_labels(
-        &mut self,
-        paint_ctx: &mut PaintCtx,
-        base_state: &BaseState,
-        env: &Env,
-        switch_width: f64,
-    ) {
+    fn paint_labels(&mut self, paint_ctx: &mut PaintCtx, env: &Env, switch_width: f64) {
         let font_name = env.get(theme::FONT_NAME);
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
@@ -82,7 +74,7 @@ impl Switch {
         let mut on_label_origin = UnitPoint::LEFT.resolve(Rect::from_origin_size(
             Point::ORIGIN,
             Size::new(
-                (base_state.size().width - on_label_layout.width()).max(0.0),
+                (paint_ctx.size().width - on_label_layout.width()).max(0.0),
                 switch_height + (font_size * 1.2) / 2.,
             ),
         ));
@@ -90,7 +82,7 @@ impl Switch {
         let mut off_label_origin = UnitPoint::LEFT.resolve(Rect::from_origin_size(
             Point::ORIGIN,
             Size::new(
-                (base_state.size().width - off_label_layout.width()).max(0.0),
+                (paint_ctx.size().width - off_label_layout.width()).max(0.0),
                 switch_height + (font_size * 1.2) / 2.,
             ),
         ));
@@ -190,7 +182,7 @@ impl Widget<bool> for Switch {
         bc.constrain(Size::new(width, env.get(theme::BORDERED_WIDGET_HEIGHT)))
     }
 
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, data: &bool, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &bool, env: &Env) {
         let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
         let switch_width = switch_height * SWITCH_WIDTH_RATIO;
         let knob_size = switch_height - 2. * SWITCH_PADDING;
@@ -243,7 +235,7 @@ impl Widget<bool> for Switch {
         paint_ctx.clip(background_rect);
 
         // paint the knob
-        let is_active = base_state.is_active();
+        let is_active = paint_ctx.is_active();
         let is_hovered = self.knob_hovered;
 
         let normal_knob_gradient = LinearGradient::new(
@@ -280,6 +272,6 @@ impl Widget<bool> for Switch {
         paint_ctx.fill(knob_circle, &knob_gradient);
 
         // paint on/off label
-        self.paint_labels(paint_ctx, base_state, env, switch_width);
+        self.paint_labels(paint_ctx, env, switch_width);
     }
 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -20,8 +20,8 @@ use std::time::{Duration, Instant};
 use unicode_segmentation::GraphemeCursor;
 
 use crate::{
-    Application, BaseState, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode,
-    LayoutCtx, PaintCtx, RawMods, SysMods, TimerToken, UpdateCtx, Widget,
+    Application, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx,
+    PaintCtx, RawMods, SysMods, TimerToken, UpdateCtx, Widget,
 };
 
 use crate::kurbo::{Affine, Line, Point, RoundedRect, Size, Vec2};
@@ -388,13 +388,7 @@ impl Widget<String> for TextBox {
         bc.constrain((self.width, env.get(theme::BORDERED_WIDGET_HEIGHT)))
     }
 
-    fn paint(
-        &mut self,
-        paint_ctx: &mut PaintCtx,
-        base_state: &BaseState,
-        data: &String,
-        env: &Env,
-    ) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &String, env: &Env) {
         // Guard against changes in data following `event`
         let content = if data.is_empty() {
             &self.placeholder
@@ -412,7 +406,7 @@ impl Widget<String> for TextBox {
         let placeholder_color = env.get(theme::PLACEHOLDER_COLOR);
         let cursor_color = env.get(theme::CURSOR_COLOR);
 
-        let has_focus = base_state.has_focus();
+        let has_focus = paint_ctx.has_focus();
 
         let border_color = if has_focus {
             env.get(theme::PRIMARY_LIGHT)

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -173,8 +173,10 @@ impl<'a, T: Data + 'static> SingleWindowState<'a, T> {
     }
 
     fn do_paint(&mut self, piet: &mut Piet) {
+        let base_state = BaseState::default();
         let mut paint_ctx = PaintCtx {
             render_ctx: piet,
+            base_state: &base_state,
             window_id: self.window_id,
             region: Rect::ZERO.into(),
         };


### PR DESCRIPTION
Way back in prehistory, PaintCtx was essentially just the
RenderContext from piet, and we passed in BaseState separately.
This doesn't make much sense anymore; it's easier to include this
as part of the context, which is a pattern we use in numerous
other places.


This raises a question: should we do the same with `BoxConstraints` in the layout method? One big upside of this approach is that it reduces the number of types that the user needs to have in scope in order to implement a widget, although that might also be fixed by a prelude...