### PR TITLE
Testing tools

### DIFF
--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -71,3 +71,6 @@ pub use mouse::MouseEvent;
 pub use widget::{Widget, WidgetId};
 pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};
+
+#[cfg(test)]
+pub(crate) use event::StateCell;

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -36,6 +36,8 @@ pub mod lens;
 mod localization;
 mod menu;
 mod mouse;
+#[cfg(test)]
+mod tests;
 mod text;
 pub mod theme;
 pub mod widget;

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -1,0 +1,136 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tools and infrastructure for testing widgets.
+
+use crate::core::{BaseState, CommandQueue};
+use crate::piet::{Device, Piet};
+use crate::*;
+
+/// Mother, tell me: where do contexts come from?
+struct Mocks<'a> {
+    ctx: MockWinCtx<'a>,
+    handle: WindowHandle,
+    command_queue: CommandQueue,
+    cursor: Option<Cursor>,
+    base_state: BaseState,
+    window_id: WindowId,
+}
+
+/// A `WinCtx` impl that we can conjure from the ether.
+pub struct MockWinCtx<'a> {
+    piet: Piet<'a>,
+}
+
+impl<'a> WinCtx<'a> for MockWinCtx<'a> {
+    fn invalidate(&mut self) {}
+    fn text_factory(&mut self) -> &mut Text {
+        self.piet.text()
+    }
+
+    fn set_cursor(&mut self, cursor: &Cursor) {}
+    //TODO: we could actually implement timers if we were ambitious
+    fn request_timer(&mut self, _deadline: std::time::Instant) -> TimerToken {
+        TimerToken::next()
+    }
+    fn open_file_sync(&mut self, _: FileDialogOptions) -> Option<FileInfo> {
+        None
+    }
+    fn save_as_sync(&mut self, _: FileDialogOptions) -> Option<FileInfo> {
+        None
+    }
+}
+
+impl<'a> MockWinCtx<'a> {
+    fn new(piet: Piet<'a>) -> Self {
+        MockWinCtx { piet }
+    }
+}
+
+impl<'a> Mocks<'a> {
+    fn with_mocks(mut f: impl FnMut(&mut Mocks)) {
+        let mut device = Device::new().expect("harness failed to get device");
+        let mut target = device
+            .bitmap_target(400, 400, 100.)
+            .expect("harness failed to create target");
+        let ctx = MockWinCtx::new(target.render_context());
+        let mut mocks = Mocks {
+            ctx,
+            handle: Default::default(),
+            command_queue: Default::default(),
+            cursor: Default::default(),
+            base_state: BaseState::new(WidgetId::next()),
+            //FIXME: makee these const or someethign idk
+            window_id: WindowId::next(),
+        };
+
+        f(&mut mocks);
+    }
+
+    fn event_ctx<'me>(&'me mut self) -> EventCtx<'me, 'a> {
+        EventCtx {
+            win_ctx: &mut self.ctx,
+            cursor: &mut self.cursor,
+            command_queue: &mut self.command_queue,
+            window_id: self.window_id,
+            window: &self.handle,
+            base_state: &mut self.base_state,
+            focus_widget: None,
+            had_active: false,
+            is_handled: false,
+            is_root: true,
+        }
+    }
+
+    fn lifecycle_ctx(&mut self) -> LifeCycleCtx {
+        LifeCycleCtx {
+            command_queue: &mut self.command_queue,
+            children: Default::default(),
+            window_id: self.window_id,
+            widget_id: self.base_state.id,
+            focus_widgets: Vec::new(),
+            request_anim: false,
+            needs_inval: false,
+            children_changed: false,
+        }
+    }
+
+    fn update_ctx(&mut self) -> UpdateCtx {
+        UpdateCtx {
+            text_factory: self.ctx.text_factory(),
+            window: &self.handle,
+            needs_inval: false,
+            children_changed: false,
+            window_id: self.window_id,
+            widget_id: self.base_state.id,
+        }
+    }
+
+    fn layout_ctx(&mut self) -> LayoutCtx {
+        LayoutCtx {
+            text_factory: self.ctx.text_factory(),
+            window_id: self.window_id,
+        }
+    }
+
+    fn paint_ctx<'me>(&'me mut self) -> PaintCtx<'me, 'a> {
+        PaintCtx {
+            render_ctx: &mut self.ctx.piet,
+            window_id: self.window_id,
+            region: Rect::ZERO.into(),
+            base_state: &self.base_state,
+            focus_widget: None,
+        }
+    }
+}

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -76,6 +76,14 @@ impl<T: Data> Harness<T> {
         f(&mut mocks);
     }
 
