### PR TITLE
Z-order painting support

### DIFF
--- a/druid/examples/anim.rs
+++ b/druid/examples/anim.rs
@@ -16,7 +16,7 @@
 
 use std::f64::consts::PI;
 
-use druid::kurbo::Line;
+use druid::kurbo::{Circle, Line};
 use druid::{
     AppLauncher, BoxConstraints, Color, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
     LocalizedString, PaintCtx, Point, RenderContext, Size, UpdateCtx, Vec2, Widget, WindowDesc,
@@ -59,9 +59,14 @@ impl Widget<u32> for AnimWidget {
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
+        let t = self.t;
         let center = Point::new(50.0, 50.0);
-        let ambit = center + 45.0 * Vec2::from_angle((0.75 + self.t) * 2.0 * PI);
-        paint_ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);
+        paint_ctx.paint_with_z_index(1, move |ctx| {
+            let ambit = center + 45.0 * Vec2::from_angle((0.75 + t) * 2.0 * PI);
+            ctx.stroke(Line::new(center, ambit), &Color::WHITE, 1.0);
+        });
+
+        paint_ctx.fill(Circle::new(center, 50.0), &Color::BLACK);
     }
 }
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -96,7 +96,7 @@ pub struct LayoutCtx<'a, 'b: 'a> {
 }
 
 /// Z-order paint operations with transformations.
