### PR TITLE
Expose types from kurbo & piet at top level

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -16,11 +16,10 @@
 
 use std::f64::consts::PI;
 
-use druid::kurbo::{Line, Point, Size, Vec2};
-use druid::piet::{Color, RenderContext};
+use druid::kurbo::Line;
 use druid::{
-    AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WindowDesc,
+    AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
+    RenderContext, Size, UpdateCtx, Vec2, Widget, WindowDesc,
 };
 
 struct AnimWidget {

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -14,15 +14,12 @@
 
 //! An example of a custom drawing widget.
 
-use druid::kurbo::{Affine, BezPath, Point, Rect, Size};
-
-use druid::piet::{
-    Color, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayoutBuilder,
-};
+use druid::kurbo::BezPath;
+use druid::piet::{FontBuilder, ImageFormat, InterpolationMode, Text, TextLayoutBuilder};
 
 use druid::{
-    AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
-    WindowDesc,
+    Affine, AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
+    Rect, RenderContext, Size, UpdateCtx, Widget, WindowDesc,
 };
 
 struct CustomWidget;

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -14,9 +14,8 @@
 
 //! This example shows how to construct a basic layout.
 
-use druid::piet::Color;
 use druid::widget::{Button, Flex, Label, SizedBox, WidgetExt};
-use druid::{AppLauncher, Widget, WindowDesc};
+use druid::{AppLauncher, Color, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
     // Begin construction of vertical layout

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -16,11 +16,9 @@
 
 use std::sync::Arc;
 
-use druid::piet::Color;
-
 use druid::lens::{self, LensExt};
 use druid::widget::{Button, Flex, Label, List, Scroll, WidgetExt};
-use druid::{AppLauncher, Data, Lens, Widget, WindowDesc};
+use druid::{AppLauncher, Color, Data, Lens, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
 struct AppData {

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -14,9 +14,8 @@
 
 //! This example allows to play with scroll bars over different color tones.
 
-use druid::piet::Color;
 use druid::widget::{Container, Flex, Scroll, SizedBox};
-use druid::{AppLauncher, Widget, WindowDesc};
+use druid::{AppLauncher, Color, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
     let mut col = Flex::column();

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -14,9 +14,8 @@
 
 //! Demos the textbox widget, as well as menu creation and overriding theme settings.
 
-use druid::piet::Color;
 use druid::widget::{EnvScope, Flex, Label, Padding, TextBox};
-use druid::{theme, AppLauncher, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
+use druid::{theme, AppLauncher, Color, Data, LocalizedString, MenuDesc, Widget, WindowDesc};
 
 fn main() {
     let window = WindowDesc::new(build_widget).menu(make_main_menu());

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -16,11 +16,10 @@
 
 use std::time::{Duration, Instant};
 
-use druid::kurbo::{Line, Size};
-use druid::piet::{Color, RenderContext};
+use druid::kurbo::Line;
 use druid::{
-    AppLauncher, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken, UpdateCtx,
-    Widget, WindowDesc,
+    AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext,
+    Size, TimerToken, UpdateCtx, Widget, WindowDesc,
 };
 
 struct TimerWidget {

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -38,6 +38,9 @@ pub mod widget;
 mod win_handler;
 mod window;
 
+// Types from kurbo & piet that are required by public API.
+pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
+pub use piet::{Color, LinearGradient, PaintBrush, RadialGradient, RenderContext, UnitPoint};
 // these are the types from shell that we expose; others we only use internally.
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Cursor, FileDialogOptions, FileInfo, FileSpec,

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -15,10 +15,12 @@
 //! A button widget.
 
 use crate::kurbo::{Point, RoundedRect, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::{Align, Label, LabelText, SizedBox};
-use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
+use crate::{
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
+    UnitPoint, UpdateCtx, Widget,
+};
 
 /// A button with a text label.
 pub struct Button<T> {

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -15,9 +15,9 @@
 //! A convenience widget that combines common styling and positioning widgets.
 
 use crate::shell::kurbo::{Point, Rect, Size};
-use crate::shell::piet::{PaintBrush, RenderContext};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintBrush, PaintCtx, RenderContext,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 struct BorderState {

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -15,10 +15,12 @@
 //! A progress bar widget.
 
 use crate::kurbo::{Point, RoundedRect, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::Align;
-use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
+use crate::{
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
+    UnitPoint, UpdateCtx, Widget,
+};
 
 /// A progress bar, displaying a numeric progress value.
 #[derive(Debug, Clone, Default)]

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -17,11 +17,11 @@
 use std::marker::PhantomData;
 
 use crate::kurbo::{Circle, Point, Rect, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::{Align, Flex, Label, LabelText, Padding};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
+    UnitPoint, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A group of radio buttons

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -19,11 +19,10 @@ use std::f64::INFINITY;
 use std::time::{Duration, Instant};
 
 use crate::kurbo::{Affine, Point, Rect, RoundedRect, Size, Vec2};
-use crate::piet::RenderContext;
 use crate::theme;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, TimerToken, UpdateCtx, Widget,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext, TimerToken,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 #[derive(Debug, Clone)]

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -15,10 +15,12 @@
 //! A slider widget.
 
 use crate::kurbo::{Circle, Point, Rect, RoundedRect, Shape, Size};
-use crate::piet::{LinearGradient, RenderContext, UnitPoint};
 use crate::theme;
 use crate::widget::Align;
-use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
+use crate::{
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
+    UnitPoint, UpdateCtx, Widget,
+};
 
 /// A slider, allowing interactive update of a numeric value.
 #[derive(Debug, Clone, Default)]

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -15,11 +15,10 @@
 //! A widget which splits an area in two, with a set ratio.
 
 use crate::kurbo::{Line, Point, Rect, Size};
-use crate::piet::RenderContext;
 use crate::widget::flex::Axis;
 use crate::{
-    theme, BoxConstraints, Cursor, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx,
-    Widget, WidgetPod,
+    theme, BoxConstraints, Cursor, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 ///A container containing two other widgets, splitting the area either horizontally or vertically.

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -24,10 +24,8 @@ use log::error;
 use usvg;
 
 use crate::{
-    kurbo::BezPath,
-    piet::{Color, RenderContext},
-    BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point, Size,
-    UpdateCtx, Widget,
+    kurbo::BezPath, BaseState, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx,
+    PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget,
 };
 
 /// A widget that renders a SVG


### PR DESCRIPTION
This feels like a cleaner and simpler alternative to having a prelude.

I've limited this to only those types that are used by public API.