### PR TITLE
Focus widgets

### DIFF
--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -19,7 +19,7 @@ use crate::kurbo::{Rect, Shape, Size, Vec2};
 use druid_shell::{Clipboard, KeyEvent, KeyModifiers, TimerToken};
 
 use crate::mouse::MouseEvent;
-use crate::{Command, Target};
+use crate::{Command, Target, WidgetId};
 
 /// An event, propagated downwards during event flow.
 ///
@@ -159,6 +159,13 @@ pub enum LifeCycle {
     /// See [`is_hot`](struct.BaseState.html#method.is_hot) for
     /// discussion about the hot status.
     HotChanged(bool),
+    /// Internal: used by the framework to route the `FocusChanged` event.
+    RouteFocusChanged {
+        /// the widget that is losing focus, if any
+        old: Option<WidgetId>,
+        /// the widget that is gaining focus, if any
+        new: Option<WidgetId>,
+    },
     /// Called when the focus status changes.
     ///
     /// This will always be called immediately after an event where a widget

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -137,13 +137,27 @@ pub enum LifeCycle {
     /// This is sent after `WidgetAdded`. Widgets should handle this event if
     /// they need to do some addition setup when a window is first created.
     WindowConnected,
-    /// Sent to a widget when its children have changed.
+    /// Sent to a widget when it or any of its children have changed.
     ///
-    /// If a widget manages children, it is responsible for calling
-    /// [`LifeCycleCtx::register_child`] for each of its existing children.
+    /// This event is used to register widgets with the framework, as well
+    /// as to register widgets to participate in certain framework features.
+    ///
+    /// ## Registering children
+    ///
+    /// Container widgets (widgets which use [`WidgetPod`] to manage children)
+    /// must ensure that this event is forwarded to those children. The [`WidgetPod`]
+    /// itself will handle registering those children with the system; this is
+    /// required for things like correct routing of events.
+    ///
+    /// ## Participating in focus
+    ///
+    /// Widgets which wish to participate in automatic focus (using tab to change
+    /// focus) must handle this event and call [`LifeCycleCtx::register_for_focus`].
     ///
     /// [`LifeCycleCtx::register_child`]: struct.LifeCycleCtx.html#method.register_child
-    RegisterChildren,
+    /// [`WidgetPod`]: struct.WidgetPod.html
+    /// [`LifeCycleCtx::register_for_focus`]: struct.LifeCycleCtx.html#method.register_for_focus
+    Register,
     /// Called at the beginning of a new animation frame.
     ///
     /// On the first frame when transitioning from idle to animating, `interval`

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -21,7 +21,7 @@ use crate::shell::{Counter, WindowHandle};
 
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
-    LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget, WidgetPod,
+    LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
 /// A unique identifier for a window.
@@ -38,6 +38,7 @@ pub struct Window<T: Data> {
     pub(crate) last_anim: Option<Instant>,
     pub(crate) needs_inval: bool,
     pub(crate) children_changed: bool,
+    pub(crate) focus: Option<WidgetId>,
     // delegate?
 }
 
@@ -56,6 +57,7 @@ impl<T: Data> Window<T> {
             last_anim: None,
             needs_inval: false,
             children_changed: false,
+            focus: None,
         }
     }
 


### PR DESCRIPTION
This adds the ability for a focused widget to give focus to the next or previous focusable widget. Widgets must register to participate in this "focus chain".

This also moves to representing focus state as an `Option<WidgetId>`, uses an internal event `RouteFocusChange` to notify only the old and new focus widgets.

I quite like this pattern of routing events to specific widgets, and I think it may be useful in other places as well.

This implements this behaviour for the textbox, using tab/shift+tab for next/previous. It can be tested in the textbox example.

Currently there's no way to request a timer from the `LifeCycleCtx`, so we don't get cursor blink in textbox when it is focused in this way.