### PR TITLE
Compute correct self size of align widget

### DIFF
--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -402,7 +402,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         self.child_size = size;
         self.child
             .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
-        let self_size = bc.constrain(Size::new(100.0, 100.0));
+        let self_size = bc.constrain(self.child_size);
         let _ = self.scroll(Vec2::new(0.0, 0.0), self_size);
         self_size
     }


### PR DESCRIPTION
This PR fixed a bug which make a `Scroll` widget inside a `Align` widget positioned incorrectly.

From:

![wrong](https://user-images.githubusercontent.com/11014119/71442584-7525f200-2741-11ea-9671-af671a4ac056.png)

To:

![correct](https://user-images.githubusercontent.com/11014119/71442588-7bb46980-2741-11ea-9f06-5649c32896c6.png)
