### PR TITLE
Unify atomically incrementing counter impls & id types

### DIFF
--- a/druid-shell/src/common_util.rs
+++ b/druid-shell/src/common_util.rs
@@ -15,6 +15,8 @@
 //! Common functions used by the backends
 
 use std::any::Any;
+use std::num::NonZeroU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Strip the access keys from the menu string.
 ///
@@ -46,5 +48,41 @@ pub(crate) trait IdleCallback: Send {
 impl<F: FnOnce(&dyn Any) + Send> IdleCallback for F {
     fn call(self: Box<F>, a: &dyn Any) {
         (*self)(a)
+    }
+}
+
+/// An incrementing counter for generating unique ids.
+///
+/// This can be used safely from multiple threads.
+///
+/// The counter will overflow if `next()` iscalled 2^64 - 2 times.
+/// If this is possible for your application, and reuse would be undesirable,
+/// use something else.
+pub struct Counter(AtomicU64);
+
+impl Counter {
+    /// Create a new counter.
+    pub const fn new() -> Counter {
+        Counter(AtomicU64::new(1))
+    }
+
+    /// Creates a new counter with a given starting value.
+    ///
+    /// # Safety
+    ///
+    /// The value must not be zero.
+    pub const unsafe fn new_unchecked(init: u64) -> Counter {
+        Counter(AtomicU64::new(init))
+    }
+
+    /// Return the next value.
+    pub fn next(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Return the next value, as a `NonZeroU64`.
+    pub fn next_nonzero(&self) -> NonZeroU64 {
+        // safe because our initial value is 1 and can only be incremented.
+        unsafe { NonZeroU64::new_unchecked(self.0.fetch_add(1, Ordering::Relaxed)) }
     }
 }

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -54,6 +54,7 @@ mod window;
 
 pub use application::Application;
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
+pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};
 pub use error::Error;
 pub use hotkey::{HotKey, KeyCompare, RawMods, SysMods};

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -16,12 +16,14 @@
 
 use std::any::Any;
 use std::cell::{Cell, RefCell};
+use std::convert::TryFrom;
 use std::ffi::c_void;
 use std::ffi::OsString;
 use std::os::raw::{c_int, c_uint};
 use std::ptr;
 use std::slice;
 use std::sync::{Arc, Mutex, Weak};
+use std::time::Instant;
 
 use gdk::{EventKey, EventMask, ModifierType, ScrollDirection, WindowExt};
 use gio::ApplicationExt;
@@ -623,9 +625,20 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
             .map(|s| FileInfo { path: s.into() })
     }
 
-    fn request_timer(&mut self, deadline: std::time::Instant) -> TimerToken {
-        let interval = time_interval_from_deadline(deadline);
-        let token = next_timer_id();
+    fn request_timer(&mut self, deadline: Instant) -> TimerToken {
+        let interval = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or_default()
+            .as_millis();
+        let interval = match u32::try_from(interval) {
+            Ok(iv) => iv,
+            Err(_) => {
+                log::warn!("timer duration exceeds gtk max of 2^32 millis");
+                u32::max_value()
+            }
+        };
+
+        let token = TimerToken::next();
 
         let handle = self.handle.clone();
 
@@ -633,14 +646,13 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
             if let Some(state) = handle.state.upgrade() {
                 if let Ok(mut handler_borrow) = state.handler.try_borrow_mut() {
                     let mut ctx = WinCtxImpl::from(&handle);
-                    handler_borrow.timer(TimerToken::new(token), &mut ctx);
+                    handler_borrow.timer(token, &mut ctx);
                     return false;
                 }
             }
             true
         });
-
-        TimerToken::new(token)
+        token
     }
 }
 
@@ -651,21 +663,6 @@ impl<'a> From<&'a WindowHandle> for WinCtxImpl<'a> {
             text: Text::new(),
         }
     }
