### PR TITLE
Implement basic traits for derived_lens

### DIFF
--- a/druid-derive/src/lens.rs
+++ b/druid-derive/src/lens.rs
@@ -64,6 +64,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         quote! {
             /// Lens for the field on #ty
             #[allow(non_camel_case_types)]
+            #[derive(Debug, Copy, Clone)]
             pub struct #field_name;
         }
     });


### PR DESCRIPTION
This PR try to add basic traits (Debug, Copy, Clone) for proc-derived field lens as other `LensEx` helpers are also implemented.  (e.g. `Then`, and `Id`)