### PR TITLE
set widget id explicitly

### DIFF
--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -157,7 +157,9 @@ fn main() {
         .expect("launch failed");
 }
 
-/// A constant widget id, that might be reused.
+/// A constant `WidgetId`. This may be passed around and can be reused when
+/// rebuilding a widget graph; however it should only ever be associated with
+/// a single widget at a time.
 const ID_ONE: WidgetId = WidgetId::reserved(1);
 
 fn make_ui() -> impl Widget<OurData> {

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -157,8 +157,11 @@ fn main() {
         .expect("launch failed");
 }
 
+/// A constant widget id, that might be reused.
+const ID_ONE: WidgetId = WidgetId::reserved(1);
+
 fn make_ui() -> impl Widget<OurData> {
-    let id_one = WidgetId::next();
+    // two ids generated at runtime
     let id_two = WidgetId::next();
     let id_three = WidgetId::next();
 
@@ -166,17 +169,17 @@ fn make_ui() -> impl Widget<OurData> {
         .with_child(ColorWell::new(true).padding(10.0), 1.0)
         .with_child(
             Flex::row()
-                .with_child(ColorWell::new(false).padding(10.).with_id(id_one), 1.0)
+                .with_child(ColorWell::new(false).padding(10.).with_id(ID_ONE), 1.0)
                 .with_child(
                     Button::<OurData>::new("freeze", move |ctx, data, _env| {
-                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_one)
+                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), ID_ONE)
                     })
                     .padding(10.0),
                     0.5,
                 )
                 .with_child(
                     Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
-                        ctx.submit_command(UNFREEZE_COLOR, id_one)
+                        ctx.submit_command(UNFREEZE_COLOR, ID_ONE)
                     })
                     .padding(10.0),
                     0.5,

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -30,7 +30,7 @@
 use std::time::{Duration, Instant};
 
 use druid::kurbo::RoundedRect;
