### PR TITLE
reimplement Button::sized in WidgetExt

### DIFF
--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -84,16 +84,15 @@ fn ui_builder() -> impl Widget<AppData> {
                     1.0,
                 )
                 .with_child(
-                    Button::sized(
+                    Button::new(
                         "Delete",
                         |_ctx, (shared, item): &mut (Arc<Vec<u32>>, u32), _env| {
                             // We have access to both child's data and shared data.
                             // Remove element from right list.
                             Arc::make_mut(shared).retain(|v| v != item);
                         },
-                        80.0,
-                        20.0,
-                    ),
+                    )
+                    .sized(80.0, 20.0),
                     0.0,
                 )
                 .padding(10.0)

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use druid::lens::{self, LensExt};
 use druid::widget::{Button, Flex, Label, List, Scroll, WidgetExt};
-use druid::{AppLauncher, Color, Data, Lens, Widget, WindowDesc};
+use druid::{AppLauncher, Color, Data, Lens, UnitPoint, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
 struct AppData {
@@ -92,7 +92,8 @@ fn ui_builder() -> impl Widget<AppData> {
                             Arc::make_mut(shared).retain(|v| v != item);
                         },
                     )
-                    .sized(80.0, 20.0),
+                    .fix_size(80.0, 20.0)
+                    .align_vertical(UnitPoint::CENTER),
                     0.0,
                 )
                 .padding(10.0)

--- a/druid/examples/slider.rs
+++ b/druid/examples/slider.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::widget::{Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider};
+use druid::widget::{
+    Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider, WidgetExt,
+};
 use druid::{AppLauncher, Data, Lens, LensWrap, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
@@ -38,12 +40,10 @@ fn build_widget() -> impl Widget<DemoState> {
     let bar = LensWrap::new(ProgressBar::new(), DemoState::value);
     let slider = LensWrap::new(Slider::new(), DemoState::value);
 
-    let button_1 = Button::sized(
-        "increment ",
-        |_ctx, data: &mut DemoState, _env| data.value += 0.1,
-        200.0,
-        100.0,
-    );
+    let button_1 = Button::new("increment ", |_ctx, data: &mut DemoState, _env| {
+        data.value += 0.1
+    })
+    .sized(200.0, 100.0);
     let button_2 = Button::new("decrement ", |_ctx, data: &mut DemoState, _env| {
         data.value -= 0.1
     });

--- a/druid/examples/slider.rs
+++ b/druid/examples/slider.rs
@@ -15,7 +15,7 @@
 use druid::widget::{
     Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider, WidgetExt,
 };
-use druid::{AppLauncher, Data, Lens, LensWrap, Widget, WindowDesc};
+use druid::{AppLauncher, Data, Lens, LensWrap, UnitPoint, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
 struct DemoState {
@@ -43,7 +43,9 @@ fn build_widget() -> impl Widget<DemoState> {
     let button_1 = Button::new("increment ", |_ctx, data: &mut DemoState, _env| {
         data.value += 0.1
     })
-    .sized(200.0, 100.0);
+    .fix_size(200.0, 100.0)
+    .align_vertical(UnitPoint::CENTER);
+
     let button_2 = Button::new("decrement ", |_ctx, data: &mut DemoState, _env| {
         data.value -= 0.1
     });

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -16,7 +16,7 @@
 
 use crate::kurbo::{Point, RoundedRect, Size};
 use crate::theme;
-use crate::widget::{Align, Label, LabelText, SizedBox};
+use crate::widget::{Label, LabelText};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
     UnitPoint, UpdateCtx, Widget,
@@ -40,24 +40,6 @@ impl<T: Data + 'static> Button<T> {
             label: Label::new(text).align(UnitPoint::CENTER),
             action: Box::new(action),
         }
-    }
-
-    /// Create a new button with a fixed size.
-    pub fn sized(
-        text: impl Into<LabelText<T>>,
-        action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static,
-        width: f64,
-        height: f64,
-    ) -> impl Widget<T> {
-        Align::vertical(
-            UnitPoint::CENTER,
-            SizedBox::new(Button {
-                label: Label::new(text).align(UnitPoint::CENTER),
-                action: Box::new(action),
-            })
-            .width(width)
-            .height(height),
-        )
     }
 
     /// A function that can be passed to `Button::new`, for buttons with no action.

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -21,7 +21,7 @@ use super::{Align, Container, EnvScope, Padding, Parse, SizedBox};
 use crate::{Data, Env, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
-pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
+pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a [`Padding`] widget with the given [`Insets`].
     ///
     /// [`Padding`]: struct.Padding.html
@@ -77,6 +77,17 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// [`SizedBox`]: struct.SizedBox.html
     fn fix_height(self, height: f64) -> SizedBox<T> {
         SizedBox::new(self).height(height)
+    }
+
+    /// Wrap a widget in an [`Align`] and a [`SizedBox`] to make it a fixed size
+    ///
+    /// [`Align`]: struct.Align.html
+    /// [`SizedBox`]: struct.SizedBox.html
+    fn sized(self, width: f64, height: f64) -> Align<T> {
+        SizedBox::new(self)
+            .width(width)
+            .height(height)
+            .align_vertical(UnitPoint::CENTER)
     }
 
     /// Wrap this widget in a [`SizedBox`] with an infinite width and height.

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -21,7 +21,7 @@ use super::{Align, Container, EnvScope, Padding, Parse, SizedBox};
 use crate::{Data, Env, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
-pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
+pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a [`Padding`] widget with the given [`Insets`].
     ///
     /// [`Padding`]: struct.Padding.html
@@ -79,15 +79,11 @@ pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
         SizedBox::new(self).height(height)
     }
 
-    /// Wrap a widget in an [`Align`] and a [`SizedBox`] to make it a fixed size
+    /// Wrap this widget in an [`SizedBox`] with an explicit width and height
     ///
-    /// [`Align`]: struct.Align.html
     /// [`SizedBox`]: struct.SizedBox.html
-    fn sized(self, width: f64, height: f64) -> Align<T> {
-        SizedBox::new(self)
-            .width(width)
-            .height(height)
-            .align_vertical(UnitPoint::CENTER)
+    fn fix_size(self, width: f64, height: f64) -> SizedBox<T> {
+        SizedBox::new(self).width(width).height(height)
     }
 
     /// Wrap this widget in a [`SizedBox`] with an infinite width and height.


### PR DESCRIPTION
The Button::sized constructor might be useful for other widgets too so I re implemented it as a WidgetExt method.
I had to add the T: 'sized lifetime constraint to widgetext to allow sized to be wrapped in a SizedBox<T> as well an Allign<T>. I don't think this will cause issues but I would like a second opinion on this.