### PR TITLE
[RFC] Widget::as_any + Widget::child (access to concrete children)

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -63,6 +63,10 @@ impl Widget<u32> for AnimWidget {
         let ambit = center + 45.0 * Vec2::from_angle((0.75 + self.t) * 2.0 * PI);
         paint_ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }
 
 fn main() {

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -65,7 +65,7 @@ impl Widget<u32> for AnimWidget {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }
 

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -112,7 +112,7 @@ impl CalcState {
     }
 }
 
-fn pad<T: Data>(inner: impl Widget<T> + 'static) -> impl Widget<T> {
+fn pad<T: Data + 'static>(inner: impl Widget<T> + 'static) -> impl Widget<T> {
     Padding::new(5.0, inner)
 }
 
@@ -134,7 +134,7 @@ fn digit_button(digit: u8) -> impl Widget<CalcState> {
     ))
 }
 
-fn flex_row<T: Data>(
+fn flex_row<T: Data + 'static>(
     w1: impl Widget<T> + 'static,
     w2: impl Widget<T> + 'static,
     w3: impl Widget<T> + 'static,

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -112,7 +112,7 @@ impl CalcState {
     }
 }
 
-fn pad<T: Data + 'static>(inner: impl Widget<T> + 'static) -> impl Widget<T> {
+fn pad<T: Data>(inner: impl Widget<T>) -> impl Widget<T> {
     Padding::new(5.0, inner)
 }
 
@@ -134,11 +134,11 @@ fn digit_button(digit: u8) -> impl Widget<CalcState> {
     ))
 }
 
-fn flex_row<T: Data + 'static>(
-    w1: impl Widget<T> + 'static,
-    w2: impl Widget<T> + 'static,
-    w3: impl Widget<T> + 'static,
-    w4: impl Widget<T> + 'static,
+fn flex_row<T: Data>(
+    w1: impl Widget<T>,
+    w2: impl Widget<T>,
+    w3: impl Widget<T>,
+    w4: impl Widget<T>,
 ) -> impl Widget<T> {
     Flex::row()
         .with_child(w1, 1.0)

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -113,6 +113,10 @@ impl Widget<String> for CustomWidget {
             InterpolationMode::Bilinear,
         );
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }
 
 fn main() {

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -67,7 +67,7 @@ impl Widget<u32> for TimerWidget {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }
 

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -65,6 +65,10 @@ impl Widget<u32> for TimerWidget {
             paint_ctx.stroke(Line::new((10.0, 10.0), (10.0, 50.0)), &Color::WHITE, 1.0);
         }
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }
 
 fn main() {

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -121,7 +121,7 @@ impl<T: Data> WindowDesc<T> {
     /// [`Widget`]: trait.Widget.html
     pub fn new<W, F>(root: F) -> WindowDesc<T>
     where
-        W: Widget<T> + 'static,
+        W: Widget<T>,
         F: Fn() -> W + 'static,
     {
         // wrap this closure in another closure that dyns the result

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -386,7 +386,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     }
 }
 
-impl<T: Data + 'static, W: Widget<T>> WidgetPod<T, W> {
+impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Box the contained widget.
     ///
     /// Convert a `WidgetPod` containing a widget of a specific concrete type

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -386,7 +386,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     }
 }
 