+    /// Retrieve a copy of this widget's `BaseState`, if possible.
+    pub(crate) fn get_state(&mut self, widget: WidgetId) -> Option<BaseState> {
+        let cell = StateCell::default();
+        let state_cell = cell.clone();
+        self.lifecycle(LifeCycle::DebugRequestState { widget, state_cell });
+        cell.take()
+    }
+
     /// Send the events that would normally be sent when the app starts.
     // should we do this automatically? Also these will change regularly?
     #[allow(dead_code)]

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -15,31 +15,207 @@
 //! Tools and infrastructure for testing widgets.
 
 use crate::core::{BaseState, CommandQueue};
-use crate::piet::{Device, Piet};
+use crate::piet::Device;
 use crate::*;
 
-/// Mother, tell me: where do contexts come from?
-struct Mocks<'a> {
-    ctx: MockWinCtx<'a>,
+const DEFAULT_SIZE: Size = Size::new(400., 400.);
+
+/// A type that tries very hard to provide a comforting and safe environment
+/// for widgets who are trying to find their way.
+///
+/// You create a `Harness` with some widget and its initial data; then you
+/// can send events to that widget and verify that expected conditions are met.
+///
+/// Harness tries to act like the normal druid environment; for instance, it will
+/// attempt to dispatch and `Command`s that are sent during event handling, and
+/// it will call `update` automatically after an event.
+///
+/// That said, it _is_ missing a bunch of logic that would normally be handled
+/// in `AppState`: for instance it does not clear the `needs_inval` and
+/// `children_changed` flags on the window after an update.
+///
+/// In addition, layout and paint **are not called automatically**. This is
+/// because paint is triggered by druid-shell, and there is no druid-shell here;
+///
+/// if you want those functions run you will need to call them yourself.
+///
+/// Also, timers don't work.  ¯\_(ツ)_/¯
+pub struct Harness<T: Data> {
+    device: Device,
+    pub data: T,
+    pub env: Env,
+    pub window: Window<T>,
     handle: WindowHandle,
     command_queue: CommandQueue,
     cursor: Option<Cursor>,
-    base_state: BaseState,
     window_id: WindowId,
 }
 
 /// A `WinCtx` impl that we can conjure from the ether.