-pub struct ZOrderPaintOp {
+pub(crate) struct ZOrderPaintOp {
     pub z_index: u32,
     pub paint_func: Box<dyn FnOnce(&mut PaintCtx) + 'static>,
     pub transform: Affine,
@@ -114,7 +114,7 @@ pub struct PaintCtx<'a, 'b: 'a> {
     pub render_ctx: &'a mut Piet<'b>,
     pub window_id: WindowId,
     /// The z-order paint operations.
-    pub z_ops: Vec<ZOrderPaintOp>,
+    pub(crate) z_ops: Vec<ZOrderPaintOp>,
     /// The currently visible region.
     pub(crate) region: Region,
     pub(crate) base_state: &'a BaseState,
@@ -534,7 +534,7 @@ impl<'a, 'b: 'a> PaintCtx<'a, 'b> {
 
     /// Allows to specify order for paint operations.
     ///
-    /// Larger `z_idx` indicate that an operation will be executed later.
+    /// Larger `z_index` indicate that an operation will be executed later.
     pub fn paint_with_z_index(
         &mut self,
         z_index: u32,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -21,8 +21,10 @@ use log;
 
 use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::piet::Piet;
+use crate::piet::RenderContext;
 use crate::{
-    Command, Cursor, Rect, Size, Target, Text, TimerToken, WidgetId, WinCtx, WindowHandle, WindowId,
+    Affine, Command, Cursor, Rect, Size, Target, Text, TimerToken, WidgetId, WinCtx, WindowHandle,
+    WindowId,
 };
 
 /// A mutable context provided to event handling methods of widgets.
@@ -93,6 +95,13 @@ pub struct LayoutCtx<'a, 'b: 'a> {
     pub(crate) window_id: WindowId,
 }
 
+/// Z-order paint operations with transformations.
+pub struct ZOrderPaintOp {
+    pub z_index: u32,
+    pub paint_func: Box<dyn FnOnce(&mut PaintCtx) + 'static>,
+    pub transform: Affine,
+}
+
 /// A context passed to paint methods of widgets.
 ///
 /// Widgets paint their appearance by calling methods on the
@@ -104,6 +113,8 @@ pub struct PaintCtx<'a, 'b: 'a> {
     /// The render context for actually painting.
     pub render_ctx: &'a mut Piet<'b>,
     pub window_id: WindowId,
+    /// The z-order paint operations.
+    pub z_ops: Vec<ZOrderPaintOp>,
     /// The currently visible region.
     pub(crate) region: Region,
     pub(crate) base_state: &'a BaseState,
@@ -512,11 +523,29 @@ impl<'a, 'b: 'a> PaintCtx<'a, 'b> {
         let mut child_ctx = PaintCtx {
             render_ctx: self.render_ctx,
             base_state: self.base_state,
+            z_ops: Vec::new(),
             window_id: self.window_id,
             focus_widget: self.focus_widget,
             region: region.into(),
         };
-        f(&mut child_ctx)
+        f(&mut child_ctx);
+        self.z_ops.append(&mut child_ctx.z_ops);
+    }
+
+    /// Allows to specify order for paint operations.
+    ///
+    /// Larger `z_idx` indicate that an operation will be executed later.
+    pub fn paint_with_z_index(
+        &mut self,
+        z_index: u32,
+        paint_func: impl FnOnce(&mut PaintCtx) + 'static,
+    ) {
+        let current_transform = self.render_ctx.current_transform();
+        self.z_ops.push(ZOrderPaintOp {
+            z_index,
+            paint_func: Box::new(paint_func),
+            transform: current_transform,
+        })
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -188,11 +188,13 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut ctx = PaintCtx {
             render_ctx: paint_ctx.render_ctx,
             window_id: paint_ctx.window_id,
+            z_ops: Vec::new(),
             region: paint_ctx.region.clone(),
             base_state: &self.state,
             focus_widget: paint_ctx.focus_widget,
         };
         self.inner.paint(&mut ctx, data, &env);
+        paint_ctx.z_ops.append(&mut ctx.z_ops);
 
         if env.get(Env::DEBUG_PAINT) {
             let rect = Rect::from_origin_size(Point::ORIGIN, ctx.size());

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -14,6 +14,7 @@
 
 //! Management of multiple windows.
 
+use std::mem;
 use std::time::Instant;
 
 use crate::kurbo::{Point, Rect, Size};
@@ -317,6 +318,25 @@ impl<T: Data> Window<T> {
         };
         let visible = Rect::from_origin_size(Point::ZERO, self.size);
         paint_ctx.with_child_ctx(visible, |ctx| self.root.paint(ctx, data, env));
+
+        paint_ctx.z_ops.sort_by_key(|k| k.z_index);
+
+        let z_ops = mem::replace(&mut paint_ctx.z_ops, Vec::new());
+        for z_op in z_ops.into_iter() {
+            paint_ctx.with_child_ctx(visible, |ctx| {
+                if let Err(e) = ctx.render_ctx.save() {
+                    log::error!("saving render context failed: {:?}", e);
+                    return;
+                }
+
+                ctx.render_ctx.transform(z_op.transform);
+                (z_op.paint_func)(ctx);
+
+                if let Err(e) = ctx.render_ctx.restore() {
+                    log::error!("restoring render context failed: {:?}", e);
+                }
+            });
+        }
     }
 
     pub(crate) fn update_title(&mut self, data: &T, env: &Env) {

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -313,15 +313,16 @@ impl<T: Data> Window<T> {
             render_ctx: piet,
             base_state: &base_state,
             window_id: self.id,
+            z_ops: Vec::new(),
             focus_widget: self.focus,
             region: Rect::ZERO.into(),
         };
         let visible = Rect::from_origin_size(Point::ZERO, self.size);
         paint_ctx.with_child_ctx(visible, |ctx| self.root.paint(ctx, data, env));
 
-        paint_ctx.z_ops.sort_by_key(|k| k.z_index);
+        let mut z_ops = mem::take(&mut paint_ctx.z_ops);
+        z_ops.sort_by_key(|k| k.z_index);
 
-        let z_ops = mem::replace(&mut paint_ctx.z_ops, Vec::new());
         for z_op in z_ops.into_iter() {
             paint_ctx.with_child_ctx(visible, |ctx| {
                 if let Err(e) = ctx.render_ctx.save() {


### PR DESCRIPTION
This addresses https://github.com/xi-editor/druid/issues/430 and replaces https://github.com/xi-editor/druid/pull/466

This requires https://github.com/linebender/piet/pull/117 to have access to `current_transform()` which is necessary to keep track of applied transformations.

One thing that is missing here (also because I'm not 100% sure) is keeping track of clipping. Right now previous clipping is not applied to z-order painting. It would be a bit trickier since `PaintCtx` would need to keep track of clipping.

One other thing that I was thinking about was thinking about is whether it would make sense to allow negative `z_index`es to allow painting below content?