-impl<T: Data, W: Widget<T> + 'static> WidgetPod<T, W> {
+impl<T: Data + 'static, W: Widget<T>> WidgetPod<T, W> {
     /// Box the contained widget.
     ///
     /// Convert a `WidgetPod` containing a widget of a specific concrete type

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -213,9 +213,9 @@ impl<U, L, W> LensWrap<U, L, W> {
 
 impl<T, U, L, W> Widget<T> for LensWrap<U, L, W>
 where
-    T: Data,
-    U: Data,
-    L: Lens<T, U>,
+    T: Data + 'static,
+    U: Data + 'static,
+    L: Lens<T, U> + 'static,
     W: Widget<U>,
 {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
@@ -250,6 +250,10 @@ where
         let inner = &mut self.inner;
         self.lens
             .with(data, |data| inner.paint(paint_ctx, data, env));
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }
 

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -213,8 +213,8 @@ impl<U, L, W> LensWrap<U, L, W> {
 
 impl<T, U, L, W> Widget<T> for LensWrap<U, L, W>
 where
-    T: Data + 'static,
-    U: Data + 'static,
+    T: Data,
+    U: Data,
     L: Lens<T, U> + 'static,
     W: Widget<U>,
 {

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -253,7 +253,7 @@ where
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }
 

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -130,6 +130,10 @@ impl<T: Data + 'static> Widget<T> for Align<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(self.child.widget())
     }
 }

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -22,7 +22,7 @@ use crate::{
 use crate::piet::UnitPoint;
 
 /// A widget that aligns its child.
-pub struct Align<T: Data> {
+pub struct Align<T: Data + 'static> {
     align: UnitPoint,
     child: WidgetPod<T, Box<dyn Widget<T>>>,
     width_factor: Option<f64>,
@@ -80,7 +80,7 @@ impl<T: Data> Align<T> {
     }
 }
 
-impl<T: Data> Widget<T> for Align<T> {
+impl<T: Data + 'static> Widget<T> for Align<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }
@@ -127,5 +127,9 @@ impl<T: Data> Widget<T> for Align<T> {
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint_with_offset(paint_ctx, data, env);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -22,7 +22,7 @@ use crate::{
 use crate::piet::UnitPoint;
 
 /// A widget that aligns its child.
-pub struct Align<T: Data + 'static> {
+pub struct Align<T: Data> {
     align: UnitPoint,
     child: WidgetPod<T, Box<dyn Widget<T>>>,
     width_factor: Option<f64>,
@@ -35,7 +35,7 @@ impl<T: Data> Align<T> {
     /// Note that the `align` parameter is specified as a `UnitPoint` in
     /// terms of left and right. This is inadequate for bidi-aware layout
     /// and thus the API will change when druid gains bidi capability.
-    pub fn new(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn new(align: UnitPoint, child: impl Widget<T>) -> Align<T> {
         Align {
             align,
             child: WidgetPod::new(child).boxed(),
@@ -45,22 +45,22 @@ impl<T: Data> Align<T> {
     }
 
     /// Create centered widget.
-    pub fn centered(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn centered(child: impl Widget<T>) -> Align<T> {
         Align::new(UnitPoint::CENTER, child)
     }
 
     /// Create right-aligned widget.
-    pub fn right(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn right(child: impl Widget<T>) -> Align<T> {
         Align::new(UnitPoint::RIGHT, child)
     }
 
     /// Create left-aligned widget.
-    pub fn left(child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn left(child: impl Widget<T>) -> Align<T> {
         Align::new(UnitPoint::LEFT, child)
     }
 
     /// Align only in the horizontal axis, keeping the child's size in the vertical.
-    pub fn horizontal(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn horizontal(align: UnitPoint, child: impl Widget<T>) -> Align<T> {
         Align {
             align,
             child: WidgetPod::new(child).boxed(),
@@ -70,7 +70,7 @@ impl<T: Data> Align<T> {
     }
 
     /// Align only in the vertical axis, keeping the child's size in the horizontal.
-    pub fn vertical(align: UnitPoint, child: impl Widget<T> + 'static) -> Align<T> {
+    pub fn vertical(align: UnitPoint, child: impl Widget<T>) -> Align<T> {
         Align {
             align,
             child: WidgetPod::new(child).boxed(),
@@ -80,7 +80,7 @@ impl<T: Data> Align<T> {
     }
 }
 
-impl<T: Data + 'static> Widget<T> for Align<T> {
+impl<T: Data> Widget<T> for Align<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -72,7 +72,7 @@ impl<T: Data> Button<T> {
     pub fn noop(_: &mut EventCtx, _: &mut T, _: &Env) {}
 }
 
-impl<T: Data> Widget<T> for Button<T> {
+impl<T: Data + 'static> Widget<T> for Button<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         match event {
             Event::MouseDown(_) => {
@@ -142,5 +142,8 @@ impl<T: Data> Widget<T> for Button<T> {
         paint_ctx.fill(rounded_rect, &bg_gradient);
 
         self.label.paint(paint_ctx, data, env);
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -72,7 +72,7 @@ impl<T: Data> Button<T> {
     pub fn noop(_: &mut EventCtx, _: &mut T, _: &Env) {}
 }
 
-impl<T: Data + 'static> Widget<T> for Button<T> {
+impl<T: Data> Widget<T> for Button<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         match event {
             Event::MouseDown(_) => {

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -144,6 +144,6 @@ impl<T: Data + 'static> Widget<T> for Button<T> {
         self.label.paint(paint_ctx, data, env);
     }
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -117,6 +117,6 @@ impl Widget<bool> for Checkbox {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -115,4 +115,8 @@ impl Widget<bool> for Checkbox {
             paint_ctx.stroke_styled(path, &env.get(theme::LABEL_COLOR), 2., &style);
         }
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -115,6 +115,10 @@ impl<T: Data> Widget<T> for Container<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(self.inner.widget())
     }
 }

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -26,7 +26,7 @@ struct BorderStyle {
 }
 
 /// A widget that provides simple visual styling options to a child.
-pub struct Container<T: Data + 'static> {
+pub struct Container<T: Data> {
     background: Option<PaintBrush>,
     border: Option<BorderStyle>,
     corner_radius: f64,
@@ -36,7 +36,7 @@ pub struct Container<T: Data + 'static> {
 
 impl<T: Data> Container<T> {
     /// Create Container with a child
-    pub fn new(inner: impl Widget<T> + 'static) -> Self {
+    pub fn new(inner: impl Widget<T>) -> Self {
         Self {
             background: None,
             border: None,

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -26,7 +26,7 @@ struct BorderStyle {
 }
 
 /// A widget that provides simple visual styling options to a child.
-pub struct Container<T: Data> {
+pub struct Container<T: Data + 'static> {
     background: Option<PaintBrush>,
     border: Option<BorderStyle>,
     corner_radius: f64,
@@ -112,5 +112,9 @@ impl<T: Data> Widget<T> for Container<T> {
         };
 
         self.inner.paint(paint_ctx, data, env);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -20,22 +20,22 @@ use crate::{
 };
 
 /// A widget that switches between two possible child views.
-pub struct Either<T: Data + 'static> {
+pub struct Either<T: Data> {
     closure: Box<dyn Fn(&T, &Env) -> bool>,
     true_branch: WidgetPod<T, Box<dyn Widget<T>>>,
     false_branch: WidgetPod<T, Box<dyn Widget<T>>>,
     current: bool,
 }
 
-impl<T: Data + 'static> Either<T> {
+impl<T: Data> Either<T> {
     /// Create a new widget that switches between two views.
     ///
     /// The given closure is evaluated on data change. If its value is `true`, then
     /// the `true_branch` widget is shown, otherwise `false_branch`.
     pub fn new(
         closure: impl Fn(&T, &Env) -> bool + 'static,
-        true_branch: impl Widget<T> + 'static,
-        false_branch: impl Widget<T> + 'static,
+        true_branch: impl Widget<T>,
+        false_branch: impl Widget<T>,
     ) -> Either<T> {
         Either {
             closure: Box::new(closure),
@@ -46,7 +46,7 @@ impl<T: Data + 'static> Either<T> {
     }
 }
 
-impl<T: Data + 'static> Widget<T> for Either<T> {
+impl<T: Data> Widget<T> for Either<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.current {
             self.true_branch.event(ctx, event, data, env)

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -20,14 +20,14 @@ use crate::{
 };
 
 /// A widget that switches between two possible child views.
-pub struct Either<T: Data> {
+pub struct Either<T: Data + 'static> {
     closure: Box<dyn Fn(&T, &Env) -> bool>,
     true_branch: WidgetPod<T, Box<dyn Widget<T>>>,
     false_branch: WidgetPod<T, Box<dyn Widget<T>>>,
     current: bool,
 }
 
-impl<T: Data> Either<T> {
+impl<T: Data + 'static> Either<T> {
     /// Create a new widget that switches between two views.
     ///
     /// The given closure is evaluated on data change. If its value is `true`, then
@@ -46,7 +46,7 @@ impl<T: Data> Either<T> {
     }
 }
 
-impl<T: Data> Widget<T> for Either<T> {
+impl<T: Data + 'static> Widget<T> for Either<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.current {
             self.true_branch.event(ctx, event, data, env)
@@ -95,5 +95,9 @@ impl<T: Data> Widget<T> for Either<T> {
         } else {
             self.false_branch.paint(paint_ctx, data, env);
         }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -98,6 +98,6 @@ impl<T: Data + 'static> Widget<T> for Either<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -95,6 +95,10 @@ impl<T: Data + 'static, W: Widget<T>> Widget<T> for EnvScope<T, W> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(&self.child)
     }
 }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -57,7 +57,7 @@ impl<T: Data, W: Widget<T>> EnvScope<T, W> {
     }
 }
 
-impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
+impl<T: Data + 'static, W: Widget<T>> Widget<T> for EnvScope<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
@@ -92,5 +92,9 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         (self.f)(&mut new_env, &data);
 
         self.child.paint(paint_ctx, data, &new_env);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -57,7 +57,7 @@ impl<T: Data, W: Widget<T>> EnvScope<T, W> {
     }
 }
 
-impl<T: Data + 'static, W: Widget<T>> Widget<T> for EnvScope<T, W> {
+impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -254,6 +254,6 @@ impl<T: Data + 'static> Widget<T> for Flex<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -36,12 +36,12 @@ pub struct Row;
 pub struct Column;
 
 /// A container with either horizontal or vertical layout.
-pub struct Flex<T: Data> {
+pub struct Flex<T: Data + 'static> {
     direction: Axis,
     children: Vec<ChildWidget<T>>,
 }
 
-struct ChildWidget<T: Data> {
+struct ChildWidget<T: Data + 'static> {
     widget: WidgetPod<T, Box<dyn Widget<T>>>,
     params: Params,
 }
@@ -149,7 +149,7 @@ impl<T: Data> Flex<T> {
     }
 }
 
-impl<T: Data> Widget<T> for Flex<T> {
+impl<T: Data + 'static> Widget<T> for Flex<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         for child in &mut self.children {
             child.widget.event(ctx, event, data, env);
@@ -251,5 +251,9 @@ impl<T: Data> Widget<T> for Flex<T> {
         for child in &mut self.children {
             child.widget.paint_with_offset(paint_ctx, data, env);
         }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -36,12 +36,12 @@ pub struct Row;
 pub struct Column;
 
 /// A container with either horizontal or vertical layout.
-pub struct Flex<T: Data + 'static> {
+pub struct Flex<T: Data> {
     direction: Axis,
     children: Vec<ChildWidget<T>>,
 }
 
-struct ChildWidget<T: Data + 'static> {
+struct ChildWidget<T: Data> {
     widget: WidgetPod<T, Box<dyn Widget<T>>>,
     params: Params,
 }
@@ -123,7 +123,7 @@ impl<T: Data> Flex<T> {
     /// Builder-style variant of `add_child`
     ///
     /// Convenient for assembling a group of widgets in a single expression.
-    pub fn with_child(mut self, child: impl Widget<T> + 'static, flex: f64) -> Self {
+    pub fn with_child(mut self, child: impl Widget<T>, flex: f64) -> Self {
         self.add_child(child, flex);
         self
     }
@@ -139,7 +139,7 @@ impl<T: Data> Flex<T> {
     /// among the flex children.
     ///
     /// See also `with_child`.
-    pub fn add_child(&mut self, child: impl Widget<T> + 'static, flex: f64) {
+    pub fn add_child(&mut self, child: impl Widget<T>, flex: f64) {
         let params = Params { flex };
         let child = ChildWidget {
             widget: WidgetPod::new(child).boxed(),
@@ -149,7 +149,7 @@ impl<T: Data> Flex<T> {
     }
 }
 
-impl<T: Data + 'static> Widget<T> for Flex<T> {
+impl<T: Data> Widget<T> for Flex<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         for child in &mut self.children {
             child.widget.event(ctx, event, data, env);

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -108,7 +108,7 @@ impl<T: Data> LabelText<T> {
     }
 }
 
-impl<T: Data + 'static> Widget<T> for Label<T> {
+impl<T: Data> Widget<T> for Label<T> {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -108,7 +108,7 @@ impl<T: Data> LabelText<T> {
     }
 }
 
-impl<T: Data> Widget<T> for Label<T> {
+impl<T: Data + 'static> Widget<T> for Label<T> {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
@@ -149,6 +149,10 @@ impl<T: Data> Widget<T> for Label<T> {
         origin.y = origin.y.min(paint_ctx.size().height);
 
         paint_ctx.draw_text(&text_layout, origin, &env.get(theme::LABEL_COLOR));
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }
 

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -152,7 +152,7 @@ impl<T: Data + 'static> Widget<T> for Label<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }
 

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -23,15 +23,15 @@ use crate::{
 };
 
 /// A list widget for a variable-size collection of items.
-pub struct List<T: Data + 'static> {
+pub struct List<T: Data> {
     closure: Box<dyn Fn() -> Box<dyn Widget<T>>>,
     children: Vec<WidgetPod<T, Box<dyn Widget<T>>>>,
 }
 
-impl<T: Data + 'static> List<T> {
+impl<T: Data> List<T> {
     /// Create a new list widget. Closure will be called every time when a new child
     /// needs to be constructed.
-    pub fn new<W: Widget<T> + 'static>(closure: impl Fn() -> W + 'static) -> Self {
+    pub fn new<W: Widget<T>>(closure: impl Fn() -> W + 'static) -> Self {
         List {
             closure: Box::new(move || Box::new(closure())),
             children: Vec::new(),
@@ -122,7 +122,7 @@ impl<T1: Data, T: Data> ListIter<(T1, T)> for (T1, Arc<Vec<T>>) {
     }
 }
 
-impl<C: Data + 'static, T: ListIter<C>> Widget<T> for List<C> {
+impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut children = self.children.iter_mut();
         data.for_each_mut(|child_data, _| {

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -23,12 +23,12 @@ use crate::{
 };
 
 /// A list widget for a variable-size collection of items.
-pub struct List<T: Data> {
+pub struct List<T: Data + 'static> {
     closure: Box<dyn Fn() -> Box<dyn Widget<T>>>,
     children: Vec<WidgetPod<T, Box<dyn Widget<T>>>>,
 }
 
-impl<T: Data> List<T> {
+impl<T: Data + 'static> List<T> {
     /// Create a new list widget. Closure will be called every time when a new child
     /// needs to be constructed.
     pub fn new<W: Widget<T> + 'static>(closure: impl Fn() -> W + 'static) -> Self {
@@ -122,7 +122,7 @@ impl<T1: Data, T: Data> ListIter<(T1, T)> for (T1, Arc<Vec<T>>) {
     }
 }
 
-impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
+impl<C: Data + 'static, T: ListIter<C>> Widget<T> for List<C> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let mut children = self.children.iter_mut();
         data.for_each_mut(|child_data, _| {
@@ -196,5 +196,9 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
                 child.paint_with_offset(paint_ctx, child_data, env);
             }
         });
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -199,6 +199,6 @@ impl<C: Data + 'static, T: ListIter<C>> Widget<T> for List<C> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -171,6 +171,10 @@ pub trait Widget<T>: 'static {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env);
 
     fn as_any(&self) -> &dyn std::any::Any;
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        None
+    }
 }
 
 // TODO: explore getting rid of this (ie be consistent about using
@@ -194,5 +198,9 @@ impl<T: 'static> Widget<T> for Box<dyn Widget<T>> {
 
     fn as_any(&self) -> &dyn Any {
         self.deref().as_any()
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        self.deref().child()
     }
 }

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// A widget that just adds padding around its child.
-pub struct Padding<T: Data + 'static> {
+pub struct Padding<T: Data> {
     left: f64,
     right: f64,
     top: f64,
@@ -29,10 +29,10 @@ pub struct Padding<T: Data + 'static> {
     child: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T: Data + 'static> Padding<T> {
+impl<T: Data> Padding<T> {
     /// Create widget with uniform padding.
     #[deprecated(since = "0.3.0", note = "Use Padding::new() instead")]
-    pub fn uniform(padding: f64, child: impl Widget<T> + 'static) -> Padding<T> {
+    pub fn uniform(padding: f64, child: impl Widget<T>) -> Padding<T> {
         Padding {
             left: padding,
             right: padding,
@@ -71,7 +71,7 @@ impl<T: Data + 'static> Padding<T> {
     /// ```
     ///
     /// [`kurbo::Insets`]: https://docs.rs/kurbo/0.5.3/kurbo/struct.Insets.html
-    pub fn new(insets: impl Into<Insets>, child: impl Widget<T> + 'static) -> Padding<T> {
+    pub fn new(insets: impl Into<Insets>, child: impl Widget<T>) -> Padding<T> {
         let insets = insets.into();
         Padding {
             left: insets.x0,
@@ -83,7 +83,7 @@ impl<T: Data + 'static> Padding<T> {
     }
 }
 
-impl<T: Data + 'static> Widget<T> for Padding<T> {
+impl<T: Data> Widget<T> for Padding<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// A widget that just adds padding around its child.
-pub struct Padding<T: Data> {
+pub struct Padding<T: Data + 'static> {
     left: f64,
     right: f64,
     top: f64,
@@ -29,7 +29,7 @@ pub struct Padding<T: Data> {
     child: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T: Data> Padding<T> {
+impl<T: Data + 'static> Padding<T> {
     /// Create widget with uniform padding.
     #[deprecated(since = "0.3.0", note = "Use Padding::new() instead")]
     pub fn uniform(padding: f64, child: impl Widget<T> + 'static) -> Padding<T> {
@@ -83,7 +83,7 @@ impl<T: Data> Padding<T> {
     }
 }
 
-impl<T: Data> Widget<T> for Padding<T> {
+impl<T: Data + 'static> Widget<T> for Padding<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.child.event(ctx, event, data, env)
     }
@@ -114,5 +114,9 @@ impl<T: Data> Widget<T> for Padding<T> {
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint_with_offset(paint_ctx, data, env);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -117,6 +117,10 @@ impl<T: Data + 'static> Widget<T> for Padding<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(self.child.widget())
     }
 }

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -20,7 +20,7 @@ impl<T> Parse<T> {
     }
 }
 
-impl<T: FromStr + Display + Data + 'static, W: Widget<String>> Widget<Option<T>> for Parse<W> {
+impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse<W> {
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -20,7 +20,7 @@ impl<T> Parse<T> {
     }
 }
 
-impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse<W> {
+impl<T: FromStr + Display + Data + 'static, W: Widget<String>> Widget<Option<T>> for Parse<W> {
     fn update(
         &mut self,
         ctx: &mut UpdateCtx,
@@ -56,6 +56,6 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -54,4 +54,8 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
     fn paint(&mut self, paint: &mut PaintCtx, _data: &Option<T>, env: &Env) {
         self.widget.paint(paint, &self.state, env)
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -110,6 +110,6 @@ impl Widget<f64> for ProgressBar {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -108,4 +108,8 @@ impl Widget<f64> for ProgressBar {
         );
         paint_ctx.fill(rounded_rect, &bar_gradient);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -45,7 +45,7 @@ impl<T: Data + PartialEq> RadioGroup<T> {
 }
 
 /// A single radio button
-pub struct Radio<T: Data + PartialEq + 'static> {
+pub struct Radio<T: Data + PartialEq> {
     variant: T,
     child_label: WidgetPod<T, Box<dyn Widget<T>>>,
 }
@@ -61,7 +61,7 @@ impl<T: Data + PartialEq> Radio<T> {
     }
 }
 
-impl<T: Data + PartialEq + 'static> Widget<T> for Radio<T> {
+impl<T: Data + PartialEq> Widget<T> for Radio<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, _env: &Env) {
         match event {
             Event::MouseDown(_) => {

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -45,7 +45,7 @@ impl<T: Data + PartialEq> RadioGroup<T> {
 }
 
 /// A single radio button
-pub struct Radio<T: Data + PartialEq> {
+pub struct Radio<T: Data + PartialEq + 'static> {
     variant: T,
     child_label: WidgetPod<T, Box<dyn Widget<T>>>,
 }
@@ -61,7 +61,7 @@ impl<T: Data + PartialEq> Radio<T> {
     }
 }
 
-impl<T: Data + PartialEq> Widget<T> for Radio<T> {
+impl<T: Data + PartialEq + 'static> Widget<T> for Radio<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, _env: &Env) {
         match event {
             Event::MouseDown(_) => {
@@ -145,5 +145,9 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
 
         // Paint the text label
         self.child_label.paint_with_offset(paint_ctx, data, env);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -148,6 +148,6 @@ impl<T: Data + PartialEq + 'static> Widget<T> for Radio<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -272,7 +272,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     }
 }
 
-impl<T: Data + 'static, W: Widget<T>> Widget<T> for Scroll<T, W> {
+impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let size = ctx.size();
         let viewport = Rect::from_origin_size(Point::ORIGIN, size);

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -427,6 +427,10 @@ impl<T: Data + 'static, W: Widget<T>> Widget<T> for Scroll<T, W> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        Some(self.child.widget())
     }
 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -272,7 +272,7 @@ impl<T: Data, W: Widget<T>> Scroll<T, W> {
     }
 }
 
-impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
+impl<T: Data + 'static, W: Widget<T>> Widget<T> for Scroll<T, W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         let size = ctx.size();
         let viewport = Rect::from_origin_size(Point::ORIGIN, size);
@@ -424,5 +424,9 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         if let Err(e) = paint_ctx.restore() {
             error!("restoring render context failed: {:?}", e);
         }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -74,7 +74,7 @@ impl<T: Data> SizedBox<T> {
     }
 }
 
-impl<T: Data> Widget<T> for SizedBox<T> {
+impl<T: Data + 'static> Widget<T> for SizedBox<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.event(ctx, event, data, env);
@@ -123,5 +123,9 @@ impl<T: Data> Widget<T> for SizedBox<T> {
         if let Some(ref mut inner) = self.inner {
             inner.paint(paint_ctx, data, env);
         }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -126,6 +126,13 @@ impl<T: Data + 'static> Widget<T> for SizedBox<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
+    }
+
+    fn child(&self) -> Option<&dyn Widget<T>> {
+        match self.inner.as_ref() {
+            Some(inner) => Some(inner),
+            None => None,
+        }
     }
 }

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -36,7 +36,7 @@ pub struct SizedBox<T: Data> {
 
 impl<T: Data> SizedBox<T> {
     /// Construct container with child, and both width and height not set.
-    pub fn new(inner: impl Widget<T> + 'static) -> Self {
+    pub fn new(inner: impl Widget<T>) -> Self {
         Self {
             inner: Some(Box::new(inner)),
             width: None,
@@ -74,7 +74,7 @@ impl<T: Data> SizedBox<T> {
     }
 }
 
-impl<T: Data + 'static> Widget<T> for SizedBox<T> {
+impl<T: Data> Widget<T> for SizedBox<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.event(ctx, event, data, env);

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -186,4 +186,8 @@ impl Widget<f64> for Slider {
         //Actually paint the knob
         paint_ctx.fill(knob_circle, &knob_gradient);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -188,6 +188,6 @@ impl Widget<f64> for Slider {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 ///A container containing two other widgets, splitting the area either horizontally or vertically.
-pub struct Split<T: Data + 'static> {
+pub struct Split<T: Data> {
     split_direction: Axis,
     draggable: bool,
     split_point: f64,
@@ -31,13 +31,9 @@ pub struct Split<T: Data + 'static> {
     child2: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T: Data + 'static> Split<T> {
+impl<T: Data> Split<T> {
     ///Create a new split panel.
-    fn new(
-        split_direction: Axis,
-        child1: impl Widget<T> + 'static,
-        child2: impl Widget<T> + 'static,
-    ) -> Self {
+    fn new(split_direction: Axis, child1: impl Widget<T>, child2: impl Widget<T>) -> Self {
         Split {
             split_direction,
             split_point: 0.5,
@@ -48,11 +44,11 @@ impl<T: Data + 'static> Split<T> {
         }
     }
     /// Create a new split panel, splitting the vertical dimension between two children.
-    pub fn vertical(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
+    pub fn vertical(child1: impl Widget<T>, child2: impl Widget<T>) -> Self {
         Self::new(Axis::Vertical, child1, child2)
     }
     /// Create a new split panel, splitting the horizontal dimension between two children.
-    pub fn horizontal(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
+    pub fn horizontal(child1: impl Widget<T>, child2: impl Widget<T>) -> Self {
         Self::new(Axis::Horizontal, child1, child2)
     }
     /// Set container's split point as a fraction of the split dimension
@@ -123,7 +119,7 @@ impl<T: Data + 'static> Split<T> {
         }
     }
 }
-impl<T: Data + 'static> Widget<T> for Split<T> {
+impl<T: Data> Widget<T> for Split<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.child1.is_active() {
             self.child1.event(ctx, event, data, env);

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -307,6 +307,6 @@ impl<T: Data + 'static> Widget<T> for Split<T> {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 ///A container containing two other widgets, splitting the area either horizontally or vertically.
-pub struct Split<T: Data> {
+pub struct Split<T: Data + 'static> {
     split_direction: Axis,
     draggable: bool,
     split_point: f64,
@@ -31,7 +31,7 @@ pub struct Split<T: Data> {
     child2: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T: Data> Split<T> {
+impl<T: Data + 'static> Split<T> {
     ///Create a new split panel.
     fn new(
         split_direction: Axis,
@@ -123,7 +123,7 @@ impl<T: Data> Split<T> {
         }
     }
 }
-impl<T: Data> Widget<T> for Split<T> {
+impl<T: Data + 'static> Widget<T> for Split<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.child1.is_active() {
             self.child1.event(ctx, event, data, env);
@@ -304,5 +304,9 @@ impl<T: Data> Widget<T> for Split<T> {
 
         self.child1.paint_with_offset(paint_ctx, &data, env);
         self.child2.paint_with_offset(paint_ctx, &data, env);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
     }
 }

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -274,4 +274,8 @@ impl Widget<bool> for Switch {
         // paint on/off label
         self.paint_labels(paint_ctx, env, switch_width);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -276,6 +276,6 @@ impl Widget<bool> for Switch {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -481,7 +481,7 @@ impl Widget<String> for TextBox {
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
-        *&self
+        self
     }
 }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -479,6 +479,10 @@ impl Widget<String> for TextBox {
         // Paint the border
         paint_ctx.stroke(clip_rect, &border_color, BORDER_WIDTH);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        *&self
+    }
 }
 
 /// Gets the next character from the given index.

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -21,7 +21,7 @@ use super::{Align, Container, EnvScope, Padding, Parse, SizedBox};
 use crate::{Data, Env, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
-pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
+pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     fn boxed(self) -> Box<dyn Widget<T>> {
         Box::new(self)
     }
@@ -142,7 +142,7 @@ pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
     }
 }
 
-fn try_get_child_impl<T: Data + 'static, C: 'static>(widget: &dyn Widget<T>) -> Option<&C> {
+fn try_get_child_impl<T: Data, C: 'static>(widget: &dyn Widget<T>) -> Option<&C> {
     let child = Widget::child(widget)?;
     match child.as_any().downcast_ref() {
         Some(concrete) => Some(concrete),
@@ -150,7 +150,7 @@ fn try_get_child_impl<T: Data + 'static, C: 'static>(widget: &dyn Widget<T>) -> 
     }
 }
 
-impl<T: Data, W: Widget<T> + 'static> WidgetExt<T> for W {}
+impl<T: Data, W: Widget<T>> WidgetExt<T> for W {}
 
 // these are 'soft overrides' of methods on WidgetExt; resolution
 // will choose an impl on a type over an impl in a trait for methods with the same

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -21,7 +21,7 @@ use super::{Align, Container, EnvScope, Padding, Parse, SizedBox};
 use crate::{Data, Env, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
-pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
+pub trait WidgetExt<T: Data + 'static>: Widget<T> + Sized + 'static {
     fn boxed(self) -> Box<dyn Widget<T>> {
         Box::new(self)
     }
@@ -134,6 +134,19 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
         Self: Widget<String>,
     {
         Parse::new(self)
+    }
+
+    /// recursively look for a child of a given type.
+    fn try_get_child<C: 'static>(&self) -> Option<&C> {
+        try_get_child_impl(self)
+    }
+}
+
+fn try_get_child_impl<T: Data + 'static, C: 'static>(widget: &dyn Widget<T>) -> Option<&C> {
+    let child = Widget::child(widget)?;
+    match child.as_any().downcast_ref() {
+        Some(concrete) => Some(concrete),
+        None => try_get_child_impl(child),
     }
 }
 

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -22,6 +22,10 @@ use crate::{Data, Env, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
 pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
+    fn boxed(self) -> Box<dyn Widget<T>> {
+        Box::new(self)
+    }
+
     /// Wrap this widget in a [`Padding`] widget with the given [`Insets`].
     ///
     /// [`Padding`]: struct.Padding.html

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -46,7 +46,7 @@ use crate::command::sys as sys_cmd;
 ///
 /// This is something of an internal detail and possibly we don't want to surface
 /// it publicly.
-pub struct DruidHandler<T: Data> {
+pub struct DruidHandler<T: Data + 'static> {
     /// The shared app state.
     app_state: Rc<RefCell<AppState<T>>>,
     /// The id for the current window.
@@ -54,7 +54,7 @@ pub struct DruidHandler<T: Data> {
 }
 
 /// State shared by all windows in the UI.
-pub(crate) struct AppState<T: Data> {
+pub(crate) struct AppState<T: Data + 'static> {
     delegate: Option<Box<dyn AppDelegate<T>>>,
     command_queue: VecDeque<(WindowId, Command)>,
     windows: Windows<T>,
@@ -63,7 +63,7 @@ pub(crate) struct AppState<T: Data> {
 }
 
 /// All active windows.
-struct Windows<T: Data> {
+struct Windows<T: Data + 'static> {
     windows: HashMap<WindowId, Window<T>>,
     state: HashMap<WindowId, WindowState>,
 }
@@ -75,7 +75,7 @@ pub(crate) struct WindowState {
 }
 
 /// Everything required for a window to handle an event.
-struct SingleWindowState<'a, T: Data> {
+struct SingleWindowState<'a, T: Data + 'static> {
     window_id: WindowId,
     window: &'a mut Window<T>,
     state: &'a mut WindowState,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -46,7 +46,7 @@ use crate::command::sys as sys_cmd;
 ///
 /// This is something of an internal detail and possibly we don't want to surface
 /// it publicly.
-pub struct DruidHandler<T: Data + 'static> {
+pub struct DruidHandler<T: Data> {
     /// The shared app state.
     app_state: Rc<RefCell<AppState<T>>>,
     /// The id for the current window.
@@ -54,7 +54,7 @@ pub struct DruidHandler<T: Data + 'static> {
 }
 
 /// State shared by all windows in the UI.
-pub(crate) struct AppState<T: Data + 'static> {
+pub(crate) struct AppState<T: Data> {
     delegate: Option<Box<dyn AppDelegate<T>>>,
     command_queue: VecDeque<(WindowId, Command)>,
     windows: Windows<T>,
@@ -63,7 +63,7 @@ pub(crate) struct AppState<T: Data + 'static> {
 }
 
 /// All active windows.
-struct Windows<T: Data + 'static> {
+struct Windows<T: Data> {
     windows: HashMap<WindowId, Window<T>>,
     state: HashMap<WindowId, WindowState>,
 }
@@ -75,7 +75,7 @@ pub(crate) struct WindowState {
 }
 
 /// Everything required for a window to handle an event.
-struct SingleWindowState<'a, T: Data + 'static> {
+struct SingleWindowState<'a, T: Data> {
     window_id: WindowId,
     window: &'a mut Window<T>,
     state: &'a mut WindowState,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -31,7 +31,7 @@ pub struct WindowId(u32);
 static WINDOW_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
 
 /// Per-window state not owned by user code.
-pub struct Window<T: Data> {
+pub struct Window<T: Data + 'static> {
     pub(crate) root: WidgetPod<T, Box<dyn Widget<T>>>,
     pub(crate) title: LocalizedString<T>,
     size: Size,
@@ -40,9 +40,9 @@ pub struct Window<T: Data> {
     // delegate?
 }
 
-impl<T: Data> Window<T> {
+impl<T: Data + 'static> Window<T> {
     pub fn new(
-        root: impl Widget<T> + 'static,
+        root: impl Widget<T>,
         title: LocalizedString<T>,
         menu: Option<MenuDesc<T>>,
     ) -> Window<T> {

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -31,7 +31,7 @@ pub struct WindowId(u32);
 static WINDOW_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
 
 /// Per-window state not owned by user code.
-pub struct Window<T: Data + 'static> {
+pub struct Window<T: Data> {
     pub(crate) root: WidgetPod<T, Box<dyn Widget<T>>>,
     pub(crate) title: LocalizedString<T>,
     size: Size,
@@ -40,7 +40,7 @@ pub struct Window<T: Data + 'static> {
     // delegate?
 }
 
-impl<T: Data + 'static> Window<T> {
+impl<T: Data> Window<T> {
     pub fn new(
         root: impl Widget<T>,
         title: LocalizedString<T>,


### PR DESCRIPTION
*this is a proof of concept, intended for discussion*

## Summary

This PR demonstrates one possible way to retrieve a particular concrete widget that may be several layers down in the tree, and in particular may be behind one or more `Box<dyn Widget>`s.

The basic idea is to add add two methods to `Widget`, that look like,

```rust
trait Widget {
    // ...
    fn as_any(&self) -> &dyn std::any::Any;
    fn child(&self) -> Option<&dyn Widget<T>> {
        None
    }
}
```

The first of these is, (annoyingly) required; all widgets will have to have an impl, and they will all look like,

```rust
fn as_any(&self) -> &dyn std::any::Any {
        *&self
    }
```

I don't think there is any getting around this; there's no way of having a default impl that doesn't either break object safety or break because the `TypeId` of `dyn Widget<T>` is not the same as the `TypeId` of the concrete type.

The second of these _does_ have a default impl, because not all widgets have a single child, which is the case that we're motivated by, here; widgets that _do_ are required to override this method to return their child.

## Motivation

- At various times I've wanted to be able to reach past multiple `Align`, `Padding`, or `Scroll` widgets to access some property on an inner widget. This might be an anti-pattern! But it has been something I've wanted to do. 😈 

- widget identity: this is what I was initially curious about; whether we could drill down into a stack of widgets and figure out if one of them had an identity. This wouldn't work with exactly this code, but would work similarly.

## ugly

This requires a new `'static` bound on all `Data`. We might be able to get away with this by adding that bound to `Data` itself (maybe by adding a `Same` trait for just the `same()` fn, and making `Data` a marker trait?)

To be properly useful we would also need to have like a `child_mut` fn; this isn't so so bad since we would only expect to need to impl these on library types, but it's still starting to get ugly;

... and it will get even more ugly when we inevitably decide we want to be able to recursively iterate _all children_, and we end up with like `iter_children` and `iter_children_mut`...

## the end

This is mostly interesting to me because it wasn't clear that we could make it work. It's interesting to know that we can. It might be something we will want to look at sometime, but I don't _think_ we'll need to do that now? But I thought it would be worth sharing to see what other folks thought.