-}
-
-fn time_interval_from_deadline(deadline: std::time::Instant) -> u32 {
-    let now = std::time::Instant::now();
-    if now >= deadline {
-        0
-    } else {
-        (deadline - now).as_millis() as u32
-    }
-}
-
-fn next_timer_id() -> usize {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    static TIMER_ID: AtomicUsize = AtomicUsize::new(1);
-    TIMER_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 fn make_gdk_cursor(cursor: &Cursor, gdk_window: &gdk::Window) -> Option<gdk::Cursor> {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -727,7 +727,7 @@ impl WndProc for MyWndProc {
                 unsafe {
                     KillTimer(hwnd, id);
                 }
-                let token = TimerToken::new(id);
+                let token = TimerToken::from_raw(id as u64);
                 self.handle.borrow().free_timer_slot(token);
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let s = s.as_mut().unwrap();
@@ -1315,12 +1315,12 @@ impl<'a> WinCtx<'a> for WinCtxImpl<'a> {
             .map(|hwnd| {
                 let (id, elapse) = self.handle.get_timer_slot(deadline);
                 unsafe {
-                    let id = SetTimer(hwnd, id.get_raw(), elapse, None);
-                    id as usize
+                    // we reuse timer ids; if this is greater than u32::max we have a problem.
+                    SetTimer(hwnd, id.into_raw() as usize, elapse, None) as u64
                 }
             })
             .unwrap_or(0);
-        TimerToken::new(id)
+        TimerToken::from_raw(id)
     }
 
     //FIXME: these two methods will be reworked to avoid reentrancy problems.

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -18,6 +18,7 @@
 
 use std::any::Any;
 
+use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error;
 use crate::keyboard::{KeyEvent, KeyModifiers};
@@ -33,18 +34,25 @@ pub type Text<'a> = <piet_common::Piet<'a> as piet_common::RenderContext>::Text;
 
 /// A token that uniquely identifies a running timer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
-pub struct TimerToken(usize);
+pub struct TimerToken(u64);
 
 impl TimerToken {
     /// A token that does not correspond to any timer.
     pub const INVALID: TimerToken = TimerToken(0);
 
-    pub(crate) const fn new(id: usize) -> TimerToken {
+    /// Create a new token.
+    pub fn next() -> TimerToken {
+        static TIMER_COUNTER: Counter = Counter::new();
+        TimerToken(TIMER_COUNTER.next())
+    }
+
+    /// Create a new token from a raw value.
+    pub const fn from_raw(id: u64) -> TimerToken {
         TimerToken(id)
     }
 
-    #[cfg(target_os = "windows")]
-    pub(crate) const fn get_raw(self) -> usize {
+    /// Get the raw value for a token.
+    pub const fn into_raw(self) -> u64 {
         self.0
     }
 }

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -14,11 +14,9 @@
 
 //! Management of multiple windows.
 
-use std::sync::atomic::{AtomicU32, Ordering};
-
 use crate::kurbo::{Point, Rect, Size};
+use crate::shell::{Counter, WindowHandle};
 
-use crate::shell::WindowHandle;
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LocalizedString, MenuDesc,
     PaintCtx, UpdateCtx, Widget, WidgetPod,
@@ -26,9 +24,7 @@ use crate::{
 
 /// A unique identifier for a window.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct WindowId(u32);
-
-static WINDOW_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
+pub struct WindowId(u64);
 
 /// Per-window state not owned by user code.
 pub struct Window<T: Data> {
@@ -102,7 +98,7 @@ impl WindowId {
     ///
     /// Do note that if we create 4 billion windows there may be a collision.
     pub fn next() -> WindowId {
-        let id = WINDOW_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-        WindowId(id)
+        static WINDOW_COUNTER: Counter = Counter::new();
+        WindowId(WINDOW_COUNTER.next())
     }
 }


### PR DESCRIPTION
We had four or five different impls of atomically incrementing counters
for generating ids. This unifies those into a single impl, and also
standardizes on `u64` as our representation for identifiers.