### PR TITLE
Add 'boxed()' fn to WidgetExt

### DIFF
--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -139,6 +139,10 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     {
         Parse::new(self)
     }
+
+    fn boxed(self) -> Box<dyn Widget<T>> {
+        Box::new(self)
+    }
 }
 
 impl<T: Data, W: Widget<T> + 'static> WidgetExt<T> for W {}

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -140,6 +140,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
         Parse::new(self)
     }
 
+    /// Wrap this widget in a `Box`.
     fn boxed(self) -> Box<dyn Widget<T>> {
         Box::new(self)
     }


### PR DESCRIPTION
Fixes #500

Create utility Method `WidgetExt::boxed` to quickly get boxed and sized `Widgets`