### PR TITLE
Handle focus change in window.rs

### DIFF
--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -204,8 +204,6 @@ pub trait Widget<T> {
 
 impl WidgetId {
     /// Allocate a new, unique widget id.
-    ///
-    /// Do note that if we create 4 billion widgets there may be a collision.
     pub(crate) fn next() -> WidgetId {
         use crate::shell::Counter;
         static WIDGET_ID_COUNTER: Counter = Counter::new();

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -247,21 +247,7 @@ impl<'a, T: Data> SingleWindowCtx<'a, T> {
             focus_widget: self.window.focus,
         };
         self.window.event(&mut ctx, &event, self.data, self.env);
-
-        let is_handled = ctx.is_handled;
-
-        if let Some(focus_req) = ctx.base_state.request_focus.take() {
-            let old = self.window.focus;
-            let new = self.window.widget_for_focus_request(focus_req);
-            self.do_lifecycle(LifeCycle::RouteFocusChanged { old, new });
-            self.window.focus = new;
-        }
-
-        if let Some(cursor) = cursor {
-            win_ctx.set_cursor(&cursor);
-        }
-
-        is_handled
+        ctx.is_handled
     }
 
     fn do_lifecycle(&mut self, event: LifeCycle) -> bool {


### PR DESCRIPTION
Another little bit of cleanup to try and isolate to the window whatever we can; this is motivated by some upcoming testing support, where we will create a window and sent it events. The more logic that lives in the window, the more consistent our testing environment will be with our real one.