### PR TITLE
Make button work with a widget as its child

### DIFF
--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -28,7 +28,7 @@ use log::error;
 
 #[cfg(feature = "svg")]
 use druid::{
-    widget::{Flex, Svg, SvgData, WidgetExt},
+    widget::{Flex, Label, Svg, SvgData, WidgetExt},
     AppLauncher, Widget, WindowDesc,
 };
 
@@ -56,6 +56,13 @@ fn ui_builder() -> impl Widget<u32> {
     let mut col = Flex::column();
 
     col.add_child(Svg::new(tiger_svg.clone()).fix_width(100.0).center(), 1.0);
-    col.add_child(Svg::new(tiger_svg), 1.0);
+    col.add_child(
+        Svg::new(tiger_svg).on_click(|_ctx, data, _env| *data += 1),
+        1.0,
+    );
+    col.add_child(
+        Label::new(|data: &u32, _env: &_| format!("Bottom tiger clicks: {}", data)),
+        1.0,
+    );
     col
 }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -38,7 +38,7 @@ impl<T: Data + 'static> Button<T> {
     /// ```
     /// use druid::widget::Button;
     ///
-    /// let button = Button::new("increment", |_ctx, data, _env| *data += 1);
+    /// let button = Button::<u32>::new("increment", |_ctx, data, _env| *data += 1);
     /// ```
     pub fn new(
         text: impl Into<LabelText<T>>,

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -39,7 +39,7 @@ mod textbox;
 mod widget_ext;
 
 pub use align::Align;
-pub use button::Button;
+pub use button::{Button, Click};
 pub use checkbox::Checkbox;
 pub use container::Container;
 pub use either::Either;

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -17,11 +17,11 @@
 use crate::kurbo::Insets;
 use crate::piet::{PaintBrush, UnitPoint};
 
-use super::{Align, Container, EnvScope, Padding, Parse, SizedBox};
-use crate::{Data, Env, Lens, LensWrap, Widget};
+use super::{Align, Button, Container, EnvScope, Padding, Parse, SizedBox};
+use crate::{Data, Env, EventCtx, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
-pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
+pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a [`Padding`] widget with the given [`Insets`].
     ///
     /// [`Padding`]: struct.Padding.html
@@ -114,6 +114,14 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// [`Env`]: struct.Env.html
     fn env_scope(self, f: impl Fn(&mut Env, &T) + 'static) -> EnvScope<T, Self> {
         EnvScope::new(f, self)
+    }
+
+    /// Wrap this widget in a [`Button`] widget. The button will execute the
+    /// provided closure on click.
+    ///
+    /// [`Button`]: struct.Button.html
+    fn on_click(self, action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static) -> Button<T> {
+        Button::custom(self, action)
     }
 
     /// Wrap this widget in a [`LensWrap`] widget for the provided [`Lens`].

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -17,7 +17,7 @@
 use crate::kurbo::Insets;
 use crate::piet::{PaintBrush, UnitPoint};
 
-use super::{Align, Button, Container, EnvScope, Padding, Parse, SizedBox};
+use super::{Align, Click, Container, EnvScope, Padding, Parse, SizedBox};
 use crate::{Data, Env, EventCtx, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
@@ -116,12 +116,12 @@ pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
         EnvScope::new(f, self)
     }
 
-    /// Wrap this widget in a [`Button`] widget. The button will execute the
+    /// Wrap this widget in a [`Click`] widget. `Click` will execute the
     /// provided closure on click.
     ///
-    /// [`Button`]: struct.Button.html
-    fn on_click(self, action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static) -> Button<T> {
-        Button::custom(self, action)
+    /// [`Click`]: struct.Click.html
+    fn on_click(self, action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static) -> Click<T> {
+        Click::new(self, action)
     }
 
     /// Wrap this widget in a [`LensWrap`] widget for the provided [`Lens`].


### PR DESCRIPTION
We've been talking about this for a while in zulip, though I'm just now realizing there's no issue for it. This is a first step toward doing some fancy buttons like a control strip and the "button" aspect of a drop-down menu, but also as-is it should be helpful for many scenarios where something needs to be "clickable".

Two issues with my implementation:
1. to recreate the existing styling, I made a ButtonBackground widget, but for some reason that widget doesn't get `is_active` updates from its parent, only `is_hot`, so I have to do extra event handling. (It's very possible I'm doing a very dumb error but I couldn't find it).
2. to make lifetimes work with WidgetExt I had to make WidgetExt ``T: Data + `static`` which I'm guessing is not ideal? It's unclear to me what I'm doing weird here, because WidgetExt is working with other widgetpod-as-child widgets as-is.

Also all the names for things are up for debate, but I'm pretty happy with it right now. I guess there's a larger question if this is appropriate for WidgetExt, but it felt right to me.