### PR TITLE
Rename label::align -> label::text_alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "druid"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "druid-derive 0.1.2",
  "druid-shell 0.4.0",
@@ -298,7 +298,7 @@ dependencies = [
 name = "druid-derive"
 version = "0.1.2"
 dependencies = [
- "druid 0.4.0",
+ "druid 0.4.1",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid"
-version = "0.4.0"
+version = "0.4.1"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Data-oriented Rust UI design toolkit."

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -37,7 +37,7 @@ impl<T: Data> Button<T> {
         action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static,
     ) -> Button<T> {
         Button {
-            label: Label::new(text).align(UnitPoint::CENTER),
+            label: Label::new(text).text_align(UnitPoint::CENTER),
             action: Box::new(action),
         }
     }

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -68,7 +68,14 @@ impl<T: Data> Label<T> {
     }
 
     /// Set text alignment.
-    pub fn align(mut self, align: UnitPoint) -> Self {
+    #[inline]
+    #[deprecated(since = "0.4.1", note = "use text_align instead")]
+    pub fn align(self, align: UnitPoint) -> Self {
+        self.text_align(align)
+    }
+
+    /// Set text alignment.
+    pub fn text_align(mut self, align: UnitPoint) -> Self {
         self.align = align;
         self
     }


### PR DESCRIPTION
'align' is ambiguous; it could refer to either the alignment of
the whole widget or the alignment of the text.