### PR TITLE
Allow standard clipboard format in Windows

### DIFF
--- a/druid-shell/src/platform/windows/clipboard.rs
+++ b/druid-shell/src/platform/windows/clipboard.rs
@@ -177,6 +177,9 @@ unsafe fn make_handle(format: &ClipboardFormat) -> HANDLE {
 }
 
 fn get_format_id(format: FormatId) -> Option<UINT> {
+    if let Some((id, _)) = STANDARD_FORMATS.iter().find(|(_, s)| s == &format) {
+        return Some(*id);
+    }
     match format {
         ClipboardFormat::TEXT => Some(CF_UNICODETEXT),
         other => register_identifier(other),
@@ -277,35 +280,38 @@ fn get_format_name(format: UINT) -> String {
 }
 
 // https://docs.microsoft.com/en-ca/windows/win32/dataxchg/standard-clipboard-formats
+const STANDARD_FORMATS: &[(UINT, &'static str)] = &[
+    (1, "CF_TEXT"),
+    (2, "CF_BITMAP"),
+    (3, "CF_METAFILEPICT"),
+    (4, "CF_SYLK"),
+    (5, "CF_DIF"),
+    (6, "CF_TIFF"),
+    (7, "CF_OEMTEXT"),
+    (8, "CF_DIB"),
+    (9, "CF_PALETTE"),
+    (10, "CF_PENDATA"),
+    (11, "CF_RIFF"),
+    (12, "CF_WAVE"),
+    (13, "CF_UNICODETEXT"),
+    (14, "CF_ENHMETAFILE"),
+    (15, "CF_HDROP"),
+    (16, "CF_LOCALE"),
+    (17, "CF_DIBV5"),
+    (0x0080, "CF_OWNERDISPLAY"),
+    (0x0081, "CF_DSPTEXT"),
+    (0x0082, "CF_DSPBITMAP"),
+    (0x0083, "CF_DSPMETAFILEPICT"),
+    (0x008E, "CF_DSPENHMETAFILE"),
+    (0x0200, "CF_PRIVATEFIRST"),
+    (0x02FF, "CF_PRIVATELAST"),
+    (0x0300, "CF_GDIOBJFIRST"),
+    (0x03FF, "CF_GDIOBJLAST"),
+];
+
 fn get_standard_format_name(format: UINT) -> Option<String> {
-    let name = match format {
-        1 => "CF_TEXT",
-        2 => "CF_BITMAP",
-        3 => "CF_METAFILEPICT",
-        4 => "CF_SYLK",
-        5 => "CF_DIF",
-        6 => "CF_TIFF",
-        7 => "CF_OEMTEXT",
-        8 => "CF_DIB",
-        9 => "CF_PALETTE",
-        10 => "CF_PENDATA",
-        11 => "CF_RIFF",
-        12 => "CF_WAVE",
-        13 => "CF_UNICODETEXT",
-        14 => "CF_ENHMETAFILE",
-        15 => "CF_HDROP",
-        16 => "CF_LOCALE",
-        17 => "CF_DIBV5",
-        0x0080 => "CF_OWNERDISPLAY",
-        0x0081 => "CF_DSPTEXT",
-        0x0082 => "CF_DSPBITMAP",
-        0x0083 => "CF_DSPMETAFILEPICT",
-        0x008E => "CF_DSPENHMETAFILE",
-        0x0200 => "CF_PRIVATEFIRST",
-        0x02FF => "CF_PRIVATELAST",
-        0x0300 => "CF_GDIOBJFIRST",
-        0x03FF => "CF_GDIOBJLAST",
-        _ => return None,
-    };
-    Some(name.into())
+    STANDARD_FORMATS
+        .iter()
+        .find(|(id, _)| *id == format)
+        .map(|(_, s)| s.to_string())
 }

--- a/druid-shell/src/platform/windows/clipboard.rs
+++ b/druid-shell/src/platform/windows/clipboard.rs
@@ -280,7 +280,7 @@ fn get_format_name(format: UINT) -> String {
 }
 
 // https://docs.microsoft.com/en-ca/windows/win32/dataxchg/standard-clipboard-formats
-const STANDARD_FORMATS: &[(UINT, &'static str)] = &[
+const STANDARD_FORMATS: &[(UINT, &str)] = &[
     (1, "CF_TEXT"),
     (2, "CF_BITMAP"),
     (3, "CF_METAFILEPICT"),

--- a/druid-shell/src/platform/windows/clipboard.rs
+++ b/druid-shell/src/platform/windows/clipboard.rs
@@ -252,7 +252,7 @@ fn iter_clipboard_types() -> impl Iterator<Item = UINT> {
 
 fn get_format_name(format: UINT) -> String {
     if let Some(name) = get_standard_format_name(format) {
-        return name;
+        return name.to_owned();
     }
 
     const BUF_SIZE: usize = 64;
@@ -280,7 +280,7 @@ fn get_format_name(format: UINT) -> String {
 }
 
 // https://docs.microsoft.com/en-ca/windows/win32/dataxchg/standard-clipboard-formats
-const STANDARD_FORMATS: &[(UINT, &str)] = &[
+static STANDARD_FORMATS: &[(UINT, &str)] = &[
     (1, "CF_TEXT"),
     (2, "CF_BITMAP"),
     (3, "CF_METAFILEPICT"),
@@ -309,9 +309,9 @@ const STANDARD_FORMATS: &[(UINT, &str)] = &[
     (0x03FF, "CF_GDIOBJLAST"),
 ];
 
-fn get_standard_format_name(format: UINT) -> Option<String> {
+fn get_standard_format_name(format: UINT) -> Option<&'static str> {
     STANDARD_FORMATS
         .iter()
         .find(|(id, _)| *id == format)
-        .map(|(_, s)| (*s).to_string())
+        .map(|(_, s)| *s)
 }

--- a/druid-shell/src/platform/windows/clipboard.rs
+++ b/druid-shell/src/platform/windows/clipboard.rs
@@ -313,5 +313,5 @@ fn get_standard_format_name(format: UINT) -> Option<String> {
     STANDARD_FORMATS
         .iter()
         .find(|(id, _)| *id == format)
-        .map(|(_, s)| s.to_string())
+        .map(|(_, s)| (*s).to_string())
 }


### PR DESCRIPTION
This PR try to allow `druid_shell::Clipboard` to use [*Standard Clipboard Formats*][1] in `Clipboard::preferred_format` and `Clipboard::get_format`, such that the following code works in Windows:

```rust
  let format_id = match clipboard.preferred_format(&["CF_DIBV5"])?;
  let data = clipboard.get_format(format_id);
```

[1]: https://docs.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats