### PR TITLE
Lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "fluent-bundle 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-langneg 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-syntax 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unic-langid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -401,6 +402,11 @@ dependencies = [
 [[package]]
 name = "fluent-syntax"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1442,6 +1448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fluent-bundle 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cb733f6cedee059a77da074a14d1d855f3c7a04de18164b181ba2aa82221e281"
 "checksum fluent-langneg 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "55e840a3a9938e6dd9a57a6a3be02bef1d51b1d75b883cdfe84810c7e7ca1293"
 "checksum fluent-syntax 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7be7427364d95bc7b59f3b7cd0b1a74bb70c2ee0ae667b63b853d359470dc85c"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum freetype 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "11926b2b410b469d0e9399eca4cbbe237a9ef02176c485803b29216307e8e028"

--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ paint_ctx.fill(rect, &fill_color);
 
 Widgets in druid (text boxes, buttons, layout components, etc.) are objects
 which implement the [Widget trait]. The trait is parametrized by a type (`T`)
-for associated data. All trait methods (`paint`, `layout`, `event`, and
-`update`) are provided with access to this data, and in the case of `event` the
-reference is mutable, so that events can directly update the data.
+for associated data. All trait methods (`event`, `lifecycle`, `update`, `paint`,
+and `layout`) are provided with access to this data, and in the case of
+`event` the reference is mutable, so that events can directly update the data.
 
 Whenever the application data changes, the framework traverses the widget
 hierarchy with an `update` method.
 
 All the widget trait methods are provided with a corresponding context
-([EventCtx], [LayoutCtx], [PaintCtx], [UpdateCtx]). The widget can request
+([EventCtx], [LifeCycleCtx], [UpdateCtx], [LayoutCtx], [PaintCtx]). The widget can request
 things and cause actions by calling methods on that context.
 
 In addition, all trait methods are provided with an environment `Env`, which
@@ -126,22 +126,23 @@ includes the current theme parameters (colors, dimensions, etc.).
 
 ```rust
 impl<T: Data> Widget<T> for Button<T> {
-    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
-      ...
-    }
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
-      ...
-    }
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
       ...
     }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+      ...
+    }
+
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+      ...
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+      ...
+    }
+
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
       ...
     }
 }
@@ -284,6 +285,7 @@ active and friendly community.
 [non-druid examples]: ./druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
 [EventCtx]: https://docs.rs/druid/0.4.0/druid/struct.EventCtx.html
+[LifeCycleCtx]: https://docs.rs/druid/0.5.0/druid/struct.EventCtx.html
 [LayoutCtx]: https://docs.rs/druid/0.4.0/druid/struct.LayoutCtx.html
 [PaintCtx]: https://docs.rs/druid/0.4.0/druid/struct.PaintCtx.html
 [UpdateCtx]: https://docs.rs/druid/0.4.0/druid/struct.UpdateCtx.html

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ impl<T: Data> Widget<T> for Button<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
       ...
     }
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
       ...
     }
 }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -28,6 +28,7 @@ unic-langid = "0.7.1"
 unicode-segmentation = "1.3.0"
 log = "0.4.8"
 usvg = {version = "0.9.0", optional = true}
+fnv = "1.0.3"
 
 [dependencies.simple_logger]
 version = "1.3.0"

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -18,8 +18,8 @@ use std::f64::consts::PI;
 
 use druid::kurbo::Line;
 use druid::{
-    AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
-    RenderContext, Size, UpdateCtx, Vec2, Widget, WindowDesc,
+    AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    PaintCtx, Point, RenderContext, Size, UpdateCtx, Vec2, Widget, WindowDesc,
 };
 
 struct AnimWidget {
@@ -47,6 +47,8 @@ impl Widget<u32> for AnimWidget {
     }
 
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&u32>, _data: &u32, _env: &Env) {}
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -33,22 +33,20 @@ impl Widget<u32> for AnimWidget {
                 self.t = 0.0;
                 ctx.request_anim_frame();
             }
-            Event::AnimFrame(interval) => {
-                self.t += (*interval as f64) * 1e-9;
-                if self.t < 1.0 {
-                    ctx.request_anim_frame();
-                }
-                // When we do fine-grained invalidation,
-                // no doubt this will be required:
-                //ctx.invalidate();
-            }
             _ => (),
         }
     }
 
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&u32>, _data: &u32, _env: &Env) {}
 
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {}
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {
+        if let LifeCycle::AnimFrame(interval) = event {
+            self.t += (*interval as f64) * 1e-9;
+            if self.t < 1.0 {
+                ctx.request_anim_frame();
+            }
+        }
+    }
 
     fn layout(
         &mut self,

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -37,7 +37,7 @@ impl Widget<u32> for AnimWidget {
         }
     }
 
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&u32>, _data: &u32, _env: &Env) {}
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {
         if let LifeCycle::AnimFrame(interval) = event {

--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -37,8 +37,6 @@ impl Widget<u32> for AnimWidget {
         }
     }
 
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {
         if let LifeCycle::AnimFrame(interval) = event {
             self.t += (*interval as f64) * 1e-9;
@@ -47,6 +45,8 @@ impl Widget<u32> for AnimWidget {
             }
         }
     }
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -18,8 +18,8 @@ use druid::kurbo::BezPath;
 use druid::piet::{FontBuilder, ImageFormat, InterpolationMode, Text, TextLayoutBuilder};
 
 use druid::{
-    Affine, AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, Point,
-    Rect, RenderContext, Size, UpdateCtx, Widget, WindowDesc,
+    Affine, AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, Point, Rect, RenderContext, Size, UpdateCtx, Widget, WindowDesc,
 };
 
 struct CustomWidget;
@@ -31,6 +31,15 @@ impl Widget<String> for CustomWidget {
         &mut self,
         _ctx: &mut UpdateCtx,
         _old_data: Option<&String>,
+        _data: &String,
+        _env: &Env,
+    ) {
+    }
+
+    fn lifecycle(
+        &mut self,
+        _ctx: &mut LifeCycleCtx,
+        _event: &LifeCycle,
         _data: &String,
         _env: &Env,
     ) {

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -27,14 +27,7 @@ struct CustomWidget;
 impl Widget<String> for CustomWidget {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut String, _env: &Env) {}
 
-    fn update(
-        &mut self,
-        _ctx: &mut UpdateCtx,
-        _old_data: Option<&String>,
-        _data: &String,
-        _env: &Env,
-    ) {
-    }
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {}
 
     fn lifecycle(
         &mut self,

--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -27,8 +27,6 @@ struct CustomWidget;
 impl Widget<String> for CustomWidget {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut String, _env: &Env) {}
 
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {}
-
     fn lifecycle(
         &mut self,
         _ctx: &mut LifeCycleCtx,
@@ -37,6 +35,8 @@ impl Widget<String> for CustomWidget {
         _env: &Env,
     ) {
     }
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -127,11 +127,8 @@ impl Widget<OurData> for ColorWell {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&OurData>, data: &OurData, _: &Env) {
-        if match old_data {
-            Some(d) => !d.same(data),
-            None => true,
-        } {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &OurData, data: &OurData, _: &Env) {
+        if !old_data.same(data) {
             ctx.invalidate()
         }
     }

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -33,8 +33,8 @@ use druid::kurbo::RoundedRect;
 use druid::widget::{Button, Flex, IdentityWrapper, WidgetExt};
 use druid::{
     AppLauncher, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, LayoutCtx, Lens,
-    LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size, TimerToken, UpdateCtx, Widget,
-    WindowDesc,
+    LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size,
+    TimerToken, UpdateCtx, Widget, WindowDesc,
 };
 
 const CYCLE_DURATION: Duration = Duration::from_millis(100);
@@ -83,9 +83,6 @@ impl ColorWell {
 impl Widget<OurData> for ColorWell {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut OurData, _env: &Env) {
         match event {
-            Event::LifeCycle(_) if self.randomize => {
-                self.token = ctx.request_timer(Instant::now() + CYCLE_DURATION);
-            }
             Event::Timer(t) if t == &self.token => {
                 let time_since_start = Instant::now() - self.start;
 
@@ -112,6 +109,15 @@ impl Widget<OurData> for ColorWell {
                     .into();
             }
             Event::Command(cmd) if cmd.selector == UNFREEZE_COLOR => self.frozen = None,
+            _ => (),
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &OurData, _: &Env) {
+        match event {
+            LifeCycle::WindowConnected if self.randomize => {
+                self.token = ctx.request_timer(Instant::now() + CYCLE_DURATION);
+            }
             _ => (),
         }
     }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -93,10 +93,6 @@ impl AppDelegate<State> for Delegate {
         ctx: &mut DelegateCtx,
     ) -> Option<Event> {
         match event {
-            Event::LifeCycle(event) => {
-                log::info!("{:?}", event);
-                Some(Event::LifeCycle(event))
-            }
             Event::TargetedCommand(_, ref cmd) if cmd.selector == druid::commands::NEW_FILE => {
                 let new_win = WindowDesc::new(ui_builder)
                     .menu(make_menu(data))

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -48,7 +48,7 @@ impl Widget<u32> for TimerWidget {
         }
     }
 
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&u32>, _data: &u32, _env: &Env) {}
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
 
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {}
 

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -18,8 +18,8 @@ use std::time::{Duration, Instant};
 
 use druid::kurbo::Line;
 use druid::{
-    AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext,
-    Size, TimerToken, UpdateCtx, Widget, WindowDesc,
+    AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    PaintCtx, RenderContext, Size, TimerToken, UpdateCtx, Widget, WindowDesc,
 };
 
 struct TimerWidget {
@@ -49,6 +49,8 @@ impl Widget<u32> for TimerWidget {
     }
 
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&u32>, _data: &u32, _env: &Env) {}
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -48,9 +48,9 @@ impl Widget<u32> for TimerWidget {
         }
     }
 
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
-
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {}
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/bloom.rs
+++ b/druid/src/bloom.rs
@@ -1,0 +1,158 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A simple bloom filter, used to track child widgets.
+
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+
+use fnv::FnvHasher;
+
+const NUM_BITS: u64 = 64;
+
+// the 'offset_basis' for the fnv-1a hash algorithm.
+// see http://www.isthe.com/chongo/tech/comp/fnv/index.html#FNV-param
+//
+// The first of these is the one described in the algorithm, the second is random.
+const OFFSET_ONE: u64 = 0xcbf2_9ce4_8422_2325;
+const OFFSET_TWO: u64 = 0xe10_3ad8_2dad_8028;
+
+/// A very simple bloom filter optimized for small values.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Bloom<T: ?Sized> {
+    bits: u64,
+    data: PhantomData<T>,
+    entry_count: usize,
+}
+
+impl<T: ?Sized + Hash> Bloom<T> {
+    /// Create a new filter.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of items that have been added to the filter.
+    ///
+    /// Does not count unique entries; this is just the number of times
+    /// `add()` was called since the filter was created or last `clear()`ed.
+    // it feels wrong to call this 'len'?
+    #[cfg(test)]
+    pub fn entry_count(&self) -> usize {
+        self.entry_count
+    }
+
+    /// Return the raw bits of this filter.
+    #[allow(dead_code)]
+    pub fn to_raw(&self) -> u64 {
+        self.bits
+    }
+
+    /// Remove all entries from the filter.
+    #[cfg(test)]
+    pub fn clear(&mut self) {
+        self.bits = 0;
+    }
+
+    /// Add an item to the filter.
+    pub fn add(&mut self, item: &T) {
+        let mask = self.make_bit_mask(item);
+        self.bits |= mask;
+        self.entry_count += 1;
+    }
+
+    /// Return whether an item exists in the filter.
+    ///
+    /// This can return false positives, but never false negatives.
+    pub fn contains(&self, item: &T) -> bool {
+        let mask = self.make_bit_mask(item);
+        self.bits & mask == mask
+    }
+
+    /// Create a new `Bloom` with the items from both filters.
+    pub fn intersection(&self, other: Bloom<T>) -> Bloom<T> {
+        Bloom {
+            bits: self.bits | other.bits,
+            data: PhantomData,
+            entry_count: self.entry_count + other.entry_count,
+        }
+    }
+
+    #[inline]
+    fn make_bit_mask(&self, item: &T) -> u64 {
+        //NOTE: we use two hash functions, which performs better than a single hash
+        // with smaller numbers of items, but poorer with more items. Threshold
+        // (given 64 bits) is ~30 items.
+        // The reasoning is that with large numbers of items we're already in bad shape;
+        // optimize for fewer false positives as we get closer to the leaves.
+        // This can be tweaked after profiling.
+        let hash1 = self.make_hash(item, OFFSET_ONE);
+        let hash2 = self.make_hash(item, OFFSET_TWO);
+        (1 << (hash1 % NUM_BITS)) | (1 << (hash2 % NUM_BITS))
+    }
+
+    #[inline]
+    fn make_hash(&self, item: &T, seed: u64) -> u64 {
+        let mut hasher = FnvHasher::with_key(seed);
+        item.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl<T: ?Sized> Default for Bloom<T> {
+    fn default() -> Self {
+        Bloom {
+            bits: 0,
+            data: PhantomData,
+            entry_count: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn very_good_test() {
+        let mut bloom = Bloom::default();
+        for i in 0..100 {
+            bloom.add(&i);
+            assert!(bloom.contains(&i));
+        }
+        bloom.clear();
+        for i in 0..100 {
+            assert!(!bloom.contains(&i));
+        }
+    }
+
+    #[test]
+    fn intersection() {
+        let mut bloom1 = Bloom::default();
+        bloom1.add(&0);
+        bloom1.add(&1);
+        assert!(!bloom1.contains(&2));
+        assert!(!bloom1.contains(&3));
+        let mut bloom2 = Bloom::default();
+        bloom2.add(&2);
+        bloom2.add(&3);
+        assert!(!bloom2.contains(&0));
+        assert!(!bloom2.contains(&1));
+
+        let bloom3 = bloom1.intersection(bloom2);
+        assert!(bloom3.contains(&0));
+        assert!(bloom3.contains(&1));
+        assert!(bloom3.contains(&2));
+        assert!(bloom3.contains(&3));
+    }
+}

--- a/druid/src/bloom.rs
+++ b/druid/src/bloom.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A simple bloom filter, used to track child widgets.
+//! A simple Bloom filter, used to track child widgets.
 
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -28,7 +28,7 @@ const NUM_BITS: u64 = 64;
 const OFFSET_ONE: u64 = 0xcbf2_9ce4_8422_2325;
 const OFFSET_TWO: u64 = 0xe10_3ad8_2dad_8028;
 
-/// A very simple bloom filter optimized for small values.
+/// A very simple Bloom filter optimized for small values.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Bloom<T: ?Sized> {
     bits: u64,
@@ -62,6 +62,7 @@ impl<T: ?Sized + Hash> Bloom<T> {
     #[cfg(test)]
     pub fn clear(&mut self) {
         self.bits = 0;
+        self.entry_count = 0;
     }
 
     /// Add an item to the filter.
@@ -80,7 +81,7 @@ impl<T: ?Sized + Hash> Bloom<T> {
     }
 
     /// Create a new `Bloom` with the items from both filters.
-    pub fn intersection(&self, other: Bloom<T>) -> Bloom<T> {
+    pub fn union(&self, other: Bloom<T>) -> Bloom<T> {
         Bloom {
             bits: self.bits | other.bits,
             data: PhantomData,
@@ -137,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    fn intersection() {
+    fn union() {
         let mut bloom1 = Bloom::default();
         bloom1.add(&0);
         bloom1.add(&1);
@@ -149,7 +150,7 @@ mod tests {
         assert!(!bloom2.contains(&0));
         assert!(!bloom2.contains(&1));
 
-        let bloom3 = bloom1.intersection(bloom2);
+        let bloom3 = bloom1.union(bloom2);
         assert!(bloom3.contains(&0));
         assert!(bloom3.contains(&1));
         assert!(bloom3.contains(&2));

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -40,6 +40,7 @@ pub struct Selector(&'static str);
 /// ```
 #[derive(Debug, Clone)]
 pub struct Command {
+    /// The command's `Selector`.
     pub selector: Selector,
     object: Option<Arc<dyn Any>>,
 }
@@ -47,7 +48,10 @@ pub struct Command {
 /// The target of a command.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Target {
+    /// The target is a window; the event will be delivered to all
+    /// widgets in that window.
     Window(WindowId),
+    /// The target is a specific widget.
     Widget(WidgetId),
 }
 

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -182,15 +182,6 @@ impl Command {
     }
 }
 
-impl Target {
-    pub(crate) fn is_window(self) -> bool {
-        match self {
-            Target::Window(_) => true,
-            _ => false,
-        }
-    }
-}
-
 impl From<Selector> for Command {
     fn from(selector: Selector) -> Command {
         Command {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -31,6 +31,9 @@ use crate::{
 /// Convenience type for dynamic boxed widget.
 pub type BoxedWidget<T> = WidgetPod<T, Box<dyn Widget<T>>>;
 
+/// Our queue type
+pub(crate) type CommandQueue = VecDeque<(Target, Command)>;
+
 /// A container for one widget in the hierarchy.
 ///
 /// Generally, container widgets don't contain other widgets directly,
@@ -609,7 +612,7 @@ pub struct EventCtx<'a, 'b> {
     pub(crate) win_ctx: &'a mut dyn WinCtx<'b>,
     pub(crate) cursor: &'a mut Option<Cursor>,
     /// Commands submitted to be run after this event.
-    pub(crate) command_queue: &'a mut VecDeque<(Target, Command)>,
+    pub(crate) command_queue: &'a mut CommandQueue,
     pub(crate) window_id: WindowId,
     // TODO: migrate most usage of `WindowHandle` to `WinCtx` instead.
     pub(crate) window: &'a WindowHandle,
@@ -621,7 +624,7 @@ pub struct EventCtx<'a, 'b> {
 }
 
 pub struct LifeCycleCtx<'a> {
-    pub(crate) command_queue: &'a mut VecDeque<(Target, Command)>,
+    pub(crate) command_queue: &'a mut CommandQueue,
     /// the registry for the current widgets children;
     /// only really meaninful during a `LifeCyle::RegisterChildren` call.
     pub(crate) children: Bloom<WidgetId>,
@@ -641,7 +644,7 @@ pub struct LifeCycleCtx<'a> {
 pub struct UpdateCtx<'a, 'b: 'a> {
     pub(crate) text_factory: &'a mut Text<'b>,
     pub(crate) window: &'a WindowHandle,
-    pub(crate) command_queue: &'a mut VecDeque<(Target, Command)>,
+    pub(crate) command_queue: &'a mut CommandQueue,
     // Discussion: we probably want to propagate more fine-grained
     // invalidations, which would mean a structure very much like
     // `EventCtx` (and possibly using the same structure).But for
@@ -994,7 +997,7 @@ mod tests {
         let (id1, id2, id3, widget) = make_widgets();
         let mut widget = WidgetPod::new(widget).boxed();
 
-        let mut command_queue: VecDeque<(Target, Command)> = VecDeque::new();
+        let mut command_queue: CommandQueue = VecDeque::new();
         let mut ctx = LifeCycleCtx {
             command_queue: &mut command_queue,
             children: Bloom::new(),

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -103,6 +103,19 @@ pub(crate) struct BaseState {
     pub(crate) children_changed: bool,
 }
 
+impl BaseState {
+    /// Update to incorporate state changes from a child.
+    fn merge_up(&mut self, child_state: &BaseState) {
+        self.needs_inval |= child_state.needs_inval;
+        self.request_anim |= child_state.request_anim;
+        self.request_timer |= child_state.request_timer;
+        self.is_hot |= child_state.is_hot;
+        self.has_active |= child_state.has_active;
+        self.request_focus |= child_state.request_focus;
+        self.children_changed |= child_state.children_changed;
+    }
+}
+
 impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Create a new widget pod.
     ///
@@ -370,13 +383,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             self.inner.event(&mut child_ctx, &child_event, data, &env);
             child_ctx.base_state.has_active |= child_ctx.base_state.is_active;
         };
-        ctx.base_state.needs_inval |= child_ctx.base_state.needs_inval;
-        ctx.base_state.request_anim |= child_ctx.base_state.request_anim;
-        ctx.base_state.request_timer |= child_ctx.base_state.request_timer;
-        ctx.base_state.is_hot |= child_ctx.base_state.is_hot;
-        ctx.base_state.has_active |= child_ctx.base_state.has_active;
-        ctx.base_state.request_focus |= child_ctx.base_state.request_focus;
-        ctx.base_state.children_changed |= child_ctx.base_state.children_changed;
+
+        ctx.base_state.merge_up(&child_ctx.base_state);
         ctx.is_handled |= child_ctx.is_handled;
     }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -786,6 +786,7 @@ impl<'a, 'b> EventCtx<'a, 'b> {
     /// Request an animation frame.
     pub fn request_anim_frame(&mut self) {
         self.base_state.request_anim = true;
+        self.base_state.needs_inval = true;
     }
 
     /// Request a timer event.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -654,6 +654,16 @@ pub struct EventCtx<'a, 'b> {
     pub(crate) widget_id: WidgetId,
 }
 
+/// A mutable context provided to the [`lifecycle`] method on widgets.
+///
+/// Certain methods on this context are only meaningful during the handling of
+/// specific lifecycle events; for instance [`register_child`]
+/// should only be called while handling [`LifeCycle::RegisterChildren`].
+///
+/// [`lifecycle`]: widget/trait.Widget.html#tymethod.lifecycle
+/// [`register_child`]: #method.register_child
+/// [`LifeCycleCtx::register_child`]: #method.register_child
+/// [`LifeCycle::RegisterChildren`]: enum.LifeCycle.html#variant.RegisterChildren
 pub struct LifeCycleCtx<'a> {
     pub(crate) command_queue: &'a mut CommandQueue,
     /// the registry for the current widgets children;
@@ -675,7 +685,6 @@ pub struct LifeCycleCtx<'a> {
 pub struct UpdateCtx<'a, 'b: 'a> {
     pub(crate) text_factory: &'a mut Text<'b>,
     pub(crate) window: &'a WindowHandle,
-    pub(crate) command_queue: &'a mut CommandQueue,
     // Discussion: we probably want to propagate more fine-grained
     // invalidations, which would mean a structure very much like
     // `EventCtx` (and possibly using the same structure).But for
@@ -988,18 +997,6 @@ impl<'a, 'b> UpdateCtx<'a, 'b> {
     /// get the `WidgetId` of the current widget.
     pub fn widget_id(&self) -> WidgetId {
         self.widget_id
-    }
-
-    pub(crate) fn make_lifecycle_ctx(&mut self) -> LifeCycleCtx {
-        LifeCycleCtx {
-            command_queue: self.command_queue,
-            children: Bloom::default(),
-            children_changed: false,
-            needs_inval: false,
-            request_anim: false,
-            window_id: self.window_id,
-            widget_id: self.widget_id,
-        }
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -449,7 +449,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         if let LifeCycle::RegisterChildren = event {
             self.state.children = ctx.children;
             self.state.children_changed = false;
-            ctx.children = ctx.children.intersection(pre_children);
+            ctx.children = ctx.children.union(pre_children);
             ctx.register_child(self.id());
         }
     }
@@ -687,7 +687,7 @@ pub struct UpdateCtx<'a, 'b: 'a> {
     pub(crate) window: &'a WindowHandle,
     // Discussion: we probably want to propagate more fine-grained
     // invalidations, which would mean a structure very much like
-    // `EventCtx` (and possibly using the same structure).But for
+    // `EventCtx` (and possibly using the same structure). But for
     // now keep it super-simple.
     pub(crate) needs_inval: bool,
     pub(crate) children_changed: bool,

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -153,6 +153,13 @@ pub enum LifeCycle {
     /// This is sent after `WidgetAdded`. Widgets should handle this event if
     /// they need to do some addition setup when a window is first created.
     WindowConnected,
+    /// Sent to a widget when its children have changed.
+    ///
+    /// If a widget manages children, it is responsible for calling
+    /// [`LifeCycleCtx::register_child`] for each of its existing children.
+    ///
+    /// [`LifeCycleCtx::register_child`]: struct.LifeCycleCtx.html#method.register_child
+    RegisterChildren,
 }
 
 /// A mouse wheel event.

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -46,12 +46,6 @@ use crate::{Command, Target};
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Debug, Clone)]
 pub enum Event {
-    /// Called when certain application and window lifecycle events occur.
-    ///
-    /// For the various possible events, see the [`LifeCycle`] enum.
-    ///
-    /// [`LifeCycle`]: enum.LifeCycle.html
-    LifeCycle(LifeCycle),
     /// Called on the root widget when the window size changes.
     ///
     /// Discussion: it's not obvious this should be propagated to user
@@ -148,9 +142,16 @@ pub enum Event {
 /// Application life cycle events.
 #[derive(Debug, Clone, Copy)]
 pub enum LifeCycle {
+    /// Sent to a `Widget` when it is added to the widget tree. This should be
+    /// the first message that each widget receives.
+    ///
+    /// Widgets should handle this event if they need to do any one-time setup
+    /// that requires access to `Data`.
+    WidgetAdded,
     /// Sent to all widgets in a given window when that window is first instantiated.
     ///
-    /// This is guaranteed to be the first event a window receives.
+    /// This is sent after `WidgetAdded`. Widgets should handle this event if
+    /// they need to do some addition setup when a window is first created.
     WindowConnected,
 }
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -95,11 +95,6 @@ pub enum Event {
     ///
     /// The value is a delta.
     Zoom(f64),
-    /// Called when the "hot" status changes.
-    ///
-    /// See [`is_hot`](struct.BaseState.html#method.is_hot) for
-    /// discussion about the hot status.
-    HotChanged(bool),
     /// Called when the focus status changes.
     ///
     /// See [`has_focus`](struct.BaseState.html#method.has_focus) for
@@ -160,6 +155,11 @@ pub enum LifeCycle {
     /// will be 0. (This logic is presently per-window but might change to
     /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
     AnimFrame(u64),
+    /// Called when the "hot" status changes.
+    ///
+    /// See [`is_hot`](struct.BaseState.html#method.is_hot) for
+    /// discussion about the hot status.
+    HotChanged(bool),
 }
 
 /// A mouse wheel event.
@@ -222,14 +222,6 @@ impl Event {
                 }
             }
             _ => Some(self.clone()),
-        }
-    }
-
-    /// Whether the event should be propagated from parent to children.
-    pub(crate) fn recurse(&self) -> bool {
-        match self {
-            Event::HotChanged(_) => false,
-            _ => true,
         }
     }
 }

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -105,12 +105,6 @@ pub enum Event {
     /// See [`has_focus`](struct.BaseState.html#method.has_focus) for
     /// discussion about the focus status.
     FocusChanged(bool),
-    /// Called at the beginning of a new animation frame.
-    ///
-    /// On the first frame when transitioning from idle to animating, `interval`
-    /// will be 0. (This logic is presently per-window but might change to
-    /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
-    AnimFrame(u64),
     /// Called on a timer event.
     ///
     /// Request a timer event through [`EventCtx::request_timer()`]. That will
@@ -160,6 +154,12 @@ pub enum LifeCycle {
     ///
     /// [`LifeCycleCtx::register_child`]: struct.LifeCycleCtx.html#method.register_child
     RegisterChildren,
+    /// Called at the beginning of a new animation frame.
+    ///
+    /// On the first frame when transitioning from idle to animating, `interval`
+    /// will be 0. (This logic is presently per-window but might change to
+    /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
+    AnimFrame(u64),
 }
 
 /// A mouse wheel event.

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -95,11 +95,6 @@ pub enum Event {
     ///
     /// The value is a delta.
     Zoom(f64),
-    /// Called when the focus status changes.
-    ///
-    /// See [`has_focus`](struct.BaseState.html#method.has_focus) for
-    /// discussion about the focus status.
-    FocusChanged(bool),
     /// Called on a timer event.
     ///
     /// Request a timer event through [`EventCtx::request_timer()`]. That will
@@ -157,9 +152,21 @@ pub enum LifeCycle {
     AnimFrame(u64),
     /// Called when the "hot" status changes.
     ///
+    /// This will always be called _before_ the event that triggered it; that is,
+    /// when the mouse moves over a widget, that widget will receive
+    /// `LifeCycle::HotChanged` before it receives `Event::MouseMoved`.
+    ///
     /// See [`is_hot`](struct.BaseState.html#method.is_hot) for
     /// discussion about the hot status.
     HotChanged(bool),
+    /// Called when the focus status changes.
+    ///
+    /// This will always be called immediately after an event where a widget
+    /// has requested focus.
+    ///
+    /// See [`has_focus`](struct.BaseState.html#method.has_focus) for
+    /// discussion about the focus status.
+    FocusChanged(bool),
 }
 
 /// A mouse wheel event.

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -54,7 +54,8 @@ pub use druid_derive::Lens;
 
 use crate::kurbo::Size;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetId,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetId,
 };
 
 /// A lens is a datatype that gives access to a part of a larger
@@ -272,6 +273,12 @@ where
         } else {
             lens.with(data, |data| inner.update(ctx, None, data, env));
         }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        let inner = &mut self.inner;
+        self.lens
+            .with(data, |data| inner.lifecycle(ctx, event, data, env))
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -259,20 +259,16 @@ where
             .with_mut(data, |data| inner.event(ctx, event, data, env))
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         let inner = &mut self.inner;
         let lens = &self.lens;
-        if let Some(old_data) = old_data {
-            lens.with(old_data, |old_data| {
-                lens.with(data, |data| {
-                    if !old_data.same(data) {
-                        inner.update(ctx, Some(old_data), data, env);
-                    }
-                })
+        lens.with(old_data, |old_data| {
+            lens.with(data, |data| {
+                if !old_data.same(data) {
+                    inner.update(ctx, old_data, data, env);
+                }
             })
-        } else {
-            lens.with(data, |data| inner.update(ctx, None, data, env));
-        }
+        })
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -259,6 +259,12 @@ where
             .with_mut(data, |data| inner.event(ctx, event, data, env))
     }
 
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        let inner = &mut self.inner;
+        self.lens
+            .with(data, |data| inner.lifecycle(ctx, event, data, env))
+    }
+
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         let inner = &mut self.inner;
         let lens = &self.lens;
@@ -269,12 +275,6 @@ where
                 }
             })
         })
-    }
-
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        let inner = &mut self.inner;
-        self.lens
-            .with(data, |data| inner.lifecycle(ctx, event, data, env))
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -23,6 +23,7 @@ pub use druid_shell::{kurbo, piet};
 
 mod app;
 mod app_delegate;
+mod bloom;
 mod box_constraints;
 mod command;
 mod core;

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -48,7 +48,9 @@ pub use shell::{
     SysMods, Text, TimerToken, WinCtx, WindowHandle,
 };
 
-pub use crate::core::{BoxedWidget, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, WidgetPod};
+pub use crate::core::{
+    BoxedWidget, EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, UpdateCtx, WidgetPod,
+};
 pub use app::{AppLauncher, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -16,8 +16,8 @@
 
 use crate::kurbo::{Rect, Size};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetId,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
 use crate::piet::UnitPoint;
@@ -88,6 +88,10 @@ impl<T: Data> Widget<T> for Align<T> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     fn layout(

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -86,7 +86,7 @@ impl<T: Data> Widget<T> for Align<T> {
         self.child.event(ctx, event, data, env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
     }
 

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -86,12 +86,12 @@ impl<T: Data> Widget<T> for Align<T> {
         self.child.event(ctx, event, data, env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
-        self.child.update(ctx, data, env);
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.child.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.child.update(ctx, data, env);
     }
 
     fn layout(

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -74,7 +74,7 @@ impl<T: Data> Widget<T> for Button<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.label.update(ctx, old_data, data, env)
     }
 

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -70,9 +70,6 @@ impl<T: Data> Widget<T> for Button<T> {
                     }
                 }
             }
-            Event::HotChanged(_) => {
-                ctx.invalidate();
-            }
             _ => (),
         }
     }
