### PR TITLE
Z-order painting

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -16,7 +16,8 @@
 
 use std::f64::consts::PI;
 
-use druid::kurbo::Line;
+use druid::kurbo::{Circle, Line, Affine};
+use druid::widget::{Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider};
 use druid::{
     AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
     RenderContext, Size, UpdateCtx, Vec2, Widget, WindowDesc,
@@ -62,11 +63,73 @@ impl Widget<u32> for AnimWidget {
         let center = Point::new(50.0, 50.0);
         let ambit = center + 45.0 * Vec2::from_angle((0.75 + self.t) * 2.0 * PI);
         paint_ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);
+
+        paint_ctx.fill(Circle::new(Point::new(100.0, 100.0), 20.0), &Color::WHITE);
+
+        paint_ctx.paint_with_z_index(3, |ctx| {
+            ctx.fill(
+                Circle::new(Point::new(140.0, 100.0), 20.0),
+                &Color::rgb8(255, 255, 0),
+            );
+        });
+
+        paint_ctx.paint_with_z_index(1, |ctx| {
+            ctx.fill(
+                Circle::new(Point::new(120.0, 100.0), 20.0),
+                &Color::rgb8(255, 0, 0),
+            );
+        });
+
+        paint_ctx.fill(
+            Circle::new(Point::new(100.0, 120.0), 20.0),
+            &Color::rgb8(255, 0, 255),
+        );
     }
 }
 
+struct CircleWidget {}
+
+impl Widget<u32> for CircleWidget {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut u32, _env: &Env) {}
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&u32>, _data: &u32, _env: &Env) {}
+
+    fn layout(
+        &mut self,
+        _layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _data: &u32,
+        _env: &Env,
+    ) -> Size {
+        bc.constrain((500.0, 500.0))
+    }
+
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
+        paint_ctx.transform(Affine::translate((-50.,0.)));
+
+        paint_ctx.fill(
+            Circle::new(Point::new(125.0, 70.0), 20.0),
+            &Color::rgb8(125, 50, 55),
+        );
+//        paint_ctx.paint_with_z_index(2, |ctx| {
+//            ctx.fill(
+//                Circle::new(Point::new(125.0, 70.0), 20.0),
+//                &Color::rgb8(125, 50, 55),
+//            );
+//        });
+    }
+}
+
+fn build_widget() -> impl Widget<u32> {
+    let anim_widget = AnimWidget { t: 0.0 };
+    let circle_widget = CircleWidget {};
+
+    Flex::column()
+        .with_child(Padding::new(0.0, circle_widget), 1.0)
+        .with_child(Padding::new(0.0, anim_widget), 1.0)
+}
+
 fn main() {
-    let window = WindowDesc::new(|| AnimWidget { t: 0.0 });
+    let window = WindowDesc::new(build_widget);
     AppLauncher::with_window(window)
         .use_simple_logger()
         .launch(0)

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -16,7 +16,7 @@
 
 use std::f64::consts::PI;
 
-use druid::kurbo::{Circle, Line, Affine};
+use druid::kurbo::{Affine, Circle, Line};
 use druid::widget::{Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider};
 use druid::{
     AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
@@ -104,18 +104,19 @@ impl Widget<u32> for CircleWidget {
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
-        paint_ctx.transform(Affine::translate((-50.,0.)));
+        paint_ctx.transform(Affine::translate((-50., 0.)));
 
         paint_ctx.fill(
             Circle::new(Point::new(125.0, 70.0), 20.0),
             &Color::rgb8(125, 50, 55),
         );
-//        paint_ctx.paint_with_z_index(2, |ctx| {
-//            ctx.fill(
-//                Circle::new(Point::new(125.0, 70.0), 20.0),
-//                &Color::rgb8(125, 50, 55),
-//            );
-//        });
+
+        paint_ctx.paint_with_z_index(2, |ctx| {
+            ctx.fill(
+                Circle::new(Point::new(135.0, 70.0), 20.0),
+                &Color::rgb8(0, 0, 255),
+            );
+        });
     }
 }
 
@@ -124,8 +125,8 @@ fn build_widget() -> impl Widget<u32> {
     let circle_widget = CircleWidget {};
 
     Flex::column()
-        .with_child(Padding::new(0.0, circle_widget), 1.0)
         .with_child(Padding::new(0.0, anim_widget), 1.0)
+        .with_child(Padding::new(0.0, circle_widget), 1.0)
 }
 
 fn main() {

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -16,8 +16,8 @@
 
 use std::f64::consts::PI;
 
-use druid::kurbo::{Affine, Circle, Line};
-use druid::widget::{Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider};
+use druid::kurbo::{Circle, Line};
+use druid::widget::{Flex, Padding};
 use druid::{
     AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
     RenderContext, Size, UpdateCtx, Vec2, Widget, WindowDesc,
@@ -60,73 +60,22 @@ impl Widget<u32> for AnimWidget {
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
+        let t = self.t;
         let center = Point::new(50.0, 50.0);
-        let ambit = center + 45.0 * Vec2::from_angle((0.75 + self.t) * 2.0 * PI);
-        paint_ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);
 
-        paint_ctx.fill(Circle::new(Point::new(100.0, 100.0), 20.0), &Color::WHITE);
-
-        paint_ctx.paint_with_z_index(3, |ctx| {
-            ctx.fill(
-                Circle::new(Point::new(140.0, 100.0), 20.0),
-                &Color::rgb8(255, 255, 0),
-            );
+        paint_ctx.paint_with_z_index(1, move |ctx| {
+            let ambit = center + 45.0 * Vec2::from_angle((0.75 + t) * 2.0 * PI);
+            ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);
         });
 
-        paint_ctx.paint_with_z_index(1, |ctx| {
-            ctx.fill(
-                Circle::new(Point::new(120.0, 100.0), 20.0),
-                &Color::rgb8(255, 0, 0),
-            );
-        });
-
-        paint_ctx.fill(
-            Circle::new(Point::new(100.0, 120.0), 20.0),
-            &Color::rgb8(255, 0, 255),
-        );
-    }
-}
-
-struct CircleWidget {}
-
-impl Widget<u32> for CircleWidget {
-    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut u32, _env: &Env) {}
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&u32>, _data: &u32, _env: &Env) {}
-
-    fn layout(
-        &mut self,
-        _layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        _data: &u32,
-        _env: &Env,
-    ) -> Size {
-        bc.constrain((500.0, 500.0))
-    }
-
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
-        paint_ctx.transform(Affine::translate((-50., 0.)));
-
-        paint_ctx.fill(
-            Circle::new(Point::new(125.0, 70.0), 20.0),
-            &Color::rgb8(125, 50, 55),
-        );
-
-        paint_ctx.paint_with_z_index(2, |ctx| {
-            ctx.fill(
-                Circle::new(Point::new(135.0, 70.0), 20.0),
-                &Color::rgb8(0, 0, 255),
-            );
-        });
+        paint_ctx.fill(Circle::new(center, 50.0), &Color::BLACK)
     }
 }
 
 fn build_widget() -> impl Widget<u32> {
     let anim_widget = AnimWidget { t: 0.0 };
-    let circle_widget = CircleWidget {};
 
-    Flex::column()
-        .with_child(Padding::new(0.0, anim_widget), 1.0)
-        .with_child(Padding::new(0.0, circle_widget), 1.0)
+    Flex::column().with_child(Padding::new(0.0, anim_widget), 1.0)
 }
 
 fn main() {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -414,7 +414,6 @@ pub struct ZOrderPaintOp {
     pub z_index: u32,
     pub paint_func: Box<dyn FnOnce(&mut PaintCtx) + 'static>,
     pub transform: Affine,
-    // todo: clip
 }
 
 /// A context passed to paint methods of widgets.

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -183,7 +183,6 @@ impl<'a, T: Data + 'static> SingleWindowState<'a, T> {
             region: Rect::ZERO.into(),
         };
 