-use druid::widget::{Button, Flex, IdentityWrapper, WidgetExt};
+use druid::widget::{Button, Flex, WidgetExt, WidgetId};
 use druid::{
     AppLauncher, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, LayoutCtx, Lens,
     LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size,
@@ -158,14 +158,15 @@ fn main() {
 }
 
 fn make_ui() -> impl Widget<OurData> {
-    let (id_one, one) = IdentityWrapper::wrap(ColorWell::new(false).padding(10.));
-    let (id_two, two) = IdentityWrapper::wrap(ColorWell::new(false).padding(10.));
-    let (id_three, three) = IdentityWrapper::wrap(ColorWell::new(false).padding(10.));
+    let id_one = WidgetId::next();
+    let id_two = WidgetId::next();
+    let id_three = WidgetId::next();
+
     Flex::column()
         .with_child(ColorWell::new(true).padding(10.0), 1.0)
         .with_child(
             Flex::row()
-                .with_child(one, 1.0)
+                .with_child(ColorWell::new(false).padding(10.).with_id(id_one), 1.0)
                 .with_child(
                     Button::<OurData>::new("freeze", move |ctx, data, _env| {
                         ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_one)
@@ -184,7 +185,7 @@ fn make_ui() -> impl Widget<OurData> {
         )
         .with_child(
             Flex::row()
-                .with_child(two, 1.)
+                .with_child(ColorWell::new(false).padding(10.).with_id(id_two), 1.)
                 .with_child(
                     Button::<OurData>::new("freeze", move |ctx, data, _env| {
                         ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_two)
@@ -203,7 +204,7 @@ fn make_ui() -> impl Widget<OurData> {
         )
         .with_child(
             Flex::row()
-                .with_child(three, 1.)
+                .with_child(ColorWell::new(false).padding(10.0).with_id(id_three), 1.)
                 .with_child(
                     Button::<OurData>::new("freeze", move |ctx, data, _env| {
                         ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_three)

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -535,24 +535,23 @@ mod tests {
     use crate::widget::{Flex, Scroll, Split, TextBox, WidgetExt};
     use crate::WindowId;
 
+    const ID_1: WidgetId = WidgetId::reserved(0);
+    const ID_2: WidgetId = WidgetId::reserved(1);
+    const ID_3: WidgetId = WidgetId::reserved(2);
+
     #[test]
     fn register_children() {
-        fn make_widgets() -> (WidgetId, WidgetId, WidgetId, impl Widget<Option<u32>>) {
-            let id1 = WidgetId::next();
-            let id2 = WidgetId::next();
-            let id3 = WidgetId::next();
-            eprintln!("{:?}, {:?}, {:?}", id1, id2, id3);
-            let widget = Split::vertical(
+        fn make_widgets() -> impl Widget<Option<u32>> {
+            Split::vertical(
                 Flex::<Option<u32>>::row()
-                    .with_child(TextBox::raw().with_id(id1).parse(), 1.0)
-                    .with_child(TextBox::raw().with_id(id2).parse(), 1.0)
-                    .with_child(TextBox::raw().with_id(id3).parse(), 1.0),
+                    .with_child(TextBox::raw().with_id(ID_1).parse(), 1.0)
+                    .with_child(TextBox::raw().with_id(ID_2).parse(), 1.0)
+                    .with_child(TextBox::raw().with_id(ID_3).parse(), 1.0),
                 Scroll::new(TextBox::raw().parse()),
-            );
-            (id1, id2, id3, widget)
+            )
         }
 
-        let (id1, id2, id3, widget) = make_widgets();
+        let widget = make_widgets();
         let mut widget = WidgetPod::new(widget).boxed();
 
         let mut command_queue: CommandQueue = VecDeque::new();
@@ -570,9 +569,9 @@ mod tests {
         let env = Env::default();
 
         widget.lifecycle(&mut ctx, &LifeCycle::Register, &None, &env);
-        assert!(ctx.children.contains(&id1));
-        assert!(ctx.children.contains(&id2));
-        assert!(ctx.children.contains(&id3));
+        assert!(ctx.children.contains(&ID_1));
+        assert!(ctx.children.contains(&ID_2));
+        assert!(ctx.children.contains(&ID_3));
         assert_eq!(ctx.children.entry_count(), 7);
     }
 }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -532,21 +532,21 @@ impl BaseState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::widget::{Flex, IdentityWrapper, Scroll, Split, TextBox, WidgetExt};
-    use crate::{WidgetId, WindowId};
+    use crate::widget::{Flex, Scroll, Split, TextBox, WidgetExt};
+    use crate::WindowId;
 
     #[test]
     fn register_children() {
         fn make_widgets() -> (WidgetId, WidgetId, WidgetId, impl Widget<Option<u32>>) {
-            let (id1, t1) = IdentityWrapper::wrap(TextBox::raw().parse());
-            let (id2, t2) = IdentityWrapper::wrap(TextBox::raw().parse());
-            let (id3, t3) = IdentityWrapper::wrap(TextBox::raw().parse());
+            let id1 = WidgetId::next();
+            let id2 = WidgetId::next();
+            let id3 = WidgetId::next();
             eprintln!("{:?}, {:?}, {:?}", id1, id2, id3);
             let widget = Split::vertical(
-                Flex::row()
-                    .with_child(t1, 1.0)
-                    .with_child(t2, 1.0)
-                    .with_child(t3, 1.0),
+                Flex::<Option<u32>>::row()
+                    .with_child(TextBox::raw().with_id(id1).parse(), 1.0)
+                    .with_child(TextBox::raw().with_id(id2).parse(), 1.0)
+                    .with_child(TextBox::raw().with_id(id3).parse(), 1.0),
                 Scroll::new(TextBox::raw().parse()),
             );
             (id1, id2, id3, widget)

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -74,7 +74,35 @@ use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
 };
 
-/// A unique identifier for a single widget.
+/// A unique identifier for a single [`Widget`].
+///
+/// `WidgetId`s are generated automatically for all widgets that participate
+/// in layout. More specifically, each [`WidgetPod`] has a unique `WidgetId`.
+///
+/// These ids are used internally to route events, and can be used to communicate
+/// between widgets, by submitting a command (as with [`EventCtx::submit_command`])
+/// and passing a `WidgetId` as the [`Target`].
+///
+/// A widget can retrieve its id via methods on the various contexts, such as
+/// [`LifeCycleCtx::widget_id`].
+///
+/// ## Explicit `WidgetId`s.
+///
+/// Sometimes, you may want to know a widget's id when constructing the widget.
+/// You can give a widget an _explicit_ id by wrapping it in an [`IdentityWrapper`]
+/// widget, or by using the [`WidgetExt::with_id`] convenience method.
+///
+/// If you set a `WidgetId` directly, you are resposible for ensuring that it
+/// is unique in time. That is: only one widget can exist with a given id at a
+/// given time.
+///
+/// [`Widget`]: trait.Widget.html
+/// [`EventCtx::submit_command`]: ../struct.EventCtx.html#method.submit_command
+/// [`Target`]: ../enum.Target.html
+/// [`WidgetPod`]: ../struct.WidgetPod.html
+/// [`LifeCycleCtx::widget_id`]: ../struct.LifeCycleCtx.html#method.id
+/// [`WidgetExt::with_id`]: ../trait.WidgetExt.html#tymethod.with_id
+/// [`IdentityWrapper`]: struct.IdentityWrapper.html
 // this is NonZeroU64 because we regularly store Option<WidgetId>
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct WidgetId(NonZeroU64);
@@ -203,7 +231,14 @@ pub trait Widget<T> {
 }
 
 impl WidgetId {
-    /// Allocate a new, unique widget id.
+    /// Allocate a new, unique `WidgetId`.
+    ///
+    /// All widgets are assigned ids automatically; you should only create
+    /// an explicit id if you need to know it ahead of time, for instance
+    /// if you want two sibling widgets to know each others' ids.
+    ///
+    /// You must ensure that a given `WidgetId` is only ever used for one
+    /// widget at a time.
     pub fn next() -> WidgetId {
         use crate::shell::Counter;
         static WIDGET_ID_COUNTER: Counter = Counter::new();

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -209,6 +209,21 @@ impl WidgetId {
         static WIDGET_ID_COUNTER: Counter = Counter::new();
         WidgetId(WIDGET_ID_COUNTER.next_nonzero())
     }
+
+    /// Create a reserved `WidgetId`, suitable for reuse.
+    ///
+    /// The caller is responsible for ensuring that this ID is in fact assigned
+    /// to a single widget at any time, or your code may become haunted.
+    ///
+    /// The actual inner representation of the returned `WidgetId` will not
+    /// be the same as the raw value that is passed in; it will be
+    /// `u64::max_value() - raw`.
+    #[allow(unsafe_code)]
+    pub const fn reserved(raw: u16) -> WidgetId {
+        let id = u64::max_value() - raw as u64;
+        // safety: by construction this can never be zero.
+        WidgetId(unsafe { std::num::NonZeroU64::new_unchecked(id) })
+    }
 }
 
 impl<T> Widget<T> for Box<dyn Widget<T>> {

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -204,7 +204,7 @@ pub trait Widget<T> {
 
 impl WidgetId {
     /// Allocate a new, unique widget id.
-    pub(crate) fn next() -> WidgetId {
+    pub fn next() -> WidgetId {
         use crate::shell::Counter;
         static WIDGET_ID_COUNTER: Counter = Counter::new();
         WidgetId(WIDGET_ID_COUNTER.next_nonzero())

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -17,7 +17,7 @@
 use crate::kurbo::Insets;
 use crate::piet::{PaintBrush, UnitPoint};
 
-use super::{Align, Container, EnvScope, Padding, Parse, SizedBox};
+use super::{Align, Container, EnvScope, IdentityWrapper, Padding, Parse, SizedBox, WidgetId};
 use crate::{Data, Env, Lens, LensWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
@@ -138,6 +138,11 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
         Self: Widget<String>,
     {
         Parse::new(self)
+    }
+
+    /// Assign the widget a specific `WidgetId`.
+    fn with_id(self, id: WidgetId) -> IdentityWrapper<Self> {
+        IdentityWrapper::wrap(self, id)
     }
 
     /// Wrap this widget in a `Box`.

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -140,7 +140,15 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
         Parse::new(self)
     }
 
-    /// Assign the widget a specific `WidgetId`.
+    /// Assign the widget a specific [`WidgetId`].
+    ///
+    /// You must ensure that a given [`WidgetId`] is only ever used for
+    /// a single widget at a time.
+    ///
+    /// An id _may_ be reused over time; for instance if you replace one
+    /// widget with another, you may reuse the first widget's id.
+    ///
+    /// [`WidgetId`]: struct.WidgetId.html
     fn with_id(self, id: WidgetId) -> IdentityWrapper<Self> {
         IdentityWrapper::wrap(self, id)
     }


### PR DESCRIPTION
After some more thought, I think this does need to be pass-in, so that you can do things like,

```rust
const MY_ID: WidgetId = WIdgetId::reserved(1);

fn make_widget() -> impl Widget<u32> {
    CustomWidget::new().with_id(MY_ID).padding(5.0).center()
}

fn main() {
   let window = WindowDesc::new(make_widget).initial_focus(MY_ID);
}
```