### PR TITLE
[WIP] VirtualList and decoupled Scrollbar widgets

### DIFF
--- a/druid/examples/virtual_list.rs
+++ b/druid/examples/virtual_list.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
-use std::sync::Arc;
-
 use druid::widget::{
     Flex, ListData, Padding, ScrollControlState, Scrollbar, VirtualList, WidgetExt,
 };
 use druid::{AppLauncher, Data, Insets, Lens, Widget, WindowDesc};
+use std::cell::RefCell;
+use std::sync::Arc;
 
 #[derive(Clone, Data, Lens, PartialEq, Default)]
 struct VirtualScrollState {

--- a/druid/examples/virtual_list.rs
+++ b/druid/examples/virtual_list.rs
@@ -99,10 +99,10 @@ fn main() {
         .use_simple_logger()
         .launch(VirtualScrollState {
             last_mouse_pos: 0.,
-            page_size: 1.0,
+            page_size: 0.,
             scroll_position: 0.0,
-            max_scroll_position: (1000000. * 30.) - 400.,
-            min_scroll_position: 0.0,
+            max_scroll_position: 0.,
+            min_scroll_position: 0.,
             mouse_wheel_enabled: true,
             tracking_mouse: false,
             scale: 0.
@@ -115,6 +115,6 @@ fn main() {
         }
         Flex::row()
             .with_child(VirtualList::new().data_provider(data), 1.)
-            .with_child(Scrollbar::new().fix_width(20.), 1.)
+            .with_child(Scrollbar::new().fix_width(20.), 0.)
     }
 }

--- a/druid/examples/virtual_list.rs
+++ b/druid/examples/virtual_list.rs
@@ -1,0 +1,120 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use druid::{AppLauncher, Data, Lens, Widget, WindowDesc};
+use druid::widget::{VirtualList, Flex, Scrollbar, WidgetExt, ScrollControlState};
+
+#[derive(Clone, Data, Lens, PartialEq)]
+struct VirtualScrollState {
+    last_mouse_pos: f64,
+    page_size: f64,
+    max_scroll_position: f64,
+    min_scroll_position: f64,
+    mouse_wheel_enabled: bool,
+    scroll_position: f64,
+    tracking_mouse: bool,
+    scale: f64
+}
+
+impl ScrollControlState for VirtualScrollState {
+    fn last_mouse_pos(&self) -> f64 {
+        self.last_mouse_pos
+    }
+
+    fn page_size(&self) -> f64 {
+        self.page_size
+    }
+
+    fn max_scroll_position(&self) -> f64 {
+        self.max_scroll_position
+    }
+
+    fn min_scroll_position(&self) -> f64 {
+        self.min_scroll_position
+    }
+
+    fn mouse_wheel_enabled(&self) -> bool {
+        self.mouse_wheel_enabled
+    }
+
+    fn scale(&self) -> f64 {
+        self.scale
+    }
+
+    fn scroll_position(&self) -> f64 {
+        self.scroll_position
+    }
+
+    fn tracking_mouse(&self) -> bool {
+        self.tracking_mouse
+    }
+
+    fn set_last_mouse_pos(&mut self, val: f64) {
+        self.last_mouse_pos = val;
+    }
+
+    fn set_page_size(&mut self, val: f64) {
+        self.page_size = val;
+    }
+
+    fn set_max_scroll_position(&mut self, val: f64) {
+        self.max_scroll_position = val;
+    }
+
+    fn set_min_scroll_position(&mut self, val: f64) {
+        self.min_scroll_position = val;
+    }
+
+    fn set_mouse_wheel_enabled(&mut self, val: bool) {
+        self.mouse_wheel_enabled = val;
+    }
+
+    fn set_tracking_mouse(&mut self, val: bool) {
+       self.tracking_mouse = val;
+    }
+
+    fn set_scale(&mut self, val:f64) {
+        self.scale = val;
+    }
+
+    fn set_scroll_position(&mut self, val: f64) {
+        self.scroll_position = val;
+    }
+}
+
+fn main() {
+    let window = WindowDesc::new(build_widget);
+    AppLauncher::with_window(window)
+        .use_simple_logger()
+        .launch(VirtualScrollState {
+            last_mouse_pos: 0.,
+            page_size: 1.0,
+            scroll_position: 0.0,
+            max_scroll_position: (1000000. * 30.) - 400.,
+            min_scroll_position: 0.0,
+            mouse_wheel_enabled: true,
+            tracking_mouse: false,
+            scale: 0.
+        }).expect("launch failed");
+
+    fn build_widget() -> impl Widget<VirtualScrollState> {
+        let mut data = Vec::new();
+        for i in 0..1000000 {
+            data.push(format!("List Item {}", i));
+        }
+        Flex::row()
+            .with_child(VirtualList::new().data_provider(data), 1.)
+            .with_child(Scrollbar::new().fix_width(20.), 1.)
+    }
+}

--- a/druid/examples/virtual_list.rs
+++ b/druid/examples/virtual_list.rs
@@ -17,6 +17,7 @@ use druid::widget::{VirtualList, Flex, Scrollbar, WidgetExt, ScrollControlState}
 
 #[derive(Clone, Data, Lens, PartialEq)]
 struct VirtualScrollState {
+    id: u64,
     last_mouse_pos: f64,
     page_size: f64,
     max_scroll_position: f64,
@@ -30,6 +31,10 @@ struct VirtualScrollState {
 impl ScrollControlState for VirtualScrollState {
     fn last_mouse_pos(&self) -> f64 {
         self.last_mouse_pos
+    }
+
+    fn id(&self) -> u64 {
+        self.id
     }
 
     fn page_size(&self) -> f64 {
@@ -98,6 +103,7 @@ fn main() {
     AppLauncher::with_window(window)
         .use_simple_logger()
         .launch(VirtualScrollState {
+            id: 1,
             last_mouse_pos: 0.,
             page_size: 0.,
             scroll_position: 0.0,
@@ -115,6 +121,6 @@ fn main() {
         }
         Flex::row()
             .with_child(VirtualList::new().data_provider(data), 1.)
-            .with_child(Scrollbar::new().fix_width(20.), 0.)
+            .with_child(Scrollbar::default().fix_width(20.), 0.)
     }
 }

--- a/druid/examples/virtual_list.rs
+++ b/druid/examples/virtual_list.rs
@@ -117,7 +117,7 @@ fn main() {
 
     fn build_widget() -> impl Widget<VirtualScrollState> {
         let mut data = Vec::new();
-        for i in 0..1000000 {
+        for i in 0..1000 {
             data.push(format!("List Item {}", i));
         }
         Flex::row()

--- a/druid/examples/virtual_list.rs
+++ b/druid/examples/virtual_list.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use druid::widget::{Flex, ScrollControlState, Scrollbar, VirtualList, WidgetExt};
 use druid::{AppLauncher, Data, Lens, Widget, WindowDesc};
-use druid::widget::{VirtualList, Flex, Scrollbar, WidgetExt, ScrollControlState};
 
 #[derive(Clone, Data, Lens, PartialEq)]
 struct VirtualScrollState {
@@ -112,7 +112,8 @@ fn main() {
             mouse_wheel_enabled: true,
             tracking_mouse: false,
             scale: 0.,
-        }).expect("launch failed");
+        })
+        .expect("launch failed");
 
     fn build_widget() -> impl Widget<VirtualScrollState> {
         let mut data = Vec::new();

--- a/druid/examples/virtual_list.rs
+++ b/druid/examples/virtual_list.rs
@@ -25,7 +25,7 @@ struct VirtualScrollState {
     mouse_wheel_enabled: bool,
     scroll_position: f64,
     tracking_mouse: bool,
-    scale: f64
+    scale: f64,
 }
 
 impl ScrollControlState for VirtualScrollState {
@@ -86,10 +86,10 @@ impl ScrollControlState for VirtualScrollState {
     }
 
     fn set_tracking_mouse(&mut self, val: bool) {
-       self.tracking_mouse = val;
+        self.tracking_mouse = val;
     }
 
-    fn set_scale(&mut self, val:f64) {
+    fn set_scale(&mut self, val: f64) {
         self.scale = val;
     }
 
@@ -111,7 +111,7 @@ fn main() {
             min_scroll_position: 0.,
             mouse_wheel_enabled: true,
             tracking_mouse: false,
-            scale: 0.
+            scale: 0.,
         }).expect("launch failed");
 
     fn build_widget() -> impl Widget<VirtualScrollState> {

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -21,7 +21,7 @@ use crate::{WidgetId, WindowId};
 
 /// An identifier for a particular command.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Selector(&'static str);
+pub struct Selector(pub &'static str);
 
 /// An arbitrary command.
 ///

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -275,7 +275,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let child_event = match event {
             Event::LifeCycle(event) => Event::LifeCycle(*event),
             Event::Size(size) => {
-                recurse = ctx.is_root;
                 Event::Size(*size)
             }
             Event::MouseDown(mouse_event) => {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -266,7 +266,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             base_state: &mut self.state,
             had_active,
             is_handled: false,
-            is_root: false,
         };
         let rect = child_ctx.base_state.layout_rect;
         // Note: could also represent this as `Option<Event>`.
@@ -563,7 +562,6 @@ pub struct EventCtx<'a, 'b> {
     pub(crate) base_state: &'a mut BaseState,
     pub(crate) had_active: bool,
     pub(crate) is_handled: bool,
-    pub(crate) is_root: bool,
     pub(crate) widget_id: WidgetId,
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -273,9 +273,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut hot_changed = None;
         let child_event = match event {
             Event::LifeCycle(event) => Event::LifeCycle(*event),
-            Event::Size(size) => {
-                Event::Size(*size)
-            }
+            Event::Size(size) => Event::Size(*size),
             Event::MouseDown(mouse_event) => {
                 let had_hot = child_ctx.base_state.is_hot;
                 let now_hot = rect.winding(mouse_event.pos) != 0;

--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use crate::kurbo;
 
 pub use druid_derive::Data;
+use std::cell::RefCell;
 
 /// A trait used to represent value types.
 ///
@@ -146,6 +147,12 @@ impl Data for f64 {
 impl<T: ?Sized + 'static> Data for Arc<T> {
     fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(self, other)
+    }
+}
+
+impl<T: ?Sized + Clone + 'static> Data for RefCell<T> {
+    fn same(&self, other: &Self) -> bool {
+        self.as_ptr() == other.as_ptr()
     }
 }
 

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -50,6 +50,8 @@ pub const SCROLL_BAR_PAD: Key<f64> = Key::new("scroll_bar_pad");
 pub const SCROLL_BAR_RADIUS: Key<f64> = Key::new("scroll_bar_radius");
 pub const SCROLL_BAR_EDGE_WIDTH: Key<f64> = Key::new("scroll_bar_edge_width");
 
+pub const DEFAULT_ANIMATION_DURATION: Key<u64> = Key::new("default_animation_duration");
+
 /// An initial theme.
 pub fn init() -> Env {
     let mut env = Env::default()
@@ -78,7 +80,8 @@ pub fn init() -> Env {
         .adding(SCROLL_BAR_WIDTH, 8.)
         .adding(SCROLL_BAR_PAD, 2.)
         .adding(SCROLL_BAR_RADIUS, 5.)
-        .adding(SCROLL_BAR_EDGE_WIDTH, 1.);
+        .adding(SCROLL_BAR_EDGE_WIDTH, 1.)
+        .adding(DEFAULT_ANIMATION_DURATION, 250_000_000u64);
 
     #[cfg(target_os = "windows")]
     {

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -32,7 +32,6 @@ mod scroll;
 mod scrollbar;
 mod sized_box;
 mod slider;
-//mod smooth_scroll;
 mod split;
 mod stepper;
 #[cfg(feature = "svg")]
@@ -49,7 +48,7 @@ pub use checkbox::Checkbox;
 pub use container::Container;
 pub use either::Either;
 pub use env_scope::EnvScope;
-pub use flex::{Column, Flex, Row};
+pub use flex::{Axis, Column, Flex, Row};
 pub use identity_wrapper::IdentityWrapper;
 pub use label::{Label, LabelText};
 pub use list::{List, ListIter};

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -68,7 +68,7 @@ pub use stepper::Stepper;
 pub use svg::{Svg, SvgData};
 pub use switch::Switch;
 pub use textbox::TextBox;
-pub use virtual_list::VirtualList;
+pub use virtual_list::{ListData, VirtualList};
 pub use widget_ext::WidgetExt;
 
 use std::ops::{Deref, DerefMut};

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -29,8 +29,10 @@ mod parse;
 mod progress_bar;
 mod radio;
 mod scroll;
+mod scrollbar;
 mod sized_box;
 mod slider;
+//mod smooth_scroll;
 mod split;
 mod stepper;
 #[cfg(feature = "svg")]
@@ -38,6 +40,7 @@ mod stepper;
 mod svg;
 mod switch;
 mod textbox;
+mod virtual_list;
 mod widget_ext;
 
 pub use align::Align;
@@ -55,6 +58,7 @@ pub use parse::Parse;
 pub use progress_bar::ProgressBar;
 pub use radio::{Radio, RadioGroup};
 pub use scroll::Scroll;
+pub use scrollbar::{Scrollbar, ScrollControlState};
 pub use sized_box::SizedBox;
 pub use slider::Slider;
 pub use split::Split;
@@ -64,6 +68,7 @@ pub use stepper::Stepper;
 pub use svg::{Svg, SvgData};
 pub use switch::Switch;
 pub use textbox::TextBox;
+pub use virtual_list::{VirtualList};
 pub use widget_ext::WidgetExt;
 
 use std::ops::{Deref, DerefMut};

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -58,7 +58,7 @@ pub use parse::Parse;
 pub use progress_bar::ProgressBar;
 pub use radio::{Radio, RadioGroup};
 pub use scroll::Scroll;
-pub use scrollbar::{Scrollbar, ScrollControlState};
+pub use scrollbar::{ScrollControlState, Scrollbar};
 pub use sized_box::SizedBox;
 pub use slider::Slider;
 pub use split::Split;
@@ -68,7 +68,7 @@ pub use stepper::Stepper;
 pub use svg::{Svg, SvgData};
 pub use switch::Switch;
 pub use textbox::TextBox;
-pub use virtual_list::{VirtualList};
+pub use virtual_list::VirtualList;
 pub use widget_ext::WidgetExt;
 
 use std::ops::{Deref, DerefMut};

--- a/druid/src/widget/scrollbar.rs
+++ b/druid/src/widget/scrollbar.rs
@@ -1,8 +1,11 @@
 use std::mem;
 
-use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext, Selector, UpdateCtx, Widget};
 use crate::kurbo::{Rect, RoundedRect, Size};
 use crate::theme;
+use crate::{
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext, Selector,
+    UpdateCtx, Widget,
+};
 
 /// Trait used for shared state between
 /// the scrollbar and the scroll container.
@@ -46,9 +49,10 @@ pub trait ScrollControlState: Data + PartialEq {
     fn set_scroll_pos_from_delta(&mut self, delta: f64) {
         let scroll_position = self.scroll_position() + delta;
 
-        self.set_scroll_position(self.min_scroll_position()
-            .max(scroll_position
-                .min(self.max_scroll_position())));
+        self.set_scroll_position(
+            self.min_scroll_position()
+                .max(scroll_position.min(self.max_scroll_position())),
+        );
     }
 }
 
@@ -147,7 +151,8 @@ impl Scrollbar {
         let page_size = data.page_size();
 
         let extent = size.height.max(size.width);
-        let target_thumb_size = (page_size / (max_scroll_position - min_scroll_position + page_size)) * extent;
+        let target_thumb_size =
+            (page_size / (max_scroll_position - min_scroll_position + page_size)) * extent;
         target_thumb_size.max(bar_width * 2.)
     }
 
@@ -162,10 +167,20 @@ impl Scrollbar {
 
         if size.width > size.height {
             // Horizontal
-            Rect::new(scaled_scroll_position, 0., scaled_scroll_position + thumb_size, bar_width * 2.)
+            Rect::new(
+                scaled_scroll_position,
+                0.,
+                scaled_scroll_position + thumb_size,
+                bar_width * 2.,
+            )
         } else {
             // Vertical
-            Rect::new(0., scaled_scroll_position, bar_width, scaled_scroll_position + thumb_size)
+            Rect::new(
+                0.,
+                scaled_scroll_position,
+                bar_width,
+                scaled_scroll_position + thumb_size,
+            )
         }
     }
 
@@ -210,8 +225,7 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
         match event {
             Event::Command(command) => {
                 let Selector(id) = command.selector;
-                if id == "scroll"
-                    && *command.get_object().unwrap_or(&0) == data.id() {
+                if id == "scroll" && *command.get_object().unwrap_or(&0) == data.id() {
                     self.show();
                     event_ctx.request_anim_frame();
                 }
@@ -242,7 +256,11 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
                 if !data.mouse_wheel_enabled() {
                     return;
                 }
-                let delta = if size.width > size.height { event.delta.x } else { event.delta.y };
+                let delta = if size.width > size.height {
+                    event.delta.x
+                } else {
+                    event.delta.y
+                };
                 self.show();
                 data.set_scroll_pos_from_delta(delta);
                 event_ctx.invalidate();
@@ -253,7 +271,11 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
                 if !data.tracking_mouse() {
                     return;
                 }
-                let pos = if size.width > size.height { event.pos.x } else { event.pos.y };
+                let pos = if size.width > size.height {
+                    event.pos.x
+                } else {
+                    event.pos.y
+                };
                 let delta = pos - data.last_mouse_pos();
 
                 data.set_scroll_pos_from_delta(delta / data.scale());
@@ -272,7 +294,8 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
                 // to translate scrollbar distance to scroll container distance
                 let distance = size.width.max(size.height);
                 let thumb_size = Scrollbar::calculated_thumb_size(data, env, &size);
-                let scale = (distance - thumb_size) / (data.max_scroll_position() - data.min_scroll_position());
+                let scale = (distance - thumb_size)
+                    / (data.max_scroll_position() - data.min_scroll_position());
                 data.set_scale(scale);
 
                 // Determine if we're over the thumb.
@@ -281,7 +304,11 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
                 let hit_test_rect = Scrollbar::calculated_thumb_rect(data, env, &size);
                 if hit_test_rect.contains(event.pos) {
                     data.set_tracking_mouse(true);
-                    data.set_last_mouse_pos(if size.width > size.height { event.pos.x } else { event.pos.y });
+                    data.set_last_mouse_pos(if size.width > size.height {
+                        event.pos.x
+                    } else {
+                        event.pos.y
+                    });
                 } else {
                     let center = hit_test_rect.center();
                     let delta = if center.x > event.pos.x || center.y > event.pos.y {
@@ -299,7 +326,7 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
                 data.set_last_mouse_pos(0.);
             }
 
-            _ => ()
+            _ => (),
         }
     }
 
@@ -307,7 +334,8 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
         if let Some(old) = old_data {
             if old.max_scroll_position() - data.max_scroll_position() != 0.
                 || old.min_scroll_position() - data.min_scroll_position() != 0.
-                || old.scroll_position() - data.scroll_position() != 0. {
+                || old.scroll_position() - data.scroll_position() != 0.
+            {
                 ctx.invalidate();
             }
         }
@@ -321,10 +349,9 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
         if data.max_scroll_position() < 0. {
             return;
         }
-        let brush = paint_ctx.render_ctx.solid_brush(
-            env.get(theme::SCROLL_BAR_COLOR)
-                .with_alpha(self.opacity),
-        );
+        let brush = paint_ctx
+            .render_ctx
+            .solid_brush(env.get(theme::SCROLL_BAR_COLOR).with_alpha(self.opacity));
         let border_brush = paint_ctx.render_ctx.solid_brush(
             env.get(theme::SCROLL_BAR_BORDER_COLOR)
                 .with_alpha(self.opacity),
@@ -345,16 +372,4 @@ pub enum ScrollPolicy {
     On,
     Off,
     Auto,
-}
-
-#[cfg(test)]
-mod scrollbar_tests {
-    use crate::widget::scrollbar::AnimationState;
-
-    #[test]
-    fn animation_state_test() {
-        let mut state = AnimationState::default();
-        let val = state.tick(1);
-        assert_eq!(val, 23.);
-    }
 }

--- a/druid/src/widget/scrollbar.rs
+++ b/druid/src/widget/scrollbar.rs
@@ -104,7 +104,7 @@ impl AnimationState {
             let total_time = self.duration + self.delay;
             self.elapsed_time = total_time * (1 - (self.elapsed_time / total_time));
         }
-        self.done = self.to == self.current_value;
+        self.done = self.to.same(&self.current_value);
     }
 }
 
@@ -171,10 +171,10 @@ impl Scrollbar {
 
     fn show(&mut self) {
         // Animation is already fading in
-        if self.animation_state.to == 1. {
+        if self.animation_state.to.same(&1.) {
             return;
         }
-        if self.animation_state.to == 0. {
+        if self.animation_state.to.same(&0.) {
             self.animation_state.reverse();
         }
         self.animation_state.delay = 0;
@@ -182,11 +182,11 @@ impl Scrollbar {
 
     fn hide(&mut self, env: &Env) {
         // Animation is already fading out
-        if self.animation_state.to == 0. {
+        if self.animation_state.to.same(&0.) {
             return;
         }
 
-        if self.animation_state.to == 1. {
+        if self.animation_state.to.same(&1.) {
             self.animation_state.reverse();
         }
         self.animation_state.delay = env.get(theme::SCROLL_BAR_FADE_DELAY) * 1_000_000;
@@ -219,7 +219,7 @@ impl<T: ScrollControlState> Widget<T> for Scrollbar {
 
             Event::HotChanged(is_hot) => {
                 self.is_hot = *is_hot;
-                if self.is_hot  {
+                if self.is_hot {
                     self.show();
                 } else {
                     self.hide(env);

--- a/druid/src/widget/scrollbar.rs
+++ b/druid/src/widget/scrollbar.rs
@@ -1,0 +1,173 @@
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext, UpdateCtx, Widget};
+use crate::kurbo::{Rect, RoundedRect, Size};
+use crate::theme;
+
+/// Trait used for shared state between
+/// the scrollbar and the scroll container.
+pub trait ScrollControlState: Data + PartialEq {
+    /// The last position reported by a MouseMove event.
+    /// used to calculate the deltas without maintaining
+    /// an offset.
+    fn last_mouse_pos(&self) -> f64;
+    /// The size of a page. Used to calculate
+    /// scroll distances when clicking on the
+    /// scroll track
+    fn page_size(&self) -> f64;
+    /// The maximum distance in pixels to scroll
+    fn max_scroll_position(&self) -> f64;
+    /// The minimum distance in pixels to scroll
+    fn min_scroll_position(&self) -> f64;
+    /// boolean for enabling/disabling the mouse
+    fn mouse_wheel_enabled(&self) -> bool;
+    /// scrollbar travel distance / scroll container travel distance
+    fn scale(&self) -> f64;
+    /// The current scroll position. This value
+    /// is always between min and max scroll positions
+    fn scroll_position(&self) -> f64;
+    /// true when tracking mouse move events
+    fn tracking_mouse(&self) -> bool;
+
+    fn set_last_mouse_pos(&mut self, val: f64);
+    fn set_page_size(&mut self, val: f64);
+    fn set_max_scroll_position(&mut self, val: f64);
+    fn set_min_scroll_position(&mut self, val: f64);
+    fn set_mouse_wheel_enabled(&mut self, val: bool);
+    fn set_tracking_mouse(&mut self, val: bool);
+    fn set_scale(&mut self, val: f64);
+    /// Sets the raw value for the scroll position
+    /// without respecting min and max. Use this
+    /// for pull or bounce calculations on the container
+    fn set_scroll_position(&mut self, val: f64);
+
+    fn set_scroll_pos_from_delta(&mut self, delta: f64) {
+        let scroll_position = self.scroll_position() + delta;
+        let min_scroll_position = self.min_scroll_position();
+        let max_scroll_position = self.max_scroll_position();
+
+        self.set_scroll_position(min_scroll_position.max(scroll_position.min(max_scroll_position)));
+    }
+}
+
+pub struct Scrollbar {
+    opacity: f64,
+}
+
+impl Scrollbar {
+    pub fn new() -> Scrollbar {
+        Scrollbar {
+            opacity: 1.,
+        }
+    }
+
+    fn calculated_thumb_size(data: &impl ScrollControlState, env: &Env, size: &Size) -> f64 {
+        let bar_width = env.get(theme::SCROLL_BAR_WIDTH);
+        let min_scroll_position = data.min_scroll_position();
+        let max_scroll_position = data.max_scroll_position();
+        let page_size = data.page_size();
+
+        let extent = size.height.max(size.width);
+        (page_size / (max_scroll_position - min_scroll_position + page_size) * extent).max(bar_width * 2.)
+    }
+}
+
+impl<T: ScrollControlState> Widget<T> for Scrollbar {
+    fn event(&mut self, event_ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        let size = event_ctx.size();
+        match event {
+            Event::Wheel(event) => {
+                if !data.mouse_wheel_enabled() {
+                    return;
+                }
+                let delta = if size.width > size.height { event.delta.x } else { event.delta.y };
+                data.set_scroll_pos_from_delta(delta);
+                event_ctx.invalidate();
+            },
+
+            Event::MouseMoved(event) => {
+                if !data.tracking_mouse() {
+                    return;
+                }
+                let pos = if size.width > size.height { event.pos.x } else { event.pos.y };
+                let delta = pos - data.last_mouse_pos();
+
+                data.set_scroll_pos_from_delta(delta / data.scale());
+                data.set_last_mouse_pos(pos);
+                event_ctx.invalidate();
+            }
+
+            Event::MouseDown(event) => {
+                data.set_tracking_mouse(true);
+                data.set_last_mouse_pos(if size.width > size.height { event.pos.x } else { event.pos.y });
+                // Set our scale since we could be dragging later
+                // The thumb size is subtracted from the total
+                // scrollable distance and a scale is calculated
+                // to translate scrollbar distance to scroll container distance
+                let distance = size.width.max(size.height);
+                let thumb_size = Scrollbar::calculated_thumb_size(data, env, &size);
+                data.set_scale((distance - thumb_size) / (data.max_scroll_position() - data.min_scroll_position()));
+            },
+
+            Event::MouseUp(_) => {
+                data.set_tracking_mouse(false);
+                data.set_last_mouse_pos(0.);
+            },
+
+            _ => ()
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+        if let Some(old) = old_data {
+            if old.max_scroll_position() != data.max_scroll_position()
+                || old.min_scroll_position() != data.min_scroll_position()
+                || old.scroll_position() != data.scroll_position() {
+                ctx.invalidate();
+            }
+        }
+    }
+
+    fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, _env: &Env) -> Size {
+        bc.constrain(bc.max())
+    }
+
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
+        let brush = paint_ctx.render_ctx.solid_brush(
+            env.get(theme::SCROLL_BAR_COLOR)
+                .with_alpha(self.opacity),
+        );
+        let border_brush = paint_ctx.render_ctx.solid_brush(
+            env.get(theme::SCROLL_BAR_BORDER_COLOR)
+                .with_alpha(self.opacity),
+        );
+
+        let radius = env.get(theme::SCROLL_BAR_RADIUS);
+        let edge_width = env.get(theme::SCROLL_BAR_EDGE_WIDTH);
+        let bar_width = env.get(theme::SCROLL_BAR_WIDTH);
+
+        let size = paint_ctx.size();
+        let min_scroll_position = data.min_scroll_position();
+        let max_scroll_position = data.max_scroll_position();
+
+        let extent = size.height.max(size.width);
+        let thumb_size = Scrollbar::calculated_thumb_size(data, env, &size);
+        let scale = (extent - thumb_size) / (max_scroll_position - min_scroll_position);
+        let scaled_scroll_position = data.scroll_position() * scale;
+
+        let bounds = if size.width > size.height {
+            // Horizontal
+            Rect::new(scaled_scroll_position, 0., scaled_scroll_position + thumb_size, bar_width * 2.)
+        } else {
+            // Vertical
+            Rect::new(0., scaled_scroll_position, bar_width, scaled_scroll_position + thumb_size)
+        };
+        let rect = RoundedRect::from_rect(bounds, radius);
+        paint_ctx.render_ctx.fill(rect, &brush);
+        paint_ctx.render_ctx.stroke(rect, &border_brush, edge_width);
+    }
+}
+
+pub enum ScrollPolicy {
+    On,
+    Off,
+    Auto,
+}

--- a/druid/src/widget/scrollbar.rs
+++ b/druid/src/widget/scrollbar.rs
@@ -223,6 +223,12 @@ impl<S: ScrollControlState> Scrollbar<S> {
     }
 }
 
+impl<S: ScrollControlState> Default for Scrollbar<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<S: ScrollControlState> Widget<RefCell<S>> for Scrollbar<S> {
     fn event(&mut self, event_ctx: &mut EventCtx, event: &Event, data: &mut RefCell<S>, env: &Env) {
         if self.scroll_policy == ScrollPolicy::Off {

--- a/druid/src/widget/scrollbar.rs
+++ b/druid/src/widget/scrollbar.rs
@@ -186,7 +186,7 @@ impl<S: ScrollControlState> Scrollbar<S> {
                 scaled_scroll_position,
                 0.,
                 scaled_scroll_position + thumb_size,
-                bar_width * 2.,
+                bar_width,
             )
         } else {
             // Vertical

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -60,9 +60,11 @@ where
             renderer_function: |_data: &T,
                                 freed_widget: Option<BoxedWidget<T>>|
              -> BoxedWidget<T> {
-                freed_widget.unwrap_or(WidgetPod::new(Box::new(
-                    Label::new(|d: &T, _env: &Env| d.to_string()).fix_height(30.),
-                )))
+                freed_widget.unwrap_or_else(|| {
+                    WidgetPod::new(Box::new(
+                        Label::new(|d: &T, _env: &Env| d.to_string()).fix_height(30.),
+                    ))
+                })
             },
             renderer_size: 30.,
             set_scroll_metrics_later: false,

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -3,9 +3,12 @@ use std::ops::Range;
 
 use log::error;
 
-use crate::{BoxConstraints, BoxedWidget, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point, Rect, RenderContext, Size, UpdateCtx, Widget, WidgetPod, Selector, Command};
-use crate::widget::{Label, ScrollControlState, WidgetExt};
 use crate::widget::flex::Axis;
+use crate::widget::{Label, ScrollControlState, WidgetExt};
+use crate::{
+    BoxConstraints, BoxedWidget, Command, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
+    Rect, RenderContext, Selector, Size, UpdateCtx, Widget, WidgetPod,
+};
 
 pub struct VirtualList<T: Data + ToString, S: ScrollControlState> {
     children: Vec<BoxedWidget<T>>,
@@ -35,7 +38,9 @@ impl<T: Data + ToString + 'static, S: ScrollControlState> VirtualList<T, S> {
             data_provider: Vec::new(),
             direction: Axis::Vertical,
             scroll_delta: 0.,
-            renderer_function: |data: &T| -> Box<dyn Widget<T>> { Box::new(Label::new(data.to_string()).fix_height(30.)) },
+            renderer_function: |data: &T| -> Box<dyn Widget<T>> {
+                Box::new(Label::new(data.to_string()).fix_height(30.))
+            },
             renderer_size: 30.,
             set_scroll_metrics_later: false,
             phantom_data: Default::default(),
@@ -79,13 +84,15 @@ impl<T: Data + ToString + 'static, S: ScrollControlState> VirtualList<T, S> {
         // Recalculate the max_scroll_position
         let page_size = match self.direction {
             Axis::Vertical => event_ctx.size().height,
-            Axis::Horizontal => event_ctx.size().width
+            Axis::Horizontal => event_ctx.size().width,
         };
         if page_size == 0. {
             self.set_scroll_metrics_later = true;
             event_ctx.request_anim_frame()
         }
-        data.set_max_scroll_position((self.data_provider.len() as f64 * self.renderer_size) - page_size);
+        data.set_max_scroll_position(
+            (self.data_provider.len() as f64 * self.renderer_size) - page_size,
+        );
         data.set_page_size(page_size);
         event_ctx.invalidate();
     }
@@ -147,7 +154,9 @@ impl<T: Data + ToString + 'static, S: ScrollControlState> Default for VirtualLis
             data_provider: Vec::new(),
             direction: Axis::Vertical,
             scroll_delta: 0.,
-            renderer_function: |data: &T| -> Box<dyn Widget<T>> { Box::new(Label::new(data.to_string()).fix_height(30.)) },
+            renderer_function: |data: &T| -> Box<dyn Widget<T>> {
+                Box::new(Label::new(data.to_string()).fix_height(30.))
+            },
             renderer_size: 0.,
             set_scroll_metrics_later: false,
             phantom_data: PhantomData,
@@ -155,7 +164,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState> Default for VirtualLis
     }
 }
 
-impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for VirtualList<T, S> {
+impl<T: Data + ToString + 'static, S: ScrollControlState> Widget<S> for VirtualList<T, S> {
     fn event(&mut self, event_ctx: &mut EventCtx, event: &Event, data: &mut S, _env: &Env) {
         match event {
             Event::Wheel(event) => {
@@ -164,7 +173,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
                 }
                 let delta = match self.direction {
                     Axis::Vertical => event.delta.y,
-                    Axis::Horizontal => event.delta.x
+                    Axis::Horizontal => event.delta.x,
                 };
                 data.set_scroll_pos_from_delta(delta);
                 event_ctx.invalidate();
@@ -180,7 +189,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
                 }
                 let pos = match self.direction {
                     Axis::Vertical => event.pos.y,
-                    Axis::Horizontal => event.pos.x
+                    Axis::Horizontal => event.pos.x,
                 };
 
                 let delta = pos - data.last_mouse_pos();
@@ -205,7 +214,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
                 }
             }
 
-            _ => ()
+            _ => (),
         }
     }
 
@@ -221,10 +230,16 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
         }
     }
 
-    fn layout(&mut self, layout_ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &S, env: &Env) -> Size {
+    fn layout(
+        &mut self,
+        layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &S,
+        env: &Env,
+    ) -> Size {
         let bounds = match self.direction {
             Axis::Vertical => bc.max().height,
-            Axis::Horizontal => bc.max().width
+            Axis::Horizontal => bc.max().width,
         };
         let (mut min, mut max) = self.translate(self.scroll_delta, bounds);
         // We've translated more than the viewport distance
@@ -318,12 +333,6 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
 fn get_scroll_metrics(direction: &Axis, rect: &Rect) -> (f64, f64) {
     match direction {
         Axis::Vertical => (rect.y0, rect.y1),
-        Axis::Horizontal => (rect.x0, rect.x1)
-    }
-}
-
-impl<T: Data> Data for Vec<T> {
-    fn same(&self, other: &Self) -> bool {
-        self.len() == other.len()
+        Axis::Horizontal => (rect.x0, rect.x1),
     }
 }

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use log::error;
 
-use crate::{BoxConstraints, BoxedWidget, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point, Rect, RenderContext, Size, UpdateCtx, Widget, WidgetPod};
+use crate::{BoxConstraints, BoxedWidget, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point, Rect, RenderContext, Size, UpdateCtx, Widget, WidgetPod, Selector, Command};
 use crate::widget::{Label, ScrollControlState, WidgetExt};
 use crate::widget::flex::Axis;
 
@@ -168,6 +168,10 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
                 };
                 data.set_scroll_pos_from_delta(delta);
                 event_ctx.invalidate();
+
+                let selector = Selector::new("scroll");
+                let command = Command::new(selector, data.id());
+                event_ctx.submit_command(command, None)
             }
 
             Event::MouseMoved(event) => {
@@ -209,8 +213,9 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
         if let Some(old_data) = old_data {
             let old_scroll_position = old_data.scroll_position();
             let new_scroll_position = data.scroll_position();
-            if old_scroll_position != new_scroll_position {
-                self.scroll_delta += new_scroll_position - old_scroll_position;
+            let delta = new_scroll_position - old_scroll_position;
+            if delta != 0. {
+                self.scroll_delta += delta;
                 update_ctx.invalidate();
             }
         }

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -138,6 +138,23 @@ impl<T: Data + ToString + 'static, S: ScrollControlState> VirtualList<T, S> {
     }
 }
 
+impl<T: Data + ToString +  'static, S: ScrollControlState> Default for VirtualList<T, S> {
+    fn default() -> Self {
+        VirtualList {
+            children: Vec::new(),
+            content_metrics: Default::default(),
+            data_range: 0..0,
+            data_provider: Vec::new(),
+            direction: Axis::Vertical,
+            scroll_delta: 0.,
+            renderer_function: |data: &T| -> Box<dyn Widget<T>> { Box::new(Label::new(data.to_string()).fix_height(30.)) },
+            renderer_size: 0.,
+            set_scroll_metrics_later: false,
+            phantom_data: PhantomData
+        }
+    }
+}
+
 impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for VirtualList<T, S> {
     fn event(&mut self, event_ctx: &mut EventCtx, event: &Event, data: &mut S, _env: &Env) {
         match event {
@@ -219,7 +236,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
         while self.data_range.start != 0 && min > 0. {
             if let Some(data) = self.data_provider.get(self.data_range.start - 1) {
                 let mut widget = WidgetPod::new((self.renderer_function)(data));
-                let child_bc = BoxConstraints::new(Size::ZERO, bc.max().clone());
+                let child_bc = BoxConstraints::new(Size::ZERO, bc.max());
                 let child_size = widget.layout(layout_ctx, &child_bc, data, env);
 
                 let mut offset = Point::new(0., 0.);
@@ -247,7 +264,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
         while max < bounds {
             if let Some(data) = self.data_provider.get(self.data_range.end) {
                 let mut widget = WidgetPod::new((self.renderer_function)(data));
-                let child_bc = BoxConstraints::new(Size::ZERO, bc.max().clone());
+                let child_bc = BoxConstraints::new(Size::ZERO, bc.max());
                 let child_size = widget.layout(layout_ctx, &child_bc, data, env);
                 let mut offset = Point::new(0., 0.);
                 max += match self.direction {

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -1,0 +1,269 @@
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, Size, UpdateCtx, Widget, WidgetPod, BoxedWidget, Rect, Point};
+use crate::widget::{Label, WidgetExt, ScrollControlState};
+use crate::widget::flex::Axis;
+use std::ops::Range;
+use std::marker::PhantomData;
+
+pub struct VirtualList<T: Data + ToString, S: ScrollControlState> {
+    children: Vec<BoxedWidget<T>>,
+    // The rect representing the area occupied by
+    // all visible widgets. This will always be
+    // equal to or larger than the BoxConstraints
+    // when virtualized.
+    content_metrics: Rect,
+    data_range: Range<usize>,
+    data_provider: Vec<T>,
+    direction: Axis,
+    scroll_delta: f64,
+    // Always represents the topmost/rightmost position depending on the direction
+    renderer_function: fn(data: &T) -> Box<dyn Widget<T>>,
+    renderer_size: f64,
+    phantom_data: PhantomData<S>,
+}
+
+impl<T: Data + ToString + 'static, S: ScrollControlState> VirtualList<T, S> {
+    pub fn new() -> VirtualList<T, S> {
+        VirtualList {
+            children: Vec::new(),
+            content_metrics: Rect::new(0., 0., 0., 0.),
+            data_range: 0..0,
+            data_provider: Vec::new(),
+            direction: Axis::Vertical,
+            scroll_delta: 0.,
+            renderer_function: |data: &T| -> Box<dyn Widget<T>> { Box::new(Label::new(data.to_string()).fix_height(30.)) },
+            renderer_size: 30.,
+            phantom_data: Default::default(),
+        }
+    }
+
+    pub fn renderer_function(mut self, val: fn(data: &T) -> Box<dyn Widget<T>>) -> Self {
+        self.renderer_function = val;
+        self
+    }
+
+    pub fn direction(mut self, val: Axis) -> Self {
+        self.direction = val;
+        self
+    }
+
+    pub fn data_provider(mut self, val: Vec<T>) -> Self {
+        self.data_provider = val;
+        self
+    }
+
+    pub fn renderer_size(mut self, val: f64) -> Self {
+        self.renderer_size = val;
+        self
+    }
+
+    fn set_scroll_metrics(&mut self, value: (f64, f64)) {
+        match self.direction {
+            Axis::Vertical => {
+                self.content_metrics.y0 = value.0;
+                self.content_metrics.y1 = value.1;
+            }
+            Axis::Horizontal => {
+                self.content_metrics.x0 = value.0;
+                self.content_metrics.x1 = value.1;
+            }
+        };
+    }
+
+    /// Translates all children by the specified delta.
+    /// Children outside the 0..limit bounds are truncated
+    fn translate(&mut self, delta: f64, limit: f64) -> (f64, f64) {
+        let (mut min, mut max) = get_scroll_metrics(&self.direction, &self.content_metrics);
+        if delta != 0. {
+            // TODO - replace implementation with Vec::drain_filter once it's stable.
+            let mut to_remove = Vec::new();
+            for (index, child) in &mut self.children.iter_mut().enumerate() {
+                let mut rect = child.get_layout_rect();
+                match self.direction {
+                    Axis::Vertical => {
+                        rect = rect.with_origin(Point::new(0., rect.y0 - delta));
+                    }
+                    Axis::Horizontal => {
+                        rect = rect.with_origin(Point::new(rect.x0 - delta, 0.));
+                    }
+                }
+                let cm = get_scroll_metrics(&self.direction, &rect);
+
+                if cm.1 < 0. {
+                    // Child is less than the viewport's min
+                    to_remove.push(index);
+                    min += cm.1 - cm.0;
+                    self.data_range.start += 1;
+                } else if cm.0 > limit {
+                    // Child is greater than the viewport's max
+                    to_remove.push(index);
+                    max -= cm.1 - cm.0;
+                    self.data_range.end -= 1;
+                } else {
+                    child.set_layout_rect(rect);
+                }
+            }
+            // Truncate children if necessary
+            if !to_remove.is_empty() {
+                to_remove.sort_by(|a, b| b.cmp(a));
+                for index in to_remove {
+                    self.children.remove(index);
+                }
+            }
+            min -= delta;
+            max -= delta;
+        }
+
+        (min, max)
+    }
+}
+
+impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for VirtualList<T, S> {
+    fn event(&mut self, event_ctx: &mut EventCtx, event: &Event, data: &mut S, _env: &Env) {
+        match event {
+            Event::Wheel(event) => {
+                if !data.mouse_wheel_enabled() {
+                    return;
+                }
+                let size = event_ctx.size();
+                let delta = if size.width > size.height { event.delta.x } else { event.delta.y };
+                data.set_scroll_pos_from_delta(delta);
+                event_ctx.invalidate();
+            },
+
+            Event::MouseMoved(event) => {
+                if !data.tracking_mouse() {
+                    return;
+                }
+                let size = event_ctx.size();
+                let pos = if size.width > size.height { event.pos.x } else { event.pos.y };
+                let delta = pos - data.last_mouse_pos();
+
+                data.set_scroll_pos_from_delta(delta / data.scale());
+                data.set_last_mouse_pos(pos);
+                event_ctx.invalidate();
+            },
+
+            Event::MouseUp(_) => {
+                data.set_tracking_mouse(false);
+            },
+
+            Event::Size(_) => {
+                // Recalculate the max_scroll_position
+                let size = match self.direction {
+                    Axis::Vertical => event_ctx.size().height,
+                    Axis::Horizontal => event_ctx.size().width
+                };
+                data.set_max_scroll_position((self.data_provider.len() as f64 * self.renderer_size) - size);
+                event_ctx.invalidate();
+            },
+
+            _ => ()
+        }
+    }
+
+    fn update(&mut self, update_ctx: &mut UpdateCtx, old_data: Option<&S>, data: &S, _env: &Env) {
+        if let Some(old_data) = old_data {
+            let old_scroll_position = old_data.scroll_position();
+            let new_scroll_position = data.scroll_position();
+            if old_scroll_position != new_scroll_position {
+                self.scroll_delta += new_scroll_position - old_scroll_position;
+                update_ctx.invalidate();
+            }
+        }
+    }
+
+    fn layout(&mut self, layout_ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &S, env: &Env) -> Size {
+        let bounds = match self.direction {
+            Axis::Vertical => bc.max().height,
+            Axis::Horizontal => bc.max().width
+        };
+        let (mut min, mut max) = self.translate(self.scroll_delta, bounds);
+        // We've translated more than the viewport distance
+        // and need to jump to a new data_range
+        if self.children.is_empty() {
+            let fractional_index = data.scroll_position() / self.renderer_size;
+            let index = fractional_index.floor() as usize;
+            self.data_range = index..index;
+            min = 0.;
+            max = (index as f64 * self.renderer_size) - (fractional_index * self.renderer_size);
+        }
+        // List items must attempt to fill the given box constraints.
+        // Determine if we need to add items behind the start index (scroll_position increasing)
+        while self.data_range.start != 0 && min > 0. {
+            if let Some(data) = self.data_provider.get(self.data_range.start - 1) {
+                let mut widget = WidgetPod::new((self.renderer_function)(data));
+                let child_bc = BoxConstraints::new(Size::ZERO, bc.max().clone());
+                let child_size = widget.layout(layout_ctx, &child_bc, data, env);
+
+                let mut offset = Point::new(0., 0.);
+                min -= match self.direction {
+                    Axis::Horizontal => {
+                        offset.x = min - child_size.width;
+                        child_size.width
+                    }
+                    Axis::Vertical => {
+                        offset.y = min - child_size.height;
+                        child_size.height
+                    }
+                };
+                let rect = Rect::from_origin_size(offset, child_size);
+                widget.set_layout_rect(rect);
+                self.data_range.start -= 1;
+                self.children.insert(0, widget);
+            } else {
+                break;
+            }
+        }
+
+        // determine if we need to add items in front of the end index
+
+        while max < bounds {
+            if let Some(data) = self.data_provider.get(self.data_range.end) {
+                let mut widget = WidgetPod::new((self.renderer_function)(data));
+                let child_bc = BoxConstraints::new(Size::ZERO, bc.max().clone());
+                let child_size = widget.layout(layout_ctx, &child_bc, data, env);
+                let mut offset = Point::new(0., 0.);
+                max += match self.direction {
+                    Axis::Horizontal => {
+                        offset.x = max;
+                        child_size.width
+                    }
+                    Axis::Vertical => {
+                        offset.y = max;
+                        child_size.height
+                    }
+                };
+                let rect = Rect::from_origin_size(offset, child_size);
+                widget.set_layout_rect(rect);
+                self.children.push(widget);
+                self.data_range.end += 1;
+            } else {
+                break;
+            }
+        }
+
+        self.set_scroll_metrics((min, max));
+        self.scroll_delta = 0.;
+        bc.max()
+    }
+
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &S, env: &Env) {
+        for (index, child) in &mut self.children.iter_mut().enumerate() {
+            let idx = self.data_range.start + index;
+            child.paint_with_offset(paint_ctx, &self.data_provider[idx], env);
+        }
+    }
+}
+
+fn get_scroll_metrics(direction: &Axis, rect: &Rect) -> (f64, f64) {
+    match direction {
+        Axis::Vertical => (rect.y0, rect.y1),
+        Axis::Horizontal => (rect.x0, rect.x1)
+    }
+}
+
+impl<T: Data> Data for Vec<T> {
+    fn same(&self, other: &Self) -> bool {
+        self.len() == other.len()
+    }
+}

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -185,7 +185,7 @@ where
             self.scroll_position_cache.insert(idx, pos);
             pos += self.get_preferred_renderer_size(idx);
         }
-        self.scroll_position_cache.get(&index).unwrap().clone()
+        *self.scroll_position_cache.get(&index).unwrap()
     }
 
     /// Gets the start and end positions of the

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -149,7 +149,7 @@ where
         // index - .0075% iterations or less of
         // the list's length.
         while current_position > pos {
-            target_index /= 1.0109375; // tested on indices of 5 or greater
+            target_index /= 1.010_937_5; // tested on indices of 5 or greater
             current_position = self.get_scroll_pos_at_index(target_index.ceil() as usize);
         }
         // At this point the current_position is

--- a/druid/src/widget/virtual_list.rs
+++ b/druid/src/widget/virtual_list.rs
@@ -138,7 +138,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState> VirtualList<T, S> {
     }
 }
 
-impl<T: Data + ToString +  'static, S: ScrollControlState> Default for VirtualList<T, S> {
+impl<T: Data + ToString + 'static, S: ScrollControlState> Default for VirtualList<T, S> {
     fn default() -> Self {
         VirtualList {
             children: Vec::new(),
@@ -150,7 +150,7 @@ impl<T: Data + ToString +  'static, S: ScrollControlState> Default for VirtualLi
             renderer_function: |data: &T| -> Box<dyn Widget<T>> { Box::new(Label::new(data.to_string()).fix_height(30.)) },
             renderer_size: 0.,
             set_scroll_metrics_later: false,
-            phantom_data: PhantomData
+            phantom_data: PhantomData,
         }
     }
 }
@@ -196,7 +196,7 @@ impl<T: Data + ToString + 'static, S: ScrollControlState, > Widget<S> for Virtua
 
             Event::Size(_) => {
                 self.set_scroll_metrics(event_ctx, data);
-            },
+            }
 
             Event::AnimFrame(_) => {
                 if self.set_scroll_metrics_later {

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -257,7 +257,6 @@ impl<'a, T: Data> SingleWindowState<'a, T> {
             command_queue: self.command_queue,
             base_state: &mut base_state,
             is_handled: false,
-            is_root: true,
             had_active: self.window.root.has_active(),
             window: &self.state.handle,
             window_id: self.window_id,


### PR DESCRIPTION
Hi -

Cool project...
I'm a 12 year UI dev and would like to contribute. Here are a few items I feel this project could benefit from and would love your feedback. I'm a relative newcomer to Rust and Druid but UI has been my focus for some time and the patterns used in Druid are very familiar to me.

## This PR is a WIP and contains: 
1. Virtual List widget - Tested using 1 million rows with no performance cost. It can take many, many more rows with zero performance impact. Works with both Vertical and Horizontal axis.
2. A Decoupled `Scrollbar` widget - Basically a slider that interpolates between a given Range instead of a viewport boundary. This decoupling allows the most flexible usage for views that virtualize layouts.
3. `Event::Size` propagates to children - this was necessary to adjust the scroll position bindings and to calculate a new `max_scroll_position` value. 

## To Test
run the `virtual_list.rs` in `examples/`

## TODO
### VirtualList
- [ ] Keyboard navigation / accessibility
- [x] Determine if reusing popped widgets provides advantages and implement if yes. ~~(tabled for later)~~ Implemented
- [x] Variable size rows/cols - Potentially impactful with performance since all items would need to be measured in order to calculate the `max_scroll_position`.
- [ ] Smooth scroll - A fairly straightforward implementation since the VirtualList design keeps this in mind. 
- [ ] Test thoroughly 
### Scrollbar
- [x] Apply animation to scrollbar - this will likely be a copy/paste from the original `Scroll` widget
- [x] Page the scroll position up or down depending on where a mouse event occurs in relation to the scroll thumb along the scroll track.
- [ ] Wire in whatever solution is found for #457 
- [x] Test thoroughly

I have a few questions also: 

1. The `update` flow seems to aggressively clone the entire data structure even when a single field is all that has changed. This still seems to happen when manually implementing the `Data` trait also. Is there a way to avoid this? If no, are there plans to address this? e.g. Observables 
2. I found the `Data` requirement to be cumbersome. Why was this chosen over just `PartialEq`? I see they are somewhat synonymous `#[druid(same_fn = "PartialEq::eq")]`
3. `Event::MouseMoved` requires a delta to be calculated manually. Are there plans to include the delta similar the `Event::Scroll`?

I hope you find these widgets useful. I certainly had fun creating them. 

Thank you for your time and feedback!

Justin
