### PR TITLE
Privatize base state

### DIFF
--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -45,9 +45,7 @@ pub use shell::{
     TimerToken, WinCtx, WindowHandle,
 };
 
-pub use crate::core::{
-    BaseState, BoxedWidget, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, WidgetPod,
-};
+pub use crate::core::{BoxedWidget, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, WidgetPod};
 pub use app::{AppLauncher, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -29,12 +29,13 @@ use crate::shell::{
 };
 
 use crate::app_delegate::{AppDelegate, DelegateCtx};
+use crate::core::BaseState;
 use crate::menu::ContextMenu;
 use crate::theme;
 use crate::window::Window;
 use crate::{
-    BaseState, Command, Data, Env, Event, EventCtx, KeyEvent, KeyModifiers, LayoutCtx, LifeCycle,
-    MenuDesc, PaintCtx, TimerToken, UpdateCtx, WheelEvent, WindowDesc, WindowId,
+    Command, Data, Env, Event, EventCtx, KeyEvent, KeyModifiers, LayoutCtx, LifeCycle, MenuDesc,
+    PaintCtx, TimerToken, UpdateCtx, WheelEvent, WindowDesc, WindowId,
 };
 
 use crate::command::sys as sys_cmd;


### PR DESCRIPTION
This removes BaseState from the public API, and moves its docs
onto `EventCtx`; duplicates of these methods can link to those
docs.

------

based on #408 