### PR TITLE
Expose PlatformError type

### DIFF
--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -13,15 +13,16 @@
 // limitations under the License.
 
 use druid::widget::{Align, Button, Flex, Label, Padding};
-use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
+use druid::{AppLauncher, LocalizedString, PlatformError, Widget, WindowDesc};
 
-fn main() {
+fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(ui_builder);
     let data = 0_u32;
     AppLauncher::with_window(main_window)
         .use_simple_logger()
-        .launch(data)
-        .expect("launch failed");
+        .launch(data)?;
+
+    Ok(())
 }
 
 fn ui_builder() -> impl Widget<u32> {

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -40,9 +40,9 @@ mod window;
 
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::{
-    Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileInfo, FileSpec,
-    FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods, SysMods, Text,
-    TimerToken, WinCtx, WindowHandle,
+    Application, Clipboard, ClipboardFormat, Cursor, Error as PlatformError, FileDialogOptions,
+    FileInfo, FileSpec, FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods,
+    SysMods, Text, TimerToken, WinCtx, WindowHandle,
 };
 
 pub use crate::core::{BoxedWidget, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, WidgetPod};


### PR DESCRIPTION
I added shell::Error to the types that are re-exported from lib.rs. I think this is sensible because this is the error type that is returned from AppLauncher::launch which is also exported from lib.rs. This makes handling errors in a fn main easier for druid apps.
`Error` is not a really descriptive name so I used `PlatformError` to be consitent with its use in `AppLauncher`
I updated the hello.rs example to show how this might be used for easier error handling.