### PR TITLE
Fix SVG widget for 0.4.0

### DIFF
--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -83,7 +83,7 @@ impl<T: Data> Widget<T> for Svg<T> {
             bc.constrain(self.get_size())
         }
     }
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &T, _env: &Env) {
         //TODO: options for aspect ratio or scaling based on height
         let scale = paint_ctx.size().width / self.get_size().width;
 

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -24,8 +24,8 @@ use log::error;
 use usvg;
 
 use crate::{
-    kurbo::BezPath, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx,
-    PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget,
+    kurbo::BezPath, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
+    RenderContext, Size, UpdateCtx, Widget,
 };
 
 /// A widget that renders a SVG

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -24,7 +24,7 @@ use log::error;
 use usvg;
 
 use crate::{
-    kurbo::BezPath, BaseState, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx,
+    kurbo::BezPath, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx,
     PaintCtx, Point, RenderContext, Size, UpdateCtx, Widget,
 };
 
@@ -83,12 +83,12 @@ impl<T: Data> Widget<T> for Svg<T> {
             bc.constrain(self.get_size())
         }
     }
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, base_state: &BaseState, _data: &T, _env: &Env) {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         //TODO: options for aspect ratio or scaling based on height
-        let scale = base_state.size().width / self.get_size().width;
+        let scale = paint_ctx.size().width / self.get_size().width;
 
-        let origin_x = (base_state.size().width - (self.get_size().width * scale)) / 2.0;
-        let origin_y = (base_state.size().height - (self.get_size().height * scale)) / 2.0;
+        let origin_x = (paint_ctx.size().width - (self.get_size().width * scale)) / 2.0;
+        let origin_y = (paint_ctx.size().height - (self.get_size().height * scale)) / 2.0;
         let origin = Point::new(origin_x, origin_y);
 
         self.svg_data.to_piet(scale, origin, paint_ctx);


### PR DESCRIPTION
The SVG feature broke in 0.4.0 because some of the trait method signatures changed.

I'm not familiar enough with github workflows to edit them, but IMO they should be updated to test against different feature flags as well.