-pub struct MockWinCtx<'a> {
-    piet: Piet<'a>,
+pub struct MockWinCtx<'a>(&'a mut Text<'a>);
+
+impl<T: Data> Harness<T> {
+    /// Create a new `Harness` with the given data and a root widget,
+    /// and provide that harness to the passed in function.
+    ///
+    /// For lifetime reasons™, we cannot just make a harness. It's complicated.
+    /// I tried my best.
+    pub fn create(data: T, root: impl Widget<T> + 'static, mut f: impl FnMut(&mut Harness<T>)) {
+        let device = Device::new().expect("harness failed to get device");
+        let mut mocks = Harness {
+            device,
+            data,
+            env: theme::init(),
+            window: Window::new(root, LocalizedString::new(""), None),
+            handle: Default::default(),
+            command_queue: Default::default(),
+            cursor: Default::default(),
+            window_id: WindowId::next(),
+        };
+
+        f(&mut mocks);
+    }
+
+    /// Send the events that would normally be sent when the app starts.
+    // should we do this automatically? Also these will change regularly?
+    #[allow(dead_code)]
+    pub fn send_initial_events(&mut self) {
+        self.lifecycle(LifeCycle::WidgetAdded);
+        self.lifecycle(LifeCycle::Register);
+        self.lifecycle(LifeCycle::WindowConnected);
+        self.event(Event::Size(DEFAULT_SIZE));
+    }
+
+    /// Send an event to the widget.
+    ///
+    /// If this event triggers lifecycle events, they will also be dispatched,
+    /// as will any resulting commands. This will also trigger `update`.
+    ///
+    /// Commands dispatched during `update` will not be sent?
+    pub fn event(&mut self, event: Event) {
+        let mut base_state = BaseState::new(self.window.root.id());
+
+        // we need to instantiate this stuff in each method in order to get
+        // around lifetime issues.
+        //
+        // we could fix this by having two types, a 'harness' and a 'harness host';
+        // the latter would house just a render context and the harness,
+        // and would pass the render context into the harness on each call.
+        let mut target = self
+            .device
+            .bitmap_target(400, 400, 100.)
+            .expect("harness failed to create target");
+        let mut piet = target.render_context();
+        let text = piet.text();
+        let mut win_ctx = MockWinCtx(text);
+
+        let mut ctx = EventCtx {
+            win_ctx: &mut win_ctx,
+            cursor: &mut self.cursor,
+            command_queue: &mut self.command_queue,
+            window_id: self.window_id,
+            window: &self.handle,
+            base_state: &mut base_state,
+            focus_widget: None,
+            had_active: false,
+            is_handled: false,
+            is_root: true,
+        };
+
+        self.window
+            .event(&mut ctx, &event, &mut self.data, &self.env);
+        self.process_commands();
+        self.update();
+    }
+
+    fn process_commands(&mut self) {
+        loop {
+            let cmd = self.command_queue.pop_front();
+            match cmd {
+                Some((target, cmd)) => self.event(Event::TargetedCommand(target, cmd)),
+                None => break,
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn lifecycle(&mut self, event: LifeCycle) {
+        let mut ctx = LifeCycleCtx {
+            command_queue: &mut self.command_queue,
+            children: Default::default(),
+            window_id: self.window_id,
+            widget_id: self.window.root.id(),
+            focus_widgets: Vec::new(),
+            request_anim: false,
+            needs_inval: false,
+            children_changed: false,
+        };
+
+        self.window
+            .lifecycle(&mut ctx, &event, &self.data, &self.env);
+    }
+
+    //TODO: should we expose this? I don't think so?
+    fn update(&mut self) {
+        let mut target = self
+            .device
+            .bitmap_target(400, 400, 100.)
+            .expect("harness failed to create target");
+        let mut piet = target.render_context();
+
+        let mut ctx = UpdateCtx {
+            text_factory: piet.text(),
+            window: &self.handle,
+            needs_inval: false,
+            children_changed: false,
+            window_id: self.window_id,
+            widget_id: self.window.root.id(),
+        };
+        self.window.update(&mut ctx, &self.data, &self.env);
+    }
+
+    #[allow(dead_code)]
+    pub fn layout(&mut self) {
+        let mut target = self
+            .device
+            .bitmap_target(400, 400, 100.)
+            .expect("harness failed to create target");
+        let mut piet = target.render_context();
+
+        let mut ctx = LayoutCtx {
+            text_factory: piet.text(),
+            window_id: self.window_id,
+        };
+        self.window.layout(&mut ctx, &self.data, &self.env);
+    }
+
+    #[allow(dead_code)]
+    pub fn paint(&mut self) {
+        let base_state = BaseState::new(self.window.root.id());
+        let mut target = self
+            .device
+            .bitmap_target(400, 400, 100.)
+            .expect("harness failed to create target");
+        let mut piet = target.render_context();
+
+        let mut ctx = PaintCtx {
+            render_ctx: &mut piet,
+            window_id: self.window_id,
+            region: Rect::ZERO.into(),
+            base_state: &base_state,
+            focus_widget: self.window.focus,
+        };
+        self.window.paint(&mut ctx, &self.data, &self.env);
+    }
 }
 
 impl<'a> WinCtx<'a> for MockWinCtx<'a> {
     fn invalidate(&mut self) {}
-    fn text_factory(&mut self) -> &mut Text {
-        self.piet.text()
+    fn text_factory(&mut self) -> &mut Text<'a> {
+        self.0
     }
 
-    fn set_cursor(&mut self, cursor: &Cursor) {}
+    fn set_cursor(&mut self, _cursor: &Cursor) {}
     //TODO: we could actually implement timers if we were ambitious
     fn request_timer(&mut self, _deadline: std::time::Instant) -> TimerToken {
         TimerToken::next()
@@ -49,88 +225,5 @@ impl<'a> WinCtx<'a> for MockWinCtx<'a> {
     }
     fn save_as_sync(&mut self, _: FileDialogOptions) -> Option<FileInfo> {
         None
-    }
-}
-
-impl<'a> MockWinCtx<'a> {
-    fn new(piet: Piet<'a>) -> Self {
-        MockWinCtx { piet }
-    }
-}
-
-impl<'a> Mocks<'a> {
-    fn with_mocks(mut f: impl FnMut(&mut Mocks)) {
-        let mut device = Device::new().expect("harness failed to get device");
-        let mut target = device
-            .bitmap_target(400, 400, 100.)
-            .expect("harness failed to create target");
-        let ctx = MockWinCtx::new(target.render_context());
-        let mut mocks = Mocks {
-            ctx,
-            handle: Default::default(),
-            command_queue: Default::default(),
-            cursor: Default::default(),
-            base_state: BaseState::new(WidgetId::next()),
-            //FIXME: makee these const or someethign idk
-            window_id: WindowId::next(),
-        };
-
-        f(&mut mocks);
-    }
-
-    fn event_ctx<'me>(&'me mut self) -> EventCtx<'me, 'a> {
-        EventCtx {
-            win_ctx: &mut self.ctx,
-            cursor: &mut self.cursor,
-            command_queue: &mut self.command_queue,
-            window_id: self.window_id,
-            window: &self.handle,
-            base_state: &mut self.base_state,
-            focus_widget: None,
-            had_active: false,
-            is_handled: false,
-            is_root: true,
-        }
-    }
-
-    fn lifecycle_ctx(&mut self) -> LifeCycleCtx {
-        LifeCycleCtx {
-            command_queue: &mut self.command_queue,
-            children: Default::default(),
-            window_id: self.window_id,
-            widget_id: self.base_state.id,
-            focus_widgets: Vec::new(),
-            request_anim: false,
-            needs_inval: false,
-            children_changed: false,
-        }
-    }
-
-    fn update_ctx(&mut self) -> UpdateCtx {
-        UpdateCtx {
-            text_factory: self.ctx.text_factory(),
-            window: &self.handle,
-            needs_inval: false,
-            children_changed: false,
-            window_id: self.window_id,
-            widget_id: self.base_state.id,
-        }
-    }
-
-    fn layout_ctx(&mut self) -> LayoutCtx {
-        LayoutCtx {
-            text_factory: self.ctx.text_factory(),
-            window_id: self.window_id,
-        }
-    }
-
-    fn paint_ctx<'me>(&'me mut self) -> PaintCtx<'me, 'a> {
-        PaintCtx {
-            render_ctx: &mut self.ctx.piet,
-            window_id: self.window_id,
-            region: Rect::ZERO.into(),
-            base_state: &self.base_state,
-            focus_widget: None,
-        }
     }
 }

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -18,7 +18,7 @@ use crate::core::{BaseState, CommandQueue};
 use crate::piet::Device;
 use crate::*;
 
