### PR TITLE
Fixup WidgetId reuse logic

### DIFF
--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -17,7 +17,7 @@
 use crate::kurbo::{Rect, Size};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetId, WidgetPod,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 use crate::piet::UnitPoint;
@@ -132,9 +132,5 @@ impl<T: Data> Widget<T> for Align<T> {
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint_with_offset(paint_ctx, data, env);
-    }
-
-    fn id(&self) -> Option<WidgetId> {
-        Some(self.child.id())
     }
 }

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -17,7 +17,7 @@
 use crate::shell::kurbo::{Point, Rect, RoundedRect, Size};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintBrush,
-    PaintCtx, RenderContext, UpdateCtx, Widget, WidgetId, WidgetPod,
+    PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,
 };
 
 struct BorderStyle {
@@ -126,9 +126,5 @@ impl<T: Data> Widget<T> for Container<T> {
         };
 
         self.inner.paint(paint_ctx, data, env);
-    }
-
-    fn id(&self) -> Option<WidgetId> {
-        Some(self.inner.id())
     }
 }

--- a/druid/src/widget/identity_wrapper.rs
+++ b/druid/src/widget/identity_wrapper.rs
@@ -58,20 +58,3 @@ impl<T: Data, W: Widget<T>> Widget<T> for IdentityWrapper<W> {
         Some(self.id)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::widget::{Label, WidgetExt, WidgetId};
-    use crate::Color;
-
-    #[test]
-    fn test_nesting() {
-        let id = WidgetId::next();
-        let label = IdentityWrapper::wrap(Label::<u32>::new("howdy there friend"), id);
-        let wrapped_up: Box<dyn Widget<u32>> =
-            Box::new(label.padding(5.0).align_left().background(Color::BLACK));
-
-        assert_eq!(wrapped_up.id(), Some(id));
-    }
-}

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -17,7 +17,7 @@
 use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    UpdateCtx, Widget, WidgetId, WidgetPod,
+    UpdateCtx, Widget, WidgetPod,
 };
 
 /// A widget that just adds padding around its child.
@@ -107,9 +107,5 @@ impl<T: Data> Widget<T> for Padding<T> {
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.child.paint_with_offset(paint_ctx, data, env);
-    }
-
-    fn id(&self) -> Option<WidgetId> {
-        Some(self.child.id())
     }
 }


### PR DESCRIPTION
This fixes an issue revealed in the process of implementing a
testing harness.

The issue is basically that I had gotten a bit clever with the
widget id stuff. Specifically, certain widgets that manage a
single child using a WidgetPod (Padding and Align, specifically)
had attempted to be transparent for the purposes of widget id;
they would reuse the id of their inner widget, if one existed.
The problem with this was that you could end up with two
WidgetPods that had the same id, and so there would be no way
to address the inner pod.

So this reverts that fanciness.