@@ -82,6 +79,9 @@ impl<T: Data> Widget<T> for Button<T> {
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        if let LifeCycle::HotChanged(_) = event {
+            ctx.invalidate();
+        }
         self.label.lifecycle(ctx, event, data, env)
     }
 

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -18,8 +18,8 @@ use crate::kurbo::{Point, RoundedRect, Size};
 use crate::theme;
 use crate::widget::{Label, LabelText};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
-    UnitPoint, UpdateCtx, Widget,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
+    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
 };
 
 /// A button with a text label.
@@ -79,6 +79,10 @@ impl<T: Data> Widget<T> for Button<T> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
         self.label.update(ctx, old_data, data, env)
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.label.lifecycle(ctx, event, data, env)
     }
 
     fn layout(

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -74,15 +74,15 @@ impl<T: Data> Widget<T> for Button<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.label.update(ctx, old_data, data, env)
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::HotChanged(_) = event {
             ctx.invalidate();
         }
         self.label.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.label.update(ctx, old_data, data, env)
     }
 
     fn layout(

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -57,7 +57,7 @@ impl Widget<bool> for Checkbox {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&bool>, _data: &bool, _env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &bool, _data: &bool, _env: &Env) {
         ctx.invalidate();
     }
 

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -18,7 +18,10 @@ use crate::kurbo::{BezPath, Point, RoundedRect, Size};
 use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
 use crate::theme;
 use crate::widget::Align;
-use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
+use crate::{
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
+    Widget,
+};
 
 /// A checkbox that toggles a boolean
 #[derive(Debug, Clone, Default)]
@@ -59,6 +62,9 @@ impl Widget<bool> for Checkbox {
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&bool>, _data: &bool, _env: &Env) {
         ctx.invalidate();
+    }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &bool, _env: &Env) {
     }
 
     fn layout(

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -53,9 +53,6 @@ impl Widget<bool> for Checkbox {
                     ctx.invalidate();
                 }
             }
-            Event::HotChanged(_) => {
-                ctx.invalidate();
-            }
             _ => (),
         }
     }
@@ -64,7 +61,10 @@ impl Widget<bool> for Checkbox {
         ctx.invalidate();
     }
 
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &bool, _env: &Env) {
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &bool, _env: &Env) {
+        if let LifeCycle::HotChanged(_) = event {
+            ctx.invalidate();
+        }
     }
 
     fn layout(

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -57,14 +57,14 @@ impl Widget<bool> for Checkbox {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &bool, _data: &bool, _env: &Env) {
-        ctx.invalidate();
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &bool, _env: &Env) {
         if let LifeCycle::HotChanged(_) = event {
             ctx.invalidate();
         }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &bool, _data: &bool, _env: &Env) {
+        ctx.invalidate();
     }
 
     fn layout(

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -16,8 +16,8 @@
 
 use crate::shell::kurbo::{Point, Rect, RoundedRect, Size};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintBrush, PaintCtx, RenderContext,
-    UpdateCtx, Widget, WidgetId, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintBrush,
+    PaintCtx, RenderContext, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
 struct BorderStyle {
@@ -84,6 +84,10 @@ impl<T: Data> Widget<T> for Container<T> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
         self.inner.update(ctx, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.inner.lifecycle(ctx, event, data, env)
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -82,7 +82,7 @@ impl<T: Data> Widget<T> for Container<T> {
         self.inner.event(ctx, event, data, env);
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, data, env);
     }
 

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -82,12 +82,12 @@ impl<T: Data> Widget<T> for Container<T> {
         self.inner.event(ctx, event, data, env);
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
-        self.inner.update(ctx, data, env);
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.inner.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.inner.update(ctx, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -60,8 +60,7 @@ impl<T: Data> Widget<T> for Either<T> {
         self.true_branch.lifecycle(ctx, event, data, env);
         self.false_branch.lifecycle(ctx, event, data, env);
     }
-
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let current = (self.closure)(data, env);
         if current != self.current {
             self.current = current;

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -16,7 +16,8 @@
 
 use crate::kurbo::{Point, Rect, Size};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 /// A widget that switches between two possible child views.
@@ -53,6 +54,11 @@ impl<T: Data> Widget<T> for Either<T> {
         } else {
             self.false_branch.event(ctx, event, data, env)
         }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.true_branch.lifecycle(ctx, event, data, env);
+        self.false_branch.lifecycle(ctx, event, data, env);
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -60,6 +60,7 @@ impl<T: Data> Widget<T> for Either<T> {
         self.true_branch.lifecycle(ctx, event, data, env);
         self.false_branch.lifecycle(ctx, event, data, env);
     }
+
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let current = (self.closure)(data, env);
         if current != self.current {

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -68,7 +68,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         self.child.event(ctx, event, data, &new_env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
 

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -18,7 +18,8 @@ use std::marker::PhantomData;
 
 use crate::kurbo::Size;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetId,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetId,
 };
 
 /// A widget that accepts a closure to update the environment for its child.
@@ -72,6 +73,12 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         (self.f)(&mut new_env, &data);
 
         self.child.update(ctx, old_data, data, &new_env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        let mut new_env = env.clone();
+        (self.f)(&mut new_env, &data);
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     fn layout(

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -68,17 +68,17 @@ impl<T: Data, W: Widget<T>> Widget<T> for EnvScope<T, W> {
         self.child.event(ctx, event, data, &new_env)
     }
 
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        let mut new_env = env.clone();
+        (self.f)(&mut new_env, &data);
+        self.child.lifecycle(ctx, event, data, env)
+    }
+
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         let mut new_env = env.clone();
         (self.f)(&mut new_env, &data);
 
         self.child.update(ctx, old_data, data, &new_env);
-    }
-
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        let mut new_env = env.clone();
-        (self.f)(&mut new_env, &data);
-        self.child.lifecycle(ctx, event, data, env)
     }
 
     fn layout(

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -128,7 +128,7 @@ impl<T: Data> Widget<T> for Flex<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         for child in &mut self.children {
             child.widget.update(ctx, data, env);
         }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -17,7 +17,8 @@
 use crate::kurbo::{Point, Rect, Size};
 
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 /// A container with either horizontal or vertical layout.
@@ -118,6 +119,12 @@ impl<T: Data> Widget<T> for Flex<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         for child in &mut self.children {
             child.widget.event(ctx, event, data, env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        for child in &mut self.children {
+            child.widget.lifecycle(ctx, event, data, env);
         }
     }
 

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -16,7 +16,8 @@
 
 use crate::kurbo::Size;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetId,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetId,
 };
 
 /// A wrapper that adds an identity to an otherwise anonymous widget.
@@ -41,6 +42,11 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
     }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.inner.lifecycle(ctx, event, data, env)
+    }
+
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         self.inner.layout(ctx, bc, data, env)
     }

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -51,7 +51,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<T, W> {
         self.inner.event(ctx, event, data, env);
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
     }
 

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -51,12 +51,12 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<T, W> {
         self.inner.event(ctx, event, data, env);
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.inner.update(ctx, old_data, data, env);
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.inner.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.inner.update(ctx, old_data, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -111,13 +111,13 @@ impl<T: Data> LabelText<T> {
 impl<T: Data> Widget<T> for Label<T> {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
+
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         if self.text.resolve(data, env) {
             ctx.invalidate();
         }
     }
-
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -21,8 +21,8 @@ use crate::piet::{
 };
 use crate::theme;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LocalizedString, PaintCtx, UpdateCtx,
-    Widget,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    LocalizedString, PaintCtx, UpdateCtx, Widget,
 };
 
 /// The text for the label
@@ -116,6 +116,8 @@ impl<T: Data> Widget<T> for Label<T> {
             ctx.invalidate();
         }
     }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -111,7 +111,7 @@ impl<T: Data> LabelText<T> {
 impl<T: Data> Widget<T> for Label<T> {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         if self.text.resolve(data, env) {
             ctx.invalidate();
         }

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -14,12 +14,14 @@
 
 //! Simple list view widget.
 
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use crate::kurbo::{Point, Rect, Size};
 
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 /// A list widget for a variable-size collection of items.
@@ -35,6 +37,23 @@ impl<T: Data> List<T> {
         List {
             closure: Box::new(move || Box::new(closure())),
             children: Vec::new(),
+        }
+    }
+
+    /// When the widget is created or the data changes, create or remove children as needed
+    fn update_child_count(&mut self, data: &impl ListIter<T>) {
+        let len = self.children.len();
+        match len.cmp(&data.data_len()) {
+            Ordering::Greater => self.children.truncate(data.data_len()),
+            Ordering::Less => {
+                data.for_each(|_, i| {
+                    if i >= len {
+                        let child = WidgetPod::new((self.closure)());
+                        self.children.push(child);
+                    }
+                });
+            }
+            Ordering::Equal => (),
         }
     }
 }
@@ -132,29 +151,27 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         });
     }
 
-    #[allow(clippy::comparison_chain)] // clippy doesn't like our very reasonable if  { } else if { }
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+        self.update_child_count(data);
         let mut children = self.children.iter_mut();
         data.for_each(|child_data, _| {
             if let Some(child) = children.next() {
                 child.update(ctx, child_data, env);
             }
         });
+    }
 
-        let len = self.children.len();
-        if len > data.data_len() {
-            self.children.truncate(data.data_len())
-        } else if len < data.data_len() {
-            data.for_each(|child_data, i| {
-                if i < len {
-                    return;
-                }
-
-                let mut child = WidgetPod::new((self.closure)());
-                child.update(ctx, child_data, env);
-                self.children.push(child);
-            });
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        if let LifeCycle::WidgetAdded = event {
+            self.update_child_count(data);
         }
+
+        let mut children = self.children.iter_mut();
+        data.for_each(|child_data, _| {
+            if let Some(child) = children.next() {
+                child.lifecycle(ctx, event, child_data, env);
+            }
+        });
     }
 
     fn layout(

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -43,6 +43,7 @@ impl<T: Data> List<T> {
     /// When the widget is created or the data changes, create or remove children as needed
     fn update_child_count(&mut self, ctx: &mut LifeCycleCtx, data: &impl ListIter<T>, env: &Env) {
         let len = self.children.len();
+        let children_changed = len != data.data_len();
         match len.cmp(&data.data_len()) {
             Ordering::Greater => self.children.truncate(data.data_len()),
             Ordering::Less => data.for_each(|child_data, i| {
@@ -53,6 +54,9 @@ impl<T: Data> List<T> {
                 }
             }),
             Ordering::Equal => (),
+        }
+        if children_changed {
+            ctx.children_changed();
         }
     }
 }

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -41,17 +41,18 @@ impl<T: Data> List<T> {
     }
 
     /// When the widget is created or the data changes, create or remove children as needed
-    fn update_child_count(&mut self, data: &impl ListIter<T>) {
+    fn update_child_count(&mut self, ctx: &mut LifeCycleCtx, data: &impl ListIter<T>, env: &Env) {
         let len = self.children.len();
         match len.cmp(&data.data_len()) {
             Ordering::Greater => self.children.truncate(data.data_len()),
             Ordering::Less => {
-                data.for_each(|_, i| {
+                data.for_each(|child_data, i| {
                     if i >= len {
-                        let child = WidgetPod::new((self.closure)());
+                        let mut child = WidgetPod::new((self.closure)());
+                        child.lifecycle(ctx, &LifeCycle::WidgetAdded, child_data, env);
                         self.children.push(child);
                     }
-                });
+                })
             }
             Ordering::Equal => (),
         }
@@ -152,7 +153,8 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
-        self.update_child_count(data);
+        let mut life_ctx = ctx.make_lifecycle_ctx();
+        self.update_child_count(&mut life_ctx, data, env);
         let mut children = self.children.iter_mut();
         data.for_each(|child_data, _| {
             if let Some(child) = children.next() {
@@ -163,7 +165,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
-            self.update_child_count(data);
+            self.update_child_count(ctx, data, env);
         }
 
         let mut children = self.children.iter_mut();

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -154,9 +154,10 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         });
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let mut life_ctx = ctx.make_lifecycle_ctx();
         self.update_child_count(&mut life_ctx, data, env);
+
         let mut children = self.children.iter_mut();
         data.for_each(|child_data, _| {
             if let Some(child) = children.next() {

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -45,15 +45,13 @@ impl<T: Data> List<T> {
         let len = self.children.len();
         match len.cmp(&data.data_len()) {
             Ordering::Greater => self.children.truncate(data.data_len()),
-            Ordering::Less => {
-                data.for_each(|child_data, i| {
-                    if i >= len {
-                        let mut child = WidgetPod::new((self.closure)());
-                        child.lifecycle(ctx, &LifeCycle::WidgetAdded, child_data, env);
-                        self.children.push(child);
-                    }
-                })
-            }
+            Ordering::Less => data.for_each(|child_data, i| {
+                if i >= len {
+                    let mut child = WidgetPod::new((self.closure)());
+                    child.lifecycle(ctx, &LifeCycle::WidgetAdded, child_data, env);
+                    self.children.push(child);
+                }
+            }),
             Ordering::Equal => (),
         }
     }

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -152,19 +152,6 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         });
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
-        if self.update_child_count(data, env) {
-            ctx.children_changed();
-        }
-
-        let mut children = self.children.iter_mut();
-        data.for_each(|child_data, _| {
-            if let Some(child) = children.next() {
-                child.update(ctx, child_data, env);
-            }
-        });
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             if self.update_child_count(data, env) {
@@ -176,6 +163,19 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         data.for_each(|child_data, _| {
             if let Some(child) = children.next() {
                 child.lifecycle(ctx, event, child_data, env);
+            }
+        });
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        if self.update_child_count(data, env) {
+            ctx.children_changed();
+        }
+
+        let mut children = self.children.iter_mut();
+        data.for_each(|child_data, _| {
+            if let Some(child) = children.next() {
+                child.update(ctx, child_data, env);
             }
         });
     }

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -136,10 +136,10 @@ pub trait Widget<T> {
     /// (available in the [`LifeCycle`] enum) that are generally related to
     /// changes in the widget graph or in the state of your specific widget.
     ///
-    /// In general, a widget is not expected to mutate the application state
-    /// in response to these events, but only to update its own internal state
-    /// as required; if a widget needs to mutate data, it can submit a [`Command`]
-    /// that will be executed at the next opportunity.
+    /// A widget is not expected to mutate the application state in response
+    /// to these events, but only to update its own internal state as required;
+    /// if a widget needs to mutate data, it can submit a [`Command`] that will
+    /// be executed at the next opportunity.
     ///
     /// [`LifeCycle`]: struct.LifeCycle.html
     /// [`LifeCycleCtx`]: struct.LifeCycleCtx.html

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -145,7 +145,7 @@ pub trait Widget<T> {
     /// used to build resources that will be retained for painting.
     ///
     /// [`invalidate`]: struct.UpdateCtx.html#method.invalidate
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env);
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env);
 
     /// Compute layout.
     ///
@@ -207,7 +207,7 @@ impl<T> Widget<T> for Box<dyn Widget<T>> {
         self.deref_mut().event(ctx, event, data, env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.deref_mut().update(ctx, old_data, data, env);
     }
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -130,7 +130,20 @@ pub trait Widget<T> {
     /// [`Command`]: struct.Command.html
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env);
 
-    #[allow(unused_variables)]
+    /// Handle a life cycle notification.
+    ///
+    /// This method is called to notify your widget of certain special events,
+    /// (available in the [`LifeCycle`] enum) that are generally related to
+    /// changes in the widget graph or in the state of your specific widget.
+    ///
+    /// In general, a widget is not expected to mutate the application state
+    /// in response to these events, but only to update its own internal state
+    /// as required; if a widget needs to mutate data, it can submit a [`Command`]
+    /// that will be executed at the next opportunity.
+    ///
+    /// [`LifeCycle`]: struct.LifeCycle.html
+    /// [`LifeCycleCtx`]: struct.LifeCycleCtx.html
+    /// [`Command`]: struct.Command.html
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env);
 
     /// Handle a change of data.

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -213,19 +213,17 @@ impl WidgetId {
     }
 }
 
-// TODO: explore getting rid of this (ie be consistent about using
-// `dyn Widget` only).
 impl<T> Widget<T> for Box<dyn Widget<T>> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.deref_mut().event(ctx, event, data, env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.deref_mut().update(ctx, old_data, data, env);
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.deref_mut().lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.deref_mut().update(ctx, old_data, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -77,7 +77,7 @@ impl<T: Data> Widget<T> for Padding<T> {
         self.child.event(ctx, event, data, env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
     }
 

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -16,8 +16,8 @@
 
 use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetId,
-    WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
 /// A widget that just adds padding around its child.
@@ -79,6 +79,10 @@ impl<T: Data> Widget<T> for Padding<T> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     fn layout(

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -77,12 +77,12 @@ impl<T: Data> Widget<T> for Padding<T> {
         self.child.event(ctx, event, data, env)
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
-        self.child.update(ctx, data, env);
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.child.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.child.update(ctx, data, env);
     }
 
     fn layout(

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -24,19 +24,12 @@ impl<T> Parse<T> {
 }
 
 impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse<W> {
-    fn update(
-        &mut self,
-        ctx: &mut UpdateCtx,
-        old_data: Option<&Option<T>>,
-        data: &Option<T>,
-        env: &Env,
-    ) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &Option<T>, data: &Option<T>, env: &Env) {
         let old = match *data {
             None => return, // Don't clobber the input
             Some(ref x) => mem::replace(&mut self.state, x.to_string()),
         };
-        let old = old_data.map(|_| old);
-        self.widget.update(ctx, old.as_ref(), &self.state, env)
+        self.widget.update(ctx, &old, &self.state, env)
     }
 
     fn lifecycle(

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -4,7 +4,8 @@ use std::str::FromStr;
 
 use crate::kurbo::Size;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetId,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetId,
 };
 
 /// Converts a `Widget<String>` to a `Widget<Option<T>>`, mapping parse errors to None
@@ -36,6 +37,16 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
         };
         let old = old_data.map(|_| old);
         self.widget.update(ctx, old.as_ref(), &self.state, env)
+    }
+
+    fn lifecycle(
+        &mut self,
+        ctx: &mut LifeCycleCtx,
+        event: &LifeCycle,
+        _data: &Option<T>,
+        env: &Env,
+    ) {
+        self.widget.lifecycle(ctx, event, &self.state, env)
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut Option<T>, env: &Env) {

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -24,12 +24,9 @@ impl<T> Parse<T> {
 }
 
 impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse<W> {
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &Option<T>, data: &Option<T>, env: &Env) {
-        let old = match *data {
-            None => return, // Don't clobber the input
-            Some(ref x) => mem::replace(&mut self.state, x.to_string()),
-        };
-        self.widget.update(ctx, &old, &self.state, env)
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut Option<T>, env: &Env) {
+        self.widget.event(ctx, event, &mut self.state, env);
+        *data = self.state.parse().ok();
     }
 
     fn lifecycle(
@@ -42,9 +39,12 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
         self.widget.lifecycle(ctx, event, &self.state, env)
     }
 
-    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut Option<T>, env: &Env) {
-        self.widget.event(ctx, event, &mut self.state, env);
-        *data = self.state.parse().ok();
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &Option<T>, data: &Option<T>, env: &Env) {
+        let old = match *data {
+            None => return, // Don't clobber the input
+            Some(ref x) => mem::replace(&mut self.state, x.to_string()),
+        };
+        self.widget.update(ctx, &old, &self.state, env)
     }
 
     fn layout(

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -35,7 +35,7 @@ impl ProgressBar {
 impl Widget<f64> for ProgressBar {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut f64, _env: &Env) {}
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&f64>, _data: &f64, _env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &f64, _data: &f64, _env: &Env) {
         ctx.invalidate();
     }
 

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -18,8 +18,8 @@ use crate::kurbo::{Point, RoundedRect, Size};
 use crate::theme;
 use crate::widget::Align;
 use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
-    UnitPoint, UpdateCtx, Widget,
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
+    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
 };
 
 /// A progress bar, displaying a numeric progress value.
@@ -38,6 +38,8 @@ impl Widget<f64> for ProgressBar {
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&f64>, _data: &f64, _env: &Env) {
         ctx.invalidate();
     }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -35,11 +35,11 @@ impl ProgressBar {
 impl Widget<f64> for ProgressBar {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut f64, _env: &Env) {}
 
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
+
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &f64, _data: &f64, _env: &Env) {
         ctx.invalidate();
     }
-
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -20,8 +20,8 @@ use crate::kurbo::{Circle, Point, Rect, Size};
 use crate::theme;
 use crate::widget::{Align, Flex, Label, LabelText, Padding};
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
-    UnitPoint, UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
+    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A group of radio buttons
@@ -87,6 +87,8 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {
         ctx.invalidate();
     }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -81,7 +81,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {
         ctx.invalidate();
     }
 

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -77,9 +77,6 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
                     ctx.invalidate();
                 }
             }
-            Event::HotChanged(_) => {
-                ctx.invalidate();
-            }
             _ => (),
         }
     }
@@ -88,7 +85,11 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         ctx.invalidate();
     }
 
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, _env: &Env) {
+        if let LifeCycle::HotChanged(_) = event {
+            ctx.invalidate();
+        }
+    }
 
     fn layout(
         &mut self,

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -81,14 +81,14 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {
-        ctx.invalidate();
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, _env: &Env) {
         if let LifeCycle::HotChanged(_) = event {
             ctx.invalidate();
         }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {
+        ctx.invalidate();
     }
 
     fn layout(

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -360,16 +360,6 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 }
                 // Show the scrollbars any time our size changes
                 Event::Size(_) => self.reset_scrollbar_fade(ctx, &env),
-                // The scroll bars will fade immediately if there's some other widget requesting animation.
-                // Guard by the timer id being invalid.
-                Event::AnimFrame(interval) if self.scroll_bars.timer_id == TimerToken::INVALID => {
-                    // Animate scroll bars opacity
-                    let diff = 2.0 * (*interval as f64) * 1e-9;
-                    self.scroll_bars.opacity -= diff;
-                    if self.scroll_bars.opacity > 0.0 {
-                        ctx.request_anim_frame();
-                    }
-                }
                 Event::Timer(id) if *id == self.scroll_bars.timer_id => {
                     // Schedule scroll bars animation
                     ctx.request_anim_frame();
@@ -395,6 +385,18 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        // The scroll bars will fade immediately if there's some other widget requesting animation.
+        // Guard by the timer id being invalid.
+        if let LifeCycle::AnimFrame(interval) = event {
+            if self.scroll_bars.timer_id == TimerToken::INVALID {
+                // Animate scroll bars opacity
+                let diff = 2.0 * (*interval as f64) * 1e-9;
+                self.scroll_bars.opacity -= diff;
+                if self.scroll_bars.opacity > 0.0 {
+                    ctx.request_anim_frame();
+                }
+            }
+        }
         self.child.lifecycle(ctx, event, data, env)
     }
 

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -380,7 +380,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
     }
 

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -21,8 +21,8 @@ use std::time::{Duration, Instant};
 use crate::kurbo::{Affine, Point, Rect, RoundedRect, Size, Vec2};
 use crate::theme;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext, TimerToken,
-    UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    RenderContext, TimerToken, UpdateCtx, Widget, WidgetPod,
 };
 
 #[derive(Debug, Clone)]
@@ -392,6 +392,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
         self.child.update(ctx, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.child.lifecycle(ctx, event, data, env)
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -385,8 +385,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        // The scroll bars will fade immediately if there's some other widget requesting animation.
-        // Guard by the timer id being invalid.
+        // Guard by the timer id being invalid, otherwise the scroll bars would fade
+        // immediately if some other widgeet started animating.
         if let LifeCycle::AnimFrame(interval) = event {
             if self.scroll_bars.timer_id == TimerToken::INVALID {
                 // Animate scroll bars opacity

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -380,10 +380,6 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
-        self.child.update(ctx, data, env);
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         // Guard by the timer id being invalid, otherwise the scroll bars would fade
         // immediately if some other widgeet started animating.
@@ -398,6 +394,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             }
         }
         self.child.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.child.update(ctx, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -89,7 +89,7 @@ impl<T: Data> Widget<T> for SizedBox<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.update(ctx, old_data, data, env);
         }

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -18,7 +18,8 @@ use std::f64::INFINITY;
 
 use crate::shell::kurbo::Size;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget, WidgetId,
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    UpdateCtx, Widget, WidgetId,
 };
 
 /// A widget with predefined size.
@@ -91,6 +92,12 @@ impl<T: Data> Widget<T> for SizedBox<T> {
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&T>, data: &T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.update(ctx, old_data, data, env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        if let Some(ref mut inner) = self.inner {
+            inner.lifecycle(ctx, event, data, env)
         }
     }
 

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -89,15 +89,15 @@ impl<T: Data> Widget<T> for SizedBox<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        if let Some(ref mut inner) = self.inner {
-            inner.update(ctx, old_data, data, env);
-        }
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let Some(ref mut inner) = self.inner {
             inner.lifecycle(ctx, event, data, env)
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        if let Some(ref mut inner) = self.inner {
+            inner.update(ctx, old_data, data, env);
         }
     }
 

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -89,7 +89,7 @@ impl Widget<f64> for Slider {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&f64>, _data: &f64, _env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &f64, _data: &f64, _env: &Env) {
         ctx.invalidate();
     }
 

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -18,8 +18,8 @@ use crate::kurbo::{Circle, Point, Rect, RoundedRect, Shape, Size};
 use crate::theme;
 use crate::widget::Align;
 use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LinearGradient, PaintCtx, RenderContext,
-    UnitPoint, UpdateCtx, Widget,
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
+    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
 };
 
 /// A slider, allowing interactive update of a numeric value.
@@ -92,6 +92,8 @@ impl Widget<f64> for Slider {
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&f64>, _data: &f64, _env: &Env) {
         ctx.invalidate();
     }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -89,11 +89,11 @@ impl Widget<f64> for Slider {
         }
     }
 
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
+
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &f64, _data: &f64, _env: &Env) {
         ctx.invalidate();
     }
-
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -17,8 +17,8 @@
 use crate::kurbo::{Line, Point, Rect, Size};
 use crate::widget::flex::Axis;
 use crate::{
-    theme, BoxConstraints, Cursor, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, RenderContext,
-    UpdateCtx, Widget, WidgetPod,
+    theme, BoxConstraints, Cursor, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,
 };
 
 ///A container containing two other widgets, splitting the area either horizontally or vertically.
@@ -181,6 +181,11 @@ impl<T: Data> Widget<T> for Split<T> {
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
         self.child1.update(ctx, &data, env);
         self.child2.update(ctx, &data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.child1.lifecycle(ctx, event, data, env);
+        self.child2.lifecycle(ctx, event, data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -178,7 +178,7 @@ impl<T: Data> Widget<T> for Split<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&T>, data: &T, env: &Env) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         self.child1.update(ctx, &data, env);
         self.child2.update(ctx, &data, env);
     }

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -178,14 +178,14 @@ impl<T: Data> Widget<T> for Split<T> {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
-        self.child1.update(ctx, &data, env);
-        self.child2.update(ctx, &data, env);
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         self.child1.lifecycle(ctx, event, data, env);
         self.child2.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.child1.update(ctx, &data, env);
+        self.child2.update(ctx, &data, env);
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -222,11 +222,8 @@ impl Widget<f64> for Stepper {
 
     fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&f64>, data: &f64, _env: &Env) {
-        if old_data
-            .map(|old_data| (*data - old_data).abs() > EPSILON)
-            .unwrap_or(true)
-        {
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &f64, data: &f64, _env: &Env) {
+        if (*data - old_data).abs() > EPSILON {
             ctx.invalidate();
         }
     }

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -15,7 +15,8 @@
 //! A stepper widget.
 
 use crate::{
-    BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, Size, TimerToken, UpdateCtx, Widget,
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,
+    TimerToken, UpdateCtx, Widget,
 };
 use std::f64::EPSILON;
 use std::time::{Duration, Instant};
@@ -218,6 +219,8 @@ impl Widget<f64> for Stepper {
             _ => (),
         }
     }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &f64, _env: &Env) {}
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: Option<&f64>, data: &f64, _env: &Env) {
         if old_data

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -24,8 +24,8 @@ use log::error;
 use usvg;
 
 use crate::{
-    kurbo::BezPath, Affine, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx,
-    Point, Rect, RenderContext, Size, UpdateCtx, Widget,
+    kurbo::BezPath, Affine, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx,
+    LifeCycle, LifeCycleCtx, PaintCtx, Point, Rect, RenderContext, Size, UpdateCtx, Widget,
 };
 
 /// A widget that renders a SVG

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -66,7 +66,7 @@ impl<T: Data> Svg<T> {
 impl<T: Data> Widget<T> for Svg<T> {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
-    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: Option<&T>, _data: &T, _env: &Env) {}
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {}
 
     fn layout(
         &mut self,

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -66,6 +66,8 @@ impl<T: Data> Svg<T> {
 impl<T: Data> Widget<T> for Svg<T> {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &T, _env: &Env) {}
+
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {}
 
     fn layout(

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -156,10 +156,6 @@ impl Widget<bool> for Switch {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&bool>, _data: &bool, _env: &Env) {
-        ctx.invalidate();
-    }
-
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &bool, env: &Env) {
         match event {
             LifeCycle::AnimFrame(_) => {
@@ -182,6 +178,12 @@ impl Widget<bool> for Switch {
                 }
             }
             _ => (),
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &bool, data: &bool, _env: &Env) {
+        if old_data != data {
+            ctx.invalidate();
         }
     }
 

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -157,27 +157,24 @@ impl Widget<bool> for Switch {
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &bool, env: &Env) {
-        match event {
-            LifeCycle::AnimFrame(_) => {
-                let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
-                let switch_width = switch_height * SWITCH_WIDTH_RATIO;
-                let knob_size = switch_height - 2. * SWITCH_PADDING;
-                let on_pos = switch_width - knob_size / 2. - SWITCH_PADDING;
-                let off_pos = knob_size / 2. + SWITCH_PADDING;
+        if let LifeCycle::AnimFrame(_) = event {
+            let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+            let switch_width = switch_height * SWITCH_WIDTH_RATIO;
+            let knob_size = switch_height - 2. * SWITCH_PADDING;
+            let on_pos = switch_width - knob_size / 2. - SWITCH_PADDING;
+            let off_pos = knob_size / 2. + SWITCH_PADDING;
 
-                // move knob to right position depending on the value
-                if self.animation_in_progress {
-                    let delta = if *data { 2. } else { -2. };
-                    self.knob_pos.x += delta;
+            // move knob to right position depending on the value
+            if self.animation_in_progress {
+                let delta = if *data { 2. } else { -2. };
+                self.knob_pos.x += delta;
 
-                    if self.knob_pos.x > off_pos && self.knob_pos.x < on_pos {
-                        ctx.request_anim_frame();
-                    } else {
-                        self.animation_in_progress = false;
-                    }
+                if self.knob_pos.x > off_pos && self.knob_pos.x < on_pos {
+                    ctx.request_anim_frame();
+                } else {
+                    self.animation_in_progress = false;
                 }
             }
-            _ => (),
         }
     }
 

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -20,7 +20,10 @@ use crate::piet::{
 };
 use crate::theme;
 use crate::widget::Align;
-use crate::{BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget};
+use crate::{
+    BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
+    Widget,
+};
 
 const SWITCH_PADDING: f64 = 3.;
 const SWITCH_WIDTH_RATIO: f64 = 2.75;
@@ -168,6 +171,9 @@ impl Widget<bool> for Switch {
 
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&bool>, _data: &bool, _env: &Env) {
         ctx.invalidate();
+    }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &bool, _env: &Env) {
     }
 
     fn layout(

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -152,7 +152,23 @@ impl Widget<bool> for Switch {
                 }
                 ctx.invalidate();
             }
-            Event::AnimFrame(_) => {
+            _ => (),
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&bool>, _data: &bool, _env: &Env) {
+        ctx.invalidate();
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &bool, env: &Env) {
+        match event {
+            LifeCycle::AnimFrame(_) => {
+                let switch_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+                let switch_width = switch_height * SWITCH_WIDTH_RATIO;
+                let knob_size = switch_height - 2. * SWITCH_PADDING;
+                let on_pos = switch_width - knob_size / 2. - SWITCH_PADDING;
+                let off_pos = knob_size / 2. + SWITCH_PADDING;
+
                 // move knob to right position depending on the value
                 if self.animation_in_progress {
                     let delta = if *data { 2. } else { -2. };
@@ -167,13 +183,6 @@ impl Widget<bool> for Switch {
             }
             _ => (),
         }
-    }
-
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: Option<&bool>, _data: &bool, _env: &Env) {
-        ctx.invalidate();
-    }
-
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &bool, _env: &Env) {
     }
 
     fn layout(

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -21,7 +21,7 @@ use unicode_segmentation::GraphemeCursor;
 
 use crate::{
     Application, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx,
-    PaintCtx, RawMods, SysMods, TimerToken, UpdateCtx, Widget,
+    LifeCycle, LifeCycleCtx, PaintCtx, RawMods, SysMods, TimerToken, UpdateCtx, Widget,
 };
 
 use crate::kurbo::{Affine, Line, Point, RoundedRect, Size, Vec2};
@@ -368,6 +368,15 @@ impl Widget<String> for TextBox {
         _env: &Env,
     ) {
         ctx.invalidate();
+    }
+
+    fn lifecycle(
+        &mut self,
+        _ctx: &mut LifeCycleCtx,
+        _event: &LifeCycle,
+        _data: &String,
+        _env: &Env,
+    ) {
     }
 
     fn layout(

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -360,13 +360,7 @@ impl Widget<String> for TextBox {
         }
     }
 
-    fn update(
-        &mut self,
-        ctx: &mut UpdateCtx,
-        _old_data: Option<&String>,
-        _data: &String,
-        _env: &Env,
-    ) {
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {
         ctx.invalidate();
     }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -360,10 +360,6 @@ impl Widget<String> for TextBox {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {
-        ctx.invalidate();
-    }
-
     fn lifecycle(
         &mut self,
         _ctx: &mut LifeCycleCtx,
@@ -371,6 +367,10 @@ impl Widget<String> for TextBox {
         _data: &String,
         _env: &Env,
     ) {
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &String, _data: &String, _env: &Env) {
+        ctx.invalidate();
     }
 
     fn layout(

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -281,10 +281,8 @@ impl<'a, T: Data> SingleWindowState<'a, T> {
         (is_handled, request_anim)
     }
 
-    fn do_lifecycle(&mut self, event: LifeCycle, win_ctx: &mut dyn WinCtx) {
+    fn do_lifecycle(&mut self, event: LifeCycle, _win_ctx: &mut dyn WinCtx) {
         let mut ctx = LifeCycleCtx {
-            request_timer: false,
-            win_ctx,
             command_queue: self.command_queue,
             window_id: self.window_id,
             widget_id: self.window.root.id(),
@@ -533,6 +531,7 @@ impl<T: Data> AppState<T> {
             let mut update_ctx = UpdateCtx {
                 text_factory: win_ctx.text_factory(),
                 window: &state.handle,
+                command_queue: &mut self.command_queue,
                 needs_inval: false,
                 window_id: id,
                 widget_id: window.root.id(),

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -29,6 +29,7 @@ use crate::shell::{
 };
 
 use crate::app_delegate::{AppDelegate, DelegateCtx};
+use crate::bloom::Bloom;
 use crate::core::BaseState;
 use crate::menu::ContextMenu;
 use crate::theme;
@@ -284,6 +285,7 @@ impl<'a, T: Data> SingleWindowState<'a, T> {
     fn do_lifecycle(&mut self, event: LifeCycle, _win_ctx: &mut dyn WinCtx) {
         let mut ctx = LifeCycleCtx {
             command_queue: self.command_queue,
+            children: Bloom::default(),
             window_id: self.window_id,
             widget_id: self.window.root.id(),
         };
@@ -749,6 +751,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
 
     fn connected(&mut self, ctx: &mut dyn WinCtx) {
         self.do_lifecycle(LifeCycle::WidgetAdded, ctx);
+        self.do_lifecycle(LifeCycle::RegisterChildren, ctx);
         self.do_lifecycle(LifeCycle::WindowConnected, ctx);
     }
 

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -542,7 +542,6 @@ impl<T: Data> AppState<T> {
             let mut update_ctx = UpdateCtx {
                 text_factory: win_ctx.text_factory(),
                 window: handle,
-                command_queue: &mut self.command_queue,
                 needs_inval: false,
                 children_changed: false,
                 window_id: id,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -281,9 +281,10 @@ impl<'a, T: Data> SingleWindowCtx<'a, T> {
 
         let is_handled = ctx.is_handled;
         if ctx.base_state.request_focus {
-            let focus_event = Event::FocusChanged(true);
+            let mut lc_ctx = ctx.make_lifecycle_ctx();
+            let focus_event = LifeCycle::FocusChanged(true);
             self.window
-                .event(&mut ctx, &focus_event, self.data, self.env);
+                .lifecycle(&mut lc_ctx, &focus_event, self.data, self.env);
         }
         self.state.needs_inval = ctx.base_state.needs_inval;
         self.state.children_changed |= ctx.base_state.children_changed;

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -62,13 +62,13 @@ impl<T: Data> Window<T> {
         }
     }
 
+    pub fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.root.lifecycle(ctx, event, data, env);
+    }
+
     pub fn update(&mut self, update_ctx: &mut UpdateCtx, data: &T, env: &Env) {
         self.update_title(&update_ctx.window, data, env);
         self.root.update(update_ctx, data, env);
-    }
-
-    pub fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        self.root.lifecycle(ctx, event, data, env);
     }
 
     pub fn layout(&mut self, layout_ctx: &mut LayoutCtx, data: &T, env: &Env) {

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -18,8 +18,8 @@ use crate::kurbo::{Point, Rect, Size};
 use crate::shell::{Counter, WindowHandle};
 
 use crate::{
-    BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LocalizedString, MenuDesc,
-    PaintCtx, UpdateCtx, Widget, WidgetPod,
+    BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget, WidgetPod,
 };
 
 /// A unique identifier for a window.
@@ -65,6 +65,10 @@ impl<T: Data> Window<T> {
     pub fn update(&mut self, update_ctx: &mut UpdateCtx, data: &T, env: &Env) {
         self.update_title(&update_ctx.window, data, env);
         self.root.update(update_ctx, data, env);
+    }
+
+    pub fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.root.lifecycle(ctx, event, data, env);
     }
 
     pub fn layout(&mut self, layout_ctx: &mut LayoutCtx, data: &T, env: &Env) {


### PR DESCRIPTION
This is the bulk of the lifecycle changes outlined in #404.

The basic idea with 'lifecycle' is that it covers events that are about the state of the _framework_, and which generally happen as a result of the processing of some other event; they're also a place for doing certain kinds of bookkeeping.

I'm going to post some more detailed thoughts a bit later, but some things on my mind:

- 'lifecycle' is actually not a great name for this. I think I prefer the names `notification`, `notice`, `internal`, `framework`... I'm really not sure. Shorter names are good, because the signatures get hairy with say `event: Notification, ctx: NotificationCtx`, but 🤷‍♂.

- this includes a mechanism for tracking widget ids; an important detail is that custom widgets which dynamically create or remove children _must_ call the `children_changed` method available on various contexts, in order for us to correctly route events.

- this tries to 'just work', for instance the `WidgetAdded` event will be sent any time a `WidgetPod` is handling either `LifeCycle::RegisterChildren`, and `old_data` is `None`. I'm not sure if this makes sense.

Anyway: this does most of the major stuff; I think there's room for some cleanup afterwards but this feels like a good starting point.

closes #404