-        eprintln!("paint");
         self.window.paint(&mut paint_ctx, self.data, self.env);
     }
 

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -178,9 +178,12 @@ impl<'a, T: Data + 'static> SingleWindowState<'a, T> {
         let mut paint_ctx = PaintCtx {
             render_ctx: piet,
             base_state: &base_state,
+            z_ops: Vec::new(),
             window_id: self.window_id,
             region: Rect::ZERO.into(),
         };
+
+        eprintln!("paint");
         self.window.paint(&mut paint_ctx, self.data, self.env);
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -15,6 +15,7 @@
 //! Management of multiple windows.
 
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::mem;
 
 use crate::kurbo::{Point, Rect, Size};
 
@@ -81,6 +82,17 @@ impl<T: Data> Window<T> {
     pub fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         let visible = Rect::from_origin_size(Point::ZERO, self.size);
         paint_ctx.with_child_ctx(visible, |ctx| self.root.paint(ctx, data, env));
+        // paint_ctx.paint_z
+
+        eprintln!("xx {:?}", paint_ctx.z_ops.len());
+
+        paint_ctx.z_ops.sort_by_key(|k| k.0);
+
+        let z_ops = mem::replace(&mut paint_ctx.z_ops, Vec::new());
+        for z_op in z_ops.into_iter() {
+//            paint_ctx.with_child_ctx(visible, |ctx| z_op.1(ctx));
+            //z_op.1();
+        }
     }
 
     pub(crate) fn update_title(&mut self, win_handle: &WindowHandle, data: &T, env: &Env) {


### PR DESCRIPTION
This addresses https://github.com/xi-editor/druid/issues/430

This requires https://github.com/linebender/piet/pull/117 to have access to `current_transform()` which is necessary to keep track of applied transformations.

One thing that is missing here (also because I'm not 100% sure) is keeping track of clipping. Right now previous clipping is not applied to z-order painting. It would be a bit trickier since `PaintCtx` would need to keep track of clipping.

One other thing that I was thinking about was thinking about is whether it would make sense to allow negative `z_index`es to allow painting below content?