-const DEFAULT_SIZE: Size = Size::new(400., 400.);
+pub(crate) const DEFAULT_SIZE: Size = Size::new(400., 400.);
 
 /// A type that tries very hard to provide a comforting and safe environment
 /// for widgets who are trying to find their way.
@@ -27,7 +27,7 @@ const DEFAULT_SIZE: Size = Size::new(400., 400.);
 /// can send events to that widget and verify that expected conditions are met.
 ///
 /// Harness tries to act like the normal druid environment; for instance, it will
-/// attempt to dispatch and `Command`s that are sent during event handling, and
+/// attempt to dispatch any `Command`s that are sent during event handling, and
 /// it will call `update` automatically after an event.
 ///
 /// That said, it _is_ missing a bunch of logic that would normally be handled
@@ -86,7 +86,6 @@ impl<T: Data> Harness<T> {
 
     /// Send the events that would normally be sent when the app starts.
     // should we do this automatically? Also these will change regularly?
-    #[allow(dead_code)]
     pub fn send_initial_events(&mut self) {
         self.lifecycle(LifeCycle::WidgetAdded);
         self.lifecycle(LifeCycle::Register);
@@ -182,7 +181,6 @@ impl<T: Data> Harness<T> {
         self.window.update(&mut ctx, &self.data, &self.env);
     }
 
-    #[allow(dead_code)]
     pub fn layout(&mut self) {
         let mut target = self
             .device

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -1,0 +1,126 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helper types for test writing.
+//!
+//! This includes tools for making throwaway widgets more easily.
+
+use crate::*;
+
+pub type EventFn<S, T> = dyn FnMut(&mut S, &mut EventCtx, &Event, &T, &Env);
+pub type LifeCycleFn<S, T> = dyn FnMut(&mut S, &mut LifeCycleCtx, &LifeCycle, &T, &Env);
+pub type UpdateFn<S, T> = dyn FnMut(&mut S, &mut UpdateCtx, &T, &T, &Env);
+pub type LayoutFn<S, T> = dyn FnMut(&mut S, &mut LayoutCtx, &BoxConstraints, &T, &Env) -> Size;
+pub type PaintFn<S, T> = dyn FnMut(&mut S, &mut PaintCtx, &T, &Env);
+
+/// A widget that can be constructed from individual functions, builder-style.
+///
+/// This widget is generic over its state, which is passed in at construction time.
+pub struct ModularWidget<S, T> {
+    state: S,
+    event: Option<Box<EventFn<S, T>>>,
+    lifecycle: Option<Box<LifeCycleFn<S, T>>>,
+    update: Option<Box<UpdateFn<S, T>>>,
+    layout: Option<Box<LayoutFn<S, T>>>,
+    paint: Option<Box<PaintFn<S, T>>>,
+}
+
+#[allow(dead_code)]
+impl<S, T> ModularWidget<S, T> {
+    pub fn new(state: S) -> Self {
+        ModularWidget {
+            state,
+            event: None,
+            lifecycle: None,
+            update: None,
+            layout: None,
+            paint: None,
+        }
+    }
+
+    pub fn event_fn(
+        mut self,
+        f: impl FnMut(&mut S, &mut EventCtx, &Event, &T, &Env) + 'static,
+    ) -> Self {
+        self.event = Some(Box::new(f));
+        self
+    }
+
+    pub fn lifecycle_fn(
+        mut self,
+        f: impl FnMut(&mut S, &mut LifeCycleCtx, &LifeCycle, &T, &Env) + 'static,
+    ) -> Self {
+        self.lifecycle = Some(Box::new(f));
+        self
+    }
+
+    pub fn update_fn(
+        mut self,
+        f: impl FnMut(&mut S, &mut UpdateCtx, &T, &T, &Env) + 'static,
+    ) -> Self {
+        self.update = Some(Box::new(f));
+        self
+    }
+
+    pub fn layout_fn(
+        mut self,
+        f: impl FnMut(&mut S, &mut LayoutCtx, &BoxConstraints, &T, &Env) -> Size + 'static,
+    ) -> Self {
+        self.layout = Some(Box::new(f));
+        self
+    }
+
+    pub fn paint_fn(mut self, f: impl FnMut(&mut S, &mut PaintCtx, &T, &Env) + 'static) -> Self {
+        self.paint = Some(Box::new(f));
+        self
+    }
+}
+
+impl<S, T: Data> Widget<T> for ModularWidget<S, T> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        if let Some(f) = self.event.as_mut() {
+            f(&mut self.state, ctx, event, data, env)
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        if let Some(f) = self.lifecycle.as_mut() {
+            f(&mut self.state, ctx, event, data, env)
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        if let Some(f) = self.update.as_mut() {
+            f(&mut self.state, ctx, old_data, data, env)
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        let ModularWidget {
+            ref mut state,
+            ref mut layout,
+            ..
+        } = self;
+        layout
+            .as_mut()
+            .map(|f| f(state, ctx, bc, data, env))
+            .unwrap_or(Size::new(100., 100.))
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        if let Some(f) = self.paint.as_mut() {
+            f(&mut self.state, ctx, data, env)
+        }
+    }
+}

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -15,3 +15,37 @@
 //! Additional unit tests that cross file or module boundaries.
 
 mod harness;
+mod helpers;
+
+use crate::widget::*;
+use crate::*;
+use harness::*;
+use helpers::*;
+
+/// test that the first widget to request focus during an event gets it.
+#[test]
+fn take_focus() {
+    const TAKE_FOCUS: Selector = Selector::new("druid-tests.take-focus");
+
+    /// A widget that takes focus when sent a particular command.
+    fn make_focus_taker() -> impl Widget<bool> {
+        ModularWidget::new(()).event_fn(|_, ctx, event, _data, _env| {
+            if let Event::Command(cmd) = event {
+                if cmd.selector == TAKE_FOCUS {
+                    ctx.request_focus();
+                }
+            }
+        })
+    }
+
+    let left_id = WidgetId::next();
+    let left = make_focus_taker().with_id(left_id);
+    let right = make_focus_taker();
+    let app = Split::vertical(left, right);
+    let data = true;
+
+    Harness::create(data, app, |harness| {
+        harness.event(Event::Command(TAKE_FOCUS.into()));
+        assert_eq!(harness.window.focus, Some(left_id));
+    })
+}

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -46,7 +46,7 @@ fn take_focus() {
 
     Harness::create(data, app, |harness| {
         harness.event(Event::Command(TAKE_FOCUS.into()));
-        assert_eq!(harness.window.focus, Some(left_id));
+        assert_eq!(harness.window().focus, Some(left_id));
     })
 }
 

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Additional unit tests that cross file or module boundaries.
+
+mod harness;


### PR DESCRIPTION
This introduces a way of testing widget trees; you can construct a harness and send events as normal.

This adds a new submodule at `druid/src/tests`, and that's probably the most interesting part of this PR.

~This also includes the commits from #498 and #497.~
This includes stuff from #501.