### PR TITLE
Debug paint

### DIFF
--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -15,7 +15,7 @@
 //! This example shows how to construct a basic layout.
 
 use druid::widget::{Button, Flex, Label, SizedBox, WidgetExt};
-use druid::{theme, AppLauncher, Color, LocalizedString, Widget, WindowDesc};
+use druid::{AppLauncher, Color, LocalizedString, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
     // Begin construction of vertical layout
@@ -56,9 +56,7 @@ fn main() {
     let window = WindowDesc::new(build_app)
         .title(LocalizedString::new("layout-demo-window-title").with_placeholder("Very flexible"));
     AppLauncher::with_window(window)
-        .configure_env(|env, _| {
-            env.set(theme::DEBUG_PAINT, true);
-        })
+        .debug_paint_layout()
         .use_simple_logger()
         .launch(0u32)
         .expect("launch failed");

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -15,7 +15,7 @@
 //! This example shows how to construct a basic layout.
 
 use druid::widget::{Button, Flex, Label, SizedBox, WidgetExt};
-use druid::{AppLauncher, Color, LocalizedString, Widget, WindowDesc};
+use druid::{theme, AppLauncher, Color, LocalizedString, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
     // Begin construction of vertical layout
@@ -56,6 +56,9 @@ fn main() {
     let window = WindowDesc::new(build_app)
         .title(LocalizedString::new("layout-demo-window-title").with_placeholder("Very flexible"));
     AppLauncher::with_window(window)
+        .configure_env(|env, _| {
+            env.set(theme::DEBUG_PAINT, true);
+        })
         .use_simple_logger()
         .launch(0u32)
         .expect("launch failed");

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -18,9 +18,7 @@ use std::sync::Arc;
 
 use druid::lens::{self, LensExt};
 use druid::widget::{Button, Flex, Label, List, Scroll, WidgetExt};
-use druid::{
-    theme, AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WindowDesc,
-};
+use druid::{AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
 struct AppData {
@@ -37,9 +35,7 @@ fn main() {
         right: Arc::new(vec![1, 2, 3]),
     };
     AppLauncher::with_window(main_window)
-        .configure_env(|env, _| {
-            env.set(theme::DEBUG_PAINT, true);
-        })
+        .debug_paint_layout()
         .use_simple_logger()
         .launch(data)
         .expect("launch failed");

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 
 use druid::lens::{self, LensExt};
 use druid::widget::{Button, Flex, Label, List, Scroll, WidgetExt};
-use druid::{AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WindowDesc};
+use druid::{
+    theme, AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WindowDesc,
+};
 
 #[derive(Clone, Data, Lens)]
 struct AppData {
@@ -35,6 +37,9 @@ fn main() {
         right: Arc::new(vec![1, 2, 3]),
     };
     AppLauncher::with_window(main_window)
+        .configure_env(|env, _| {
+            env.set(theme::DEBUG_PAINT, true);
+        })
         .use_simple_logger()
         .launch(data)
         .expect("launch failed");

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -101,9 +101,7 @@ impl<T: Data> AppLauncher<T> {
 
     /// Paint colorful rectangles for layout debugging.
     ///
-    /// The rectangles are the size of each widget's `PaintCtx`. The colors are
-    /// distinct per `WidgetPod`, so each non-`WidgetPod` child of a `WidgetPod`
-    /// will have the same color as its parent.
+    /// The rectangles are drawn around each widget's layout rect.
     pub fn debug_paint_layout(self) -> Self {
         self.configure_env(|env, _| {
             env.set(Env::DEBUG_PAINT, true);

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -99,6 +99,17 @@ impl<T: Data> AppLauncher<T> {
         self.ext_event_host.make_sink()
     }
 
+    /// Paint colorful rectangles for layout debugging.
+    ///
+    /// The rectangles are the size of each widget's `PaintCtx`. The colors are
+    /// distinct per `WidgetPod`, so each non-`WidgetPod` child of a `WidgetPod`
+    /// will have the same color as its parent.
+    pub fn debug_paint_layout(self) -> Self {
+        self.configure_env(|env, _| {
+            env.set(Env::DEBUG_PAINT, true);
+        })
+    }
+
     /// Build the windows and start the runloop.
     ///
     /// Returns an error if a window cannot be instantiated. This is usually

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -192,10 +192,10 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         self.inner.paint(&mut ctx, data, &env);
 
         if env.get(Env::DEBUG_PAINT) {
-            let rect = Rect::from_origin_size(Point::ORIGIN, paint_ctx.size());
+            let rect = Rect::from_origin_size(Point::ORIGIN, ctx.size());
             let id = self.id().to_raw();
             let color = env.get_debug_color(id);
-            paint_ctx.stroke(rect, &color, 1.0);
+            ctx.stroke(rect, &color, 1.0);
         }
     }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -19,10 +19,10 @@ use std::collections::VecDeque;
 use log;
 
 use crate::bloom::Bloom;
-use crate::kurbo::{Affine, Rect, Shape, Point, Size};
+use crate::kurbo::{Affine, Point, Rect, Shape, Size};
 use crate::piet::RenderContext;
 use crate::{
-    theme, BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
     PaintCtx, Target, UpdateCtx, Widget, WidgetId,
 };
 
@@ -191,9 +191,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         };
         self.inner.paint(&mut ctx, data, &env);
 
-        if env.get(theme::DEBUG_PAINT) {
+        if env.get(Env::DEBUG_PAINT) {
             let rect = Rect::from_origin_size(Point::ORIGIN, paint_ctx.size());
-            let id: u64 = u64::from(self.id());
+            let id = self.id().to_raw();
             let color = env.get_debug_color(id);
             paint_ctx.stroke(rect, &color, 1.0);
         }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -19,10 +19,10 @@ use std::collections::VecDeque;
 use log;
 
 use crate::bloom::Bloom;
-use crate::kurbo::{Affine, Rect, Shape, Size};
+use crate::kurbo::{Affine, Rect, Shape, Point, Size};
 use crate::piet::RenderContext;
 use crate::{
-    BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    theme, BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
     PaintCtx, Target, UpdateCtx, Widget, WidgetId,
 };
 
@@ -190,6 +190,13 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             focus_widget: paint_ctx.focus_widget,
         };
         self.inner.paint(&mut ctx, data, &env);
+
+        if env.get(theme::DEBUG_PAINT) {
+            let rect = Rect::from_origin_size(Point::ORIGIN, paint_ctx.size());
+            let id: u64 = u64::from(self.id());
+            let color = env.get_debug_color(id);
+            paint_ctx.stroke(rect, &color, 1.0);
+        }
     }
 
     /// Paint the widget, translating it by the origin of its layout rectangle.

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -43,6 +43,7 @@ pub struct Env(Arc<EnvImpl>);
 #[derive(Clone)]
 struct EnvImpl {
     map: HashMap<String, Value>,
+    debug_colors: HashMap<u64, Color>,
     l10n: Arc<L10nManager>,
 }
 
@@ -70,6 +71,7 @@ pub enum Value {
     Color(Color),
     LinearGradient(Arc<LinearGradient>),
     Float(f64),
+    Bool(bool),
     UnsignedInt(u64),
     String(String),
 }
@@ -165,6 +167,12 @@ impl Env {
     pub(crate) fn localization_manager(&self) -> &L10nManager {
         &self.0.l10n
     }
+
+    /// Given an id, returns one of 18 distinct colors
+    pub(crate) fn get_debug_color(&self, id: u64) -> Color {
+        let color_num = id % self.0.debug_colors.len() as u64;
+        self.0.debug_colors.get(&color_num).unwrap().clone()
+    }
 }
 
 impl<T> Key<T> {
@@ -210,6 +218,7 @@ impl Value {
             (Color(_), Color(_)) => true,
             (LinearGradient(_), LinearGradient(_)) => true,
             (Float(_), Float(_)) => true,
+            (Bool(_), Bool(_)) => true,
             (UnsignedInt(_), UnsignedInt(_)) => true,
             (String(_), String(_)) => true,
             _ => false,
@@ -226,6 +235,7 @@ impl Debug for Value {
             Value::Color(c) => write!(f, "Color {:?}", c),
             Value::LinearGradient(g) => write!(f, "LinearGradient {:?}", g),
             Value::Float(x) => write!(f, "Float {}", x),
+            Value::Bool(b) => write!(f, "Bool {}", b),
             Value::UnsignedInt(x) => write!(f, "UnsignedInt {}", x),
             Value::String(s) => write!(f, "String {:?}", s),
         }
@@ -244,6 +254,7 @@ impl Data for Value {
             (Color(c1), Color(c2)) => c1.as_rgba_u32() == c2.as_rgba_u32(),
             (LinearGradient(g1), LinearGradient(g2)) => Arc::ptr_eq(g1, g2),
             (Float(f1), Float(f2)) => f1.same(&f2),
+            (Bool(b1), Bool(b2)) => b1 == b2,
             (UnsignedInt(f1), UnsignedInt(f2)) => f1.same(&f2),
             (String(s1), String(s2)) => s1 == s2,
             _ => false,
@@ -270,9 +281,33 @@ impl Data for EnvImpl {
 impl Default for Env {
     fn default() -> Self {
         let l10n = L10nManager::new(vec!["builtin.ftl".into()], "./resources/i18n/");
+
+        // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
+        // They're picked for visual distinction and accessbility (99 percent)
+        let mut debug_colors = HashMap::new();
+        debug_colors.insert(0, Color::rgb8(230, 25, 75));
+        debug_colors.insert(1, Color::rgb8(60, 180, 75));
+        debug_colors.insert(2, Color::rgb8(255, 225, 25));
+        debug_colors.insert(3, Color::rgb8(0, 130, 200));
+        debug_colors.insert(4, Color::rgb8(245, 130, 48));
+        debug_colors.insert(5, Color::rgb8(70, 240, 240));
+        debug_colors.insert(6, Color::rgb8(240, 50, 230));
+        debug_colors.insert(7, Color::rgb8(250, 190, 190));
+        debug_colors.insert(8, Color::rgb8(0, 128, 128));
+        debug_colors.insert(9, Color::rgb8(230, 190, 255));
+        debug_colors.insert(10, Color::rgb8(170, 110, 40));
+        debug_colors.insert(11, Color::rgb8(255, 250, 200));
+        debug_colors.insert(12, Color::rgb8(128, 0, 0));
+        debug_colors.insert(13, Color::rgb8(170, 255, 195));
+        debug_colors.insert(14, Color::rgb8(0, 0, 128));
+        debug_colors.insert(15, Color::rgb8(128, 128, 128));
+        debug_colors.insert(16, Color::rgb8(255, 255, 255));
+        debug_colors.insert(17, Color::rgb8(0, 0, 0));
+
         let inner = EnvImpl {
             l10n: Arc::new(l10n),
             map: HashMap::new(),
+            debug_colors,
         };
         Env(Arc::new(inner))
     }
@@ -373,6 +408,7 @@ macro_rules! impl_value_type_arc {
 }
 
 impl_value_type_owned!(f64, Float);
+impl_value_type_owned!(bool, Bool);
 impl_value_type_owned!(u64, UnsignedInt);
 impl_value_type_owned!(Color, Color);
 impl_value_type_owned!(Rect, Rect);

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -43,7 +43,7 @@ pub struct Env(Arc<EnvImpl>);
 #[derive(Clone)]
 struct EnvImpl {
     map: HashMap<String, Value>,
-    debug_colors: HashMap<u64, Color>,
+    debug_colors: Vec<Color>,
     l10n: Arc<L10nManager>,
 }
 
@@ -170,9 +170,17 @@ impl Env {
 
     /// Given an id, returns one of 18 distinct colors
     pub(crate) fn get_debug_color(&self, id: u64) -> Color {
-        let color_num = id % self.0.debug_colors.len() as u64;
-        self.0.debug_colors.get(&color_num).unwrap().clone()
+        let color_num = id as usize % self.0.debug_colors.len();
+        self.0.debug_colors[color_num].clone()
     }
+
+    /// State for whether or not to paint colorful rectangles for layout
+    /// debugging.
+    ///
+    /// Set by the `debug_paint_layout()` method on [`AppLauncher`]'.
+    ///
+    /// [`AppLauncher`]: struct.AppLauncher.html
+    pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("debug_paint");
 }
 
 impl<T> Key<T> {
@@ -284,32 +292,34 @@ impl Default for Env {
 
         // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
         // They're picked for visual distinction and accessbility (99 percent)
-        let mut debug_colors = HashMap::new();
-        debug_colors.insert(0, Color::rgb8(230, 25, 75));
-        debug_colors.insert(1, Color::rgb8(60, 180, 75));
-        debug_colors.insert(2, Color::rgb8(255, 225, 25));
-        debug_colors.insert(3, Color::rgb8(0, 130, 200));
-        debug_colors.insert(4, Color::rgb8(245, 130, 48));
-        debug_colors.insert(5, Color::rgb8(70, 240, 240));
-        debug_colors.insert(6, Color::rgb8(240, 50, 230));
-        debug_colors.insert(7, Color::rgb8(250, 190, 190));
-        debug_colors.insert(8, Color::rgb8(0, 128, 128));
-        debug_colors.insert(9, Color::rgb8(230, 190, 255));
-        debug_colors.insert(10, Color::rgb8(170, 110, 40));
-        debug_colors.insert(11, Color::rgb8(255, 250, 200));
-        debug_colors.insert(12, Color::rgb8(128, 0, 0));
-        debug_colors.insert(13, Color::rgb8(170, 255, 195));
-        debug_colors.insert(14, Color::rgb8(0, 0, 128));
-        debug_colors.insert(15, Color::rgb8(128, 128, 128));
-        debug_colors.insert(16, Color::rgb8(255, 255, 255));
-        debug_colors.insert(17, Color::rgb8(0, 0, 0));
+        let debug_colors = vec![
+            Color::rgb8(230, 25, 75),
+            Color::rgb8(60, 180, 75),
+            Color::rgb8(255, 225, 25),
+            Color::rgb8(0, 130, 200),
+            Color::rgb8(245, 130, 48),
+            Color::rgb8(70, 240, 240),
+            Color::rgb8(240, 50, 230),
+            Color::rgb8(250, 190, 190),
+            Color::rgb8(0, 128, 128),
+            Color::rgb8(230, 190, 255),
+            Color::rgb8(170, 110, 40),
+            Color::rgb8(255, 250, 200),
+            Color::rgb8(128, 0, 0),
+            Color::rgb8(170, 255, 195),
+            Color::rgb8(0, 0, 128),
+            Color::rgb8(128, 128, 128),
+            Color::rgb8(255, 255, 255),
+            Color::rgb8(0, 0, 0),
+        ];
 
         let inner = EnvImpl {
             l10n: Arc::new(l10n),
             map: HashMap::new(),
             debug_colors,
         };
-        Env(Arc::new(inner))
+
+        Env(Arc::new(inner)).adding(Env::DEBUG_PAINT, false)
     }
 }
 

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -50,6 +50,8 @@ pub const SCROLL_BAR_PAD: Key<f64> = Key::new("scroll_bar_pad");
 pub const SCROLL_BAR_RADIUS: Key<f64> = Key::new("scroll_bar_radius");
 pub const SCROLL_BAR_EDGE_WIDTH: Key<f64> = Key::new("scroll_bar_edge_width");
 
+pub const DEBUG_PAINT: Key<bool> = Key::new("debug_paint");
+
 /// An initial theme.
 pub fn init() -> Env {
     let mut env = Env::default()
@@ -78,7 +80,8 @@ pub fn init() -> Env {
         .adding(SCROLL_BAR_WIDTH, 8.)
         .adding(SCROLL_BAR_PAD, 2.)
         .adding(SCROLL_BAR_RADIUS, 5.)
-        .adding(SCROLL_BAR_EDGE_WIDTH, 1.);
+        .adding(SCROLL_BAR_EDGE_WIDTH, 1.)
+        .adding(DEBUG_PAINT, false);
 
     #[cfg(target_os = "windows")]
     {

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -50,8 +50,6 @@ pub const SCROLL_BAR_PAD: Key<f64> = Key::new("scroll_bar_pad");
 pub const SCROLL_BAR_RADIUS: Key<f64> = Key::new("scroll_bar_radius");
 pub const SCROLL_BAR_EDGE_WIDTH: Key<f64> = Key::new("scroll_bar_edge_width");
 
-pub const DEBUG_PAINT: Key<bool> = Key::new("debug_paint");
-
 /// An initial theme.
 pub fn init() -> Env {
     let mut env = Env::default()
@@ -80,8 +78,7 @@ pub fn init() -> Env {
         .adding(SCROLL_BAR_WIDTH, 8.)
         .adding(SCROLL_BAR_PAD, 2.)
         .adding(SCROLL_BAR_RADIUS, 5.)
-        .adding(SCROLL_BAR_EDGE_WIDTH, 1.)
-        .adding(DEBUG_PAINT, false);
+        .adding(SCROLL_BAR_EDGE_WIDTH, 1.);
 
     #[cfg(target_os = "windows")]
     {

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -259,11 +259,9 @@ impl WidgetId {
         // safety: by construction this can never be zero.
         WidgetId(unsafe { std::num::NonZeroU64::new_unchecked(id) })
     }
-}
 
-impl From<WidgetId> for u64 {
-    fn from(id: WidgetId) -> u64 {
-        id.0.into()
+    pub(crate) fn to_raw(self) -> u64 {
+        self.0.into()
     }
 }
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -261,6 +261,12 @@ impl WidgetId {
     }
 }
 
+impl From<WidgetId> for u64 {
+    fn from(id: WidgetId) -> u64 {
+        id.0.into()
+    }
+}
+
 impl<T> Widget<T> for Box<dyn Widget<T>> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         self.deref_mut().event(ctx, event, data, env)


### PR DESCRIPTION
Here's a proof of concept for #487. Biggest potential issue is the fact that Widgets inside a WidgetPod have their borders drawn with the same color as their direct WidgetPod parent, because WidgetPods are the only things that receive new IDs.
<img width="612" alt="Screen Shot 2020-01-29 at 10 49 46 AM" src="https://user-images.githubusercontent.com/543668/73392282-55c53c00-428e-11ea-8960-0f3f5e88eba7.png">

<img width="677" alt="Screen Shot 2020-01-29 at 10 46 52 AM" src="https://user-images.githubusercontent.com/543668/73392400-9cb33180-428e-11ea-8693-111878265278.png">


Currently I have debug paint enabled in the layout and list examples. It's pretty easy to enable:
```
        .configure_env(|env, _| {
            env.set(theme::DEBUG_PAINT, true);
        })
```

Seems weird that DEBUG_PAINT is in theme, but I don't know of another place we're setting env values like that.