### PR TITLE
Add druid::prelude

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -16,8 +16,7 @@
 
 use std::f64::consts::PI;
 
-use druid::kurbo::{Line, Point, Size, Vec2};
-use druid::piet::{Color, RenderContext};
+use druid::prelude::*;
 use druid::{
     AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
     WindowDesc,

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -14,12 +14,7 @@
 
 //! An example of a custom drawing widget.
 
-use druid::kurbo::{Affine, BezPath, Point, Rect, Size};
-
-use druid::piet::{
-    Color, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayoutBuilder,
-};
-
+use druid::prelude::*;
 use druid::{
     AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
     WindowDesc,

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -14,8 +14,8 @@
 
 //! This example shows how to construct a basic layout.
 
-use druid::piet::Color;
-use druid::widget::{Button, Flex, Label, SizedBox, WidgetExt};
+use druid::prelude::*;
+use druid::widget::{Button, Flex, Label, SizedBox};
 use druid::{AppLauncher, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -16,9 +16,8 @@
 
 use std::sync::Arc;
 
-use druid::piet::Color;
-
-use druid::lens::{self, LensExt};
+use druid::lens;
+use druid::prelude::*;
 use druid::widget::{Button, Flex, Label, List, Scroll, WidgetExt};
 use druid::{AppLauncher, Data, Lens, Widget, WindowDesc};
 

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -14,7 +14,7 @@
 
 //! This example allows to play with scroll bars over different color tones.
 
-use druid::piet::Color;
+use druid::prelude::*;
 use druid::widget::{Container, Flex, Scroll, SizedBox};
 use druid::{AppLauncher, Widget, WindowDesc};
 

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -14,7 +14,7 @@
 
 //! This example demonstrates the `Split` widget
 
-use druid::piet::Color;
+use druid::prelude::*;
 use druid::widget::{Align, Container, Label, Padding, Split};
 use druid::{AppLauncher, Widget, WindowDesc};
 

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -14,7 +14,7 @@
 
 //! Demos the textbox widget, as well as menu creation and overriding theme settings.
 
-use druid::piet::Color;
+use druid::prelude::*;
 use druid::widget::{EnvScope, Flex, Label, Padding, TextBox};
 use druid::{theme, AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
 

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -16,8 +16,7 @@
 
 use std::time::{Duration, Instant};
 
-use druid::kurbo::{Line, Size};
-use druid::piet::{Color, RenderContext};
+use druid::prelude::*;
 use druid::{
     AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken, UpdateCtx,
     Widget, WindowDesc,

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -62,3 +62,21 @@ pub use mouse::MouseEvent;
 pub use widget::Widget;
 pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};
+
+/// The druid prelude imports geometric types from [`kurbo`], drawing types from [`piet`],
+/// deriveable traits ([`Data`] & [`Lens`]), and the extension traits
+/// ([`WidgetExt`] and [`LensExt`]).
+///
+/// [`kurbo`]: https://crates.io/crates/kurbo
+/// [`piet`]: https://crates.io/crates/piet
+/// [`Data`]: trait.Data.html
+/// [`Lens`]: lens/trait.Lens.html
+/// [`LensExt`]: trait.LensExt.html
+/// [`WidgetExt`]: trait.WidgetExt.html
+pub mod prelude {
+    pub use crate::data::Data;
+    pub use crate::kurbo::*;
+    pub use crate::lens::{Lens, LensExt};
+    pub use crate::piet::*;
+    pub use crate::widget::WidgetExt;
+}

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -14,12 +14,10 @@
 
 //! A widget that aligns its child (for example, centering it).
 
-use crate::kurbo::{Rect, Size};
+use crate::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
-
-use crate::piet::UnitPoint;
 
 /// A widget that aligns its child.
 pub struct Align<T: Data> {

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -14,8 +14,7 @@
 
 //! A button widget.
 
-use crate::kurbo::{Point, RoundedRect, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
+use crate::prelude::*;
 use crate::theme;
 use crate::widget::{Align, Label, LabelText, SizedBox};
 use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -14,8 +14,7 @@
 
 //! A checkbox widget.
 
-use crate::kurbo::{BezPath, Point, RoundedRect, Size};
-use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
+use crate::prelude::*;
 use crate::theme;
 use crate::widget::Align;
 use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -14,8 +14,7 @@
 
 //! A convenience widget that combines common styling and positioning widgets.
 
-use crate::shell::kurbo::{Point, Rect, Size};
-use crate::shell::piet::{PaintBrush, RenderContext};
+use crate::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -14,7 +14,7 @@
 
 //! A widget that switches dynamically between two child views.
 
-use crate::kurbo::{Point, Rect, Size};
+use crate::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -16,7 +16,7 @@
 
 use std::marker::PhantomData;
 
-use crate::kurbo::Size;
+use crate::prelude::*;
 use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A widget that accepts a closure to update the environment for its child.

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -14,8 +14,7 @@
 
 //! A widget that arranges its children in a one-dimensional array.
 
-use crate::kurbo::{Point, Rect, Size};
-
+use crate::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -14,11 +14,7 @@
 
 //! A label widget.
 
-use crate::kurbo::{Point, Rect, Size};
-use crate::piet::{
-    FontBuilder, PietText, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
-    UnitPoint,
-};
+use crate::prelude::*;
 use crate::theme;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LocalizedString, PaintCtx, UpdateCtx,

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -16,8 +16,7 @@
 
 use std::sync::Arc;
 
-use crate::kurbo::{Point, Rect, Size};
-
+use crate::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -14,7 +14,7 @@
 
 //! A widget that just adds padding during layout.
 
-use crate::kurbo::{Insets, Point, Rect, Size};
+use crate::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -1,8 +1,24 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A helper widget for parsing data into text.
+
 use std::fmt::Display;
 use std::mem;
 use std::str::FromStr;
 
-use crate::kurbo::Size;
+use crate::prelude::*;
 use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// Converts a `Widget<String>` to a `Widget<Option<T>>`, mapping parse errors to None

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -14,8 +14,7 @@
 
 //! A progress bar widget.
 
-use crate::kurbo::{Point, RoundedRect, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
+use crate::prelude::*;
 use crate::theme;
 use crate::widget::Align;
 use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -16,8 +16,7 @@
 
 use std::marker::PhantomData;
 
-use crate::kurbo::{Circle, Point, Rect, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
+use crate::prelude::*;
 use crate::theme;
 use crate::widget::{Align, Flex, Label, LabelText, Padding};
 use crate::{

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -18,8 +18,7 @@ use log::error;
 use std::f64::INFINITY;
 use std::time::{Duration, Instant};
 
-use crate::kurbo::{Affine, Point, Rect, RoundedRect, Size, Vec2};
-use crate::piet::RenderContext;
+use crate::prelude::*;
 use crate::theme;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken, UpdateCtx, Widget,

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -16,7 +16,7 @@
 
 use std::f64::INFINITY;
 
-use crate::shell::kurbo::Size;
+use crate::prelude::*;
 use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
 
 /// A widget with predefined size.

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -14,8 +14,7 @@
 
 //! A slider widget.
 
-use crate::kurbo::{Circle, Point, Rect, RoundedRect, Shape, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
+use crate::prelude::*;
 use crate::theme;
 use crate::widget::Align;
 use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -14,8 +14,7 @@
 
 //! A widget which splits an area in two, with a set ratio.
 
-use crate::kurbo::{Line, Point, Rect, Size};
-use crate::piet::RenderContext;
+use crate::prelude::*;
 use crate::widget::flex::Axis;
 use crate::{
     theme, BoxConstraints, Cursor, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -20,14 +20,11 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use log::error;
-
 use usvg;
 
+use crate::prelude::*;
 use crate::{
-    kurbo::BezPath,
-    piet::{Color, RenderContext},
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point, Size,
-    UpdateCtx, Widget,
+    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
 };
 
 /// A widget that renders a SVG

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -19,18 +19,13 @@ use std::ops::Range;
 use std::time::{Duration, Instant};
 use unicode_segmentation::GraphemeCursor;
 
+use crate::prelude::*;
+use crate::theme;
+use crate::widget::Align;
 use crate::{
     Application, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx,
     PaintCtx, RawMods, SysMods, TimerToken, UpdateCtx, Widget,
 };
-
-use crate::kurbo::{Affine, Line, Point, RoundedRect, Size, Vec2};
-use crate::piet::{
-    FontBuilder, PietText, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
-    UnitPoint,
-};
-use crate::theme;
-use crate::widget::Align;
 
 const BORDER_WIDTH: f64 = 1.;
 const PADDING_TOP: f64 = 5.;

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -14,10 +14,8 @@
 
 //! Convenience methods for widgets.
 
-use crate::kurbo::Insets;
-use crate::piet::{PaintBrush, UnitPoint};
-
 use super::{Align, Container, EnvScope, Padding, Parse, SizedBox};
+use crate::prelude::*;
 use crate::{Data, Env, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.


### PR DESCRIPTION
This is mostly a glob re-export of `kurbo` and `piet` types.

I think it's a pretty big papercut that you need to A) know that these types are in a weird place and B) import them  all individually. I don't love preludes, but this feels like an improvement? I guess another option would be to export them all into the base namespace, but that would get cluttered quickly. Another option might be to export them into a number of submodules like `geometry`, `text`, `paint` etcetera, but that also feels too clever.

Very open to thoughts from others on this, doesn't feel like there's an ideal solution.