### PR TITLE
Add a proof-of-concept ViewSwitcher widget

### DIFF
--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -82,7 +82,7 @@ fn make_ui() -> impl Widget<AppState> {
                     ),
             ),
             4 => Box::new(
-                Split::horizontal(
+                Split::vertical(
                     Label::new("Left split").center(),
                     Label::new("Right split").center(),
                 )

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -1,3 +1,19 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This example demonstrates the `ViewSwitcher` widget
+
 use druid::widget::{Button, Flex, Label, Split, TextBox, ViewSwitcher, WidgetExt};
 use druid::{AppLauncher, Data, Env, Lens, LocalizedString, Widget, WindowDesc};
 use std::sync::Arc;

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -1,0 +1,86 @@
+use druid::lens::{Id, Tuple};
+use druid::widget::{Button, Flex, Label, TextBox, ViewSwitcher, WidgetExt};
+use druid::{AppLauncher, Data, Env, Lens, LensExt, LocalizedString, Widget, WindowDesc};
+use std::sync::Arc;
+
+#[derive(Clone, Data, Lens)]
+struct AppState {
+    current_view: u32,
+    current_text: String,
+    numbers: Arc<Vec<u32>>,
+}
+
+fn main() {
+    let main_window = WindowDesc::new(make_ui).title(LocalizedString::new("View Switcher"));
+    let data = AppState {
+        current_view: 0,
+        current_text: "Edit me!".to_string(),
+        numbers: Arc::new((0..5).collect()),
+    };
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(data)
+        .expect("launch failed");
+}
+
+fn make_ui() -> impl Widget<AppState> {
+    let mut switcher_column = Flex::column();
+    switcher_column.add_child(
+        Label::new(|data: &u32, _env: &Env| format!("Current view: {}", data))
+            .lens(AppState::current_view),
+        0.0,
+    );
+    for i in 0..5 {
+        switcher_column.add_child(
+            Button::<u32>::new(format!("View {}", i), move |_event, data, _env| {
+                *data = i;
+            })
+            .lens(AppState::current_view),
+            0.0,
+        );
+    }
+
+    let view_switcher_lens = Tuple::new(AppState::current_view, Id);
+
+    let view_switcher = ViewSwitcher::new(|data: &(u32, AppState), _env| {
+        let current_text_lens = Id.map(
+            |data: &(u32, AppState)| String::from(&data.1.current_text),
+            |data, text| data.1.current_text = text,
+        );
+
+        match data.0 {
+            0 => Box::new(Label::new("Simple Label").center()),
+            1 => Box::new(Button::new(
+                "Another Simple Button",
+                |_event, _data, _env| {
+                    println!("Simple button clicked!");
+                },
+            )),
+            2 => Box::new(Button::new("Simple Button", |_event, _data, _env| {
+                println!("Simple button clicked!");
+            })),
+            3 => Box::new(
+                Flex::column()
+                    .with_child(Label::new("Here is a label").center(), 1.0)
+                    .with_child(
+                        Button::new("Button", |_event, _data, _env| {
+                            println!("Complex button clicked!");
+                        }),
+                        1.0,
+                    )
+                    .with_child(TextBox::new().lens(current_text_lens.clone()), 1.0)
+                    .with_child(
+                        Label::new(|data: &String, _env: &Env| format!("Value entered: {}", data))
+                            .lens(current_text_lens.clone()),
+                        1.0,
+                    ),
+            ),
+            _ => Box::new(Label::new("Unknown").center()),
+        }
+    })
+    .lens(view_switcher_lens);
+
+    Flex::row()
+        .with_child(switcher_column, 0.0)
+        .with_child(view_switcher, 1.0)
+}

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -1,6 +1,5 @@
-use druid::lens::{Id, Tuple};
-use druid::widget::{Button, Flex, Label, TextBox, ViewSwitcher, WidgetExt};
-use druid::{AppLauncher, Data, Env, Lens, LensExt, LocalizedString, Widget, WindowDesc};
+use druid::widget::{Button, Flex, Label, Split, TextBox, ViewSwitcher, WidgetExt};
+use druid::{AppLauncher, Data, Env, Lens, LocalizedString, Widget, WindowDesc};
 use std::sync::Arc;
 
 #[derive(Clone, Data, Lens)]
@@ -30,7 +29,7 @@ fn make_ui() -> impl Widget<AppState> {
             .lens(AppState::current_view),
         0.0,
     );
-    for i in 0..5 {
+    for i in 0..6 {
         switcher_column.add_child(
             Button::<u32>::new(format!("View {}", i), move |_event, data, _env| {
                 *data = i;
@@ -40,25 +39,19 @@ fn make_ui() -> impl Widget<AppState> {
         );
     }
 
-    let view_switcher_lens = Tuple::new(AppState::current_view, Id);
-
-    let view_switcher = ViewSwitcher::new(|data: &(u32, AppState), _env| {
-        let current_text_lens = Id.map(
-            |data: &(u32, AppState)| String::from(&data.1.current_text),
-            |data, text| data.1.current_text = text,
-        );
-
-        match data.0 {
+    let view_switcher = ViewSwitcher::new(
+        |data: &AppState, _env| data.current_view,
+        |selector, _env| match selector {
             0 => Box::new(Label::new("Simple Label").center()),
-            1 => Box::new(Button::new(
-                "Another Simple Button",
-                |_event, _data, _env| {
-                    println!("Simple button clicked!");
-                },
-            )),
-            2 => Box::new(Button::new("Simple Button", |_event, _data, _env| {
+            1 => Box::new(Button::new("Simple Button", |_event, _data, _env| {
                 println!("Simple button clicked!");
             })),
+            2 => Box::new(Button::new(
+                "Another Simple Button",
+                |_event, _data, _env| {
+                    println!("Another simple button clicked!");
+                },
+            )),
             3 => Box::new(
                 Flex::column()
                     .with_child(Label::new("Here is a label").center(), 1.0)
@@ -68,17 +61,23 @@ fn make_ui() -> impl Widget<AppState> {
                         }),
                         1.0,
                     )
-                    .with_child(TextBox::new().lens(current_text_lens.clone()), 1.0)
+                    .with_child(TextBox::new().lens(AppState::current_text), 1.0)
                     .with_child(
                         Label::new(|data: &String, _env: &Env| format!("Value entered: {}", data))
-                            .lens(current_text_lens.clone()),
+                            .lens(AppState::current_text),
                         1.0,
                     ),
             ),
+            4 => Box::new(
+                Split::horizontal(
+                    Label::new("Left split").center(),
+                    Label::new("Right split").center(),
+                )
+                .draggable(true),
+            ),
             _ => Box::new(Label::new("Unknown").center()),
-        }
-    })
-    .lens(view_switcher_lens);
+        },
+    );
 
     Flex::row()
         .with_child(switcher_column, 0.0)

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -16,13 +16,11 @@
 
 use druid::widget::{Button, Flex, Label, Split, TextBox, ViewSwitcher, WidgetExt};
 use druid::{AppLauncher, Data, Env, Lens, LocalizedString, Widget, WindowDesc};
-use std::sync::Arc;
 
 #[derive(Clone, Data, Lens)]
 struct AppState {
     current_view: u32,
     current_text: String,
-    numbers: Arc<Vec<u32>>,
 }
 
 fn main() {
@@ -30,7 +28,6 @@ fn main() {
     let data = AppState {
         current_view: 0,
         current_text: "Edit me!".to_string(),
-        numbers: Arc::new((0..5).collect()),
     };
     AppLauncher::with_window(main_window)
         .use_simple_logger()

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The xi-editor Authors.
+// Copyright 2020 The xi-editor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -545,3 +545,39 @@ where
         v
     }
 }
+
+#[derive(Debug, Copy, Clone)]
+pub struct Tuple<L, R> {
+    left: L,
+    right: R,
+}
+
+impl<L, R> Tuple<L, R> {
+    pub fn new<T, U1, U2>(left: L, right: R) -> Self
+    where
+        L: Lens<T, U1>,
+        R: Lens<T, U2>,
+    {
+        Self { left, right }
+    }
+}
+
+impl<T, U1, U2, L, R> Lens<T, (U1, U2)> for Tuple<L, R>
+where
+    U1: Clone,
+    U2: Clone,
+    L: Lens<T, U1>,
+    R: Lens<T, U2>,
+{
+    fn with<V, F: FnOnce(&(U1, U2)) -> V>(&self, data: &T, f: F) -> V {
+        f(&(self.left.get(data), self.right.get(data)))
+    }
+
+    fn with_mut<V, F: FnOnce(&mut (U1, U2)) -> V>(&self, data: &mut T, f: F) -> V {
+        let mut r = (self.left.get(data), self.right.get(data));
+        let v = f(&mut r);
+        self.left.put(data, r.0);
+        self.right.put(data, r.1);
+        v
+    }
+}

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -545,39 +545,3 @@ where
         v
     }
 }
-
-#[derive(Debug, Copy, Clone)]
-pub struct Tuple<L, R> {
-    left: L,
-    right: R,
-}
-
-impl<L, R> Tuple<L, R> {
-    pub fn new<T, U1, U2>(left: L, right: R) -> Self
-    where
-        L: Lens<T, U1>,
-        R: Lens<T, U2>,
-    {
-        Self { left, right }
-    }
-}
-
-impl<T, U1, U2, L, R> Lens<T, (U1, U2)> for Tuple<L, R>
-where
-    U1: Clone,
-    U2: Clone,
-    L: Lens<T, U1>,
-    R: Lens<T, U2>,
-{
-    fn with<V, F: FnOnce(&(U1, U2)) -> V>(&self, data: &T, f: F) -> V {
-        f(&(self.left.get(data), self.right.get(data)))
-    }
-
-    fn with_mut<V, F: FnOnce(&mut (U1, U2)) -> V>(&self, data: &mut T, f: F) -> V {
-        let mut r = (self.left.get(data), self.right.get(data));
-        let v = f(&mut r);
-        self.left.put(data, r.0);
-        self.right.put(data, r.1);
-        v
-    }
-}

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -38,6 +38,7 @@ mod stepper;
 mod svg;
 mod switch;
 mod textbox;
+mod view_switcher;
 mod widget_ext;
 
 pub use align::Align;
@@ -64,6 +65,7 @@ pub use stepper::Stepper;
 pub use svg::{Svg, SvgData};
 pub use switch::Switch;
 pub use textbox::TextBox;
+pub use view_switcher::ViewSwitcher;
 pub use widget_ext::WidgetExt;
 
 use std::num::NonZeroU64;

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -1,0 +1,80 @@
+use crate::{
+    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
+    Point, Rect, Size, UpdateCtx, Widget, WidgetPod,
+};
+
+pub struct ViewSwitcher<T, U>
+where
+    T: Data + PartialEq,
+    U: Data,
+{
+    closure: Box<dyn Fn(&(T, U), &Env) -> Box<dyn Widget<(T, U)>>>,
+    current_child: Option<WidgetPod<(T, U), Box<dyn Widget<(T, U)>>>>,
+}
+
+impl<T, U> ViewSwitcher<T, U>
+where
+    T: Data + PartialEq,
+    U: Data,
+{
+    pub fn new(closure: impl Fn(&(T, U), &Env) -> Box<dyn Widget<(T, U)>> + 'static) -> Self {
+        Self {
+            closure: Box::new(closure),
+            current_child: None,
+        }
+    }
+}
+
+impl<T, U> Widget<(T, U)> for ViewSwitcher<T, U>
+where
+    T: Data + PartialEq,
+    U: Data,
+{
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut (T, U), env: &Env) {
+        if let Some(ref mut child) = self.current_child {
+            child.event(ctx, event, data, env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &(T, U), env: &Env) {
+        if let LifeCycle::WidgetAdded = event {
+            self.current_child = Some(WidgetPod::new((self.closure)(data, env)));
+        }
+        if let Some(ref mut child) = self.current_child {
+            child.lifecycle(ctx, event, data, env);
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &(T, U), data: &(T, U), env: &Env) {
+        if self.current_child.is_none() || data.0 != old_data.0 {
+            self.current_child = Some(WidgetPod::new((self.closure)(data, env)));
+        }
+
+        if let Some(ref mut child) = self.current_child {
+            child.update(ctx, data, env);
+        }
+    }
+
+    fn layout(
+        &mut self,
+        layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &(T, U),
+        env: &Env,
+    ) -> Size {
+        match self.current_child {
+            Some(ref mut child) => {
+                let size = child.layout(layout_ctx, bc, data, env);
+                child.set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+                size
+            }
+            None => bc.max(),
+        }
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &(T, U), env: &Env) {
+        if let Some(ref mut child) = self.current_child {
+            child.paint(ctx, data, env);
+        }
+    }
+}

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -79,7 +79,7 @@ impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
         }
 
         if !old_data.same(data) {
-            ctx.invalidate();
+            ctx.request_paint();
         }
     }
 

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -1,8 +1,26 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A widget that can dynamically switch between one of many views.
+
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     Point, Rect, Size, UpdateCtx, Widget, WidgetPod,
 };
 
+/// A widget that can switch dynamically between one of many views depending
+/// application state.
 pub struct ViewSwitcher<T: Data, U: PartialEq + Clone> {
     child_selector: Box<dyn Fn(&T, &Env) -> U>,
     child_builder: Box<dyn Fn(U, &Env) -> Box<dyn Widget<T>>>,
@@ -11,6 +29,15 @@ pub struct ViewSwitcher<T: Data, U: PartialEq + Clone> {
 }
 
 impl<T: Data, U: PartialEq + Clone> ViewSwitcher<T, U> {
+    /// Create a new view switcher.
+    ///
+    /// The `child_selector` closure is called every time the application data changes.
+    /// If the value it returns is the same as the one it returned during the previous
+    /// data change, nothing happens. If it returns a different value, then the
+    /// `child_builder` closure is called with the new value.
+    ///
+    /// The `child_builder` closure is expected to create a new child widget depending
+    /// on the selector to it.
     pub fn new(
         child_selector: impl Fn(&T, &Env) -> U + 'static,
         child_builder: impl Fn(U, &Env) -> Box<dyn Widget<T>> + 'static,
@@ -47,7 +74,8 @@ impl<T: Data, U: PartialEq + Clone> Widget<T> for ViewSwitcher<T, U> {
         match &self.active_child_id {
             Some(current_child_id) => {
                 if &child_id != current_child_id {
-                    self.active_child = Some(WidgetPod::new((self.child_builder)(child_id.clone(), env)));
+                    self.active_child =
+                        Some(WidgetPod::new((self.child_builder)(child_id.clone(), env)));
                     self.active_child_id = Some(child_id);
                     ctx.children_changed();
                 }

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// A widget that can switch dynamically between one of many views depending
-/// application state.
+/// on application state.
 pub struct ViewSwitcher<T: Data, U: PartialEq> {
     child_selector: Box<dyn Fn(&T, &Env) -> U>,
     child_builder: Box<dyn Fn(&U, &Env) -> Box<dyn Widget<T>>>,

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -22,7 +22,7 @@ use crate::{
 /// A widget that can switch dynamically between one of many views depending
 /// on application state.
 
-pub struct ViewSwitcher<T: Data, U> {
+pub struct ViewSwitcher<T, U> {
     child_picker: Box<dyn Fn(&T, &Env) -> U>,
     child_builder: Box<dyn Fn(&U, &Env) -> Box<dyn Widget<T>>>,
     active_child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
@@ -90,7 +90,6 @@ impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
         data: &T,
         env: &Env,
     ) -> Size {
-        // TODO: correctly handle paint bounds for the child.
         match self.active_child {
             Some(ref mut child) => {
                 let size = child.layout(layout_ctx, bc, data, env);

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -21,14 +21,14 @@ use crate::{
 
 /// A widget that can switch dynamically between one of many views depending
 /// application state.
-pub struct ViewSwitcher<T: Data, U: PartialEq + Clone> {
+pub struct ViewSwitcher<T: Data, U: PartialEq> {
     child_selector: Box<dyn Fn(&T, &Env) -> U>,
-    child_builder: Box<dyn Fn(U, &Env) -> Box<dyn Widget<T>>>,
+    child_builder: Box<dyn Fn(&U, &Env) -> Box<dyn Widget<T>>>,
     active_child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
     active_child_id: Option<U>,
 }
 
-impl<T: Data, U: PartialEq + Clone> ViewSwitcher<T, U> {
+impl<T: Data, U: PartialEq> ViewSwitcher<T, U> {
     /// Create a new view switcher.
     ///
     /// The `child_selector` closure is called every time the application data changes.
@@ -40,7 +40,7 @@ impl<T: Data, U: PartialEq + Clone> ViewSwitcher<T, U> {
     /// on the selector to it.
     pub fn new(
         child_selector: impl Fn(&T, &Env) -> U + 'static,
-        child_builder: impl Fn(U, &Env) -> Box<dyn Widget<T>> + 'static,
+        child_builder: impl Fn(&U, &Env) -> Box<dyn Widget<T>> + 'static,
     ) -> Self {
         Self {
             child_selector: Box::new(child_selector),
@@ -51,7 +51,7 @@ impl<T: Data, U: PartialEq + Clone> ViewSwitcher<T, U> {
     }
 }
 
-impl<T: Data, U: PartialEq + Clone> Widget<T> for ViewSwitcher<T, U> {
+impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Some(ref mut child) = self.active_child {
             child.event(ctx, event, data, env);
@@ -61,8 +61,8 @@ impl<T: Data, U: PartialEq + Clone> Widget<T> for ViewSwitcher<T, U> {
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             let child_id = (self.child_selector)(data, env);
-            self.active_child_id = Some(child_id.clone());
-            self.active_child = Some(WidgetPod::new((self.child_builder)(child_id, env)));
+            self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, env)));
+            self.active_child_id = Some(child_id);
         }
         if let Some(ref mut child) = self.active_child {
             child.lifecycle(ctx, event, data, env);
@@ -71,16 +71,12 @@ impl<T: Data, U: PartialEq + Clone> Widget<T> for ViewSwitcher<T, U> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         let child_id = (self.child_selector)(data, env);
-        match &self.active_child_id {
-            Some(current_child_id) => {
-                if &child_id != current_child_id {
-                    self.active_child =
-                        Some(WidgetPod::new((self.child_builder)(child_id.clone(), env)));
-                    self.active_child_id = Some(child_id);
-                    ctx.children_changed();
-                }
+        if let Some(ref active_child_id) = self.active_child_id {
+            if &child_id != active_child_id {
+                self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, env)));
+                self.active_child_id = Some(child_id);
+                ctx.children_changed();
             }
-            None => {}
         }
 
         if !old_data.same(data) {


### PR DESCRIPTION
I'm looking for some feedback and help with this code. I plan to use this in an app I'm building, but it might be valuable to Druid as a whole.

## Short Summary

This PR contains a `ViewSwitcher` widget that can display one out of any number of child widgets, in the same way that `Either` can display one out of two widgets. I want to use this as a foundation for a sidebar and a tab-bar widget.

## Longer Description

I've been working on a little app where I need a sidebar similar to the one in this screenshot:

<img width="550" alt="614d3" src="https://user-images.githubusercontent.com/120190/73740592-74d03c00-476e-11ea-9af5-bf79a1617afd.png">

Clicking on an item in the sidebar switches the right side of the window to a different view. The items on the left need to be dynamically generated from a field in the application state, and updated whenever it changes. The view on the right can be anything that implements `Widget<T>`. Each item on the left can map to an entirely different type of widget on the right.

As a preliminary step, I've built a widget that I'm calling `ViewSwitcher`. The code is inspired by the `List` and `Either` widgets. The argument to `ViewSwitcher` is a closure that is passed some data from a lens, and returns one of many different views based on that data. Something like this:

```rust
ViewSwitcher::new(|data: &(u32, AppState), _env| {
        match data.0 {
            0 => Box::new(Label::new("Simple Label").center()),
            1 => Box::new(Button::new(
                "Another Simple Button",
                |_event, _data, _env| {
                    println!("Simple button clicked!");
                },
            )),
            2 => Box::new(Button::new("Simple Button", |_event, _data, _env| {
                println!("Simple button clicked!");
            })),
            _ => Box::new(Label::new("Unknown").center()),
        }
    })
```

The closure is called every time the application data changes, and the view that it returns is the one that gets rendered on screen.

The `ViewSwitcher` needs to be wrapped in a `LensWrap` that gives it access to a tuple of data. The first item in the tuple needs to be the field that will be used to figure out which widget should be returned from the closure. The second item in the tuple can be the full application state or part of the application state. I've added a `Tuple` lens to the codebase to make this convenient.

With the `Tuple` lens available, you can write something like this:

```rust
ViewSwitcher::new(|data: &(u32, AppState), _env| {
        match data.0 {
            // ... return something useful
        }
    })
    .lens(Tuple::new(AppState::current_view, Id));
```

I'm not happy with this API at all, but I couldn't figure out anything better. I wanted the children of `ViewSwitcher` to have the ability to lens down to whichever bit of data they wanted from the entire application state. At the same time, I wanted the closure to be unaware of the structure of the app state and have easy access to a single field it could simply `match` on.

With some help, I can work on this for the next week or so and get this to a state where it can be merged into Druid. If this design completely misses the mark, then I'm hoping I can learn from the feedback and come up with something better.

When I've figured out how to build this widget, I want to start working on a `Sidebar`. I feel I should be able to cobble it together with a `Split`, `List`, `Scroll` and `ViewSwitcher`. At that point, someone might be able to use the same design to build a `TabView`.

### Broken/Missing Pieces

- The child view is created from scratch every time the application data changes. I need to cache all the different children somewhere so I can reuse them and their internal state doesn't get lost.
- Keyboard events don't work in the `TextBox` widget. Not sure why this happens or how to fix it.
- I see tons of warnings on my console saying `WARN  [druid::core] old_data missing in WidgetId(XX), skipping update` (where XX is a bunch of different numbers). Again, I can't figure out why this happens and what the consequences are.
- I'm not sure using the `Tuple` lens here makes for a great API. Would love some feedback on how to make this better.