### PR TITLE
Move more logic to window

### DIFF
--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -22,7 +22,7 @@ use crate::ext_event::{ExtEventHost, ExtEventSink};
 use crate::kurbo::Size;
 use crate::shell::{Application, Error as PlatformError, RunLoop, WindowBuilder, WindowHandle};
 use crate::win_handler::AppState;
-use crate::window::{Window, WindowId};
+use crate::window::{PendingWindow, WindowId};
 use crate::{theme, AppDelegate, Data, DruidHandler, Env, LocalizedString, MenuDesc, Widget};
 
 /// A function that modifies the initial environment.
@@ -212,7 +212,7 @@ impl<T: Data> WindowDesc<T> {
         let root = (self.root_builder)();
         state
             .borrow_mut()
-            .add_window(self.id, Window::new(root, title, menu));
+            .add_window(self.id, PendingWindow::new(root, title, menu));
 
         builder.build()
     }

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -94,7 +94,7 @@ fn simple_layout() {
 
     Harness::create(true, widget, |harness| {
         harness.send_initial_events();
-        harness.layout();
+        harness.just_layout();
         let state = harness.get_state(id_1).expect("failed to retrieve id_1");
         assert_eq!(
             state.layout_rect.x0,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -90,7 +90,7 @@ impl<T: Data> PendingWindow<T> {
 
 impl<T: Data> Window<T> {
     /// `true` iff any child requested an animation frame during the last `AnimFrame` event.
-    pub fn wants_animation_frame(&self) -> bool {
+    pub(crate) fn wants_animation_frame(&self) -> bool {
         self.last_anim.is_some()
     }
 
@@ -121,7 +121,7 @@ impl<T: Data> Window<T> {
         }
     }
 
-    pub fn event(
+    pub(crate) fn event(
         &mut self,
         win_ctx: &mut dyn WinCtx,
         queue: &mut CommandQueue,
@@ -181,7 +181,13 @@ impl<T: Data> Window<T> {
     }
 
     /// Returns `true` if any widget has requested an animation frame
-    pub fn lifecycle(&mut self, queue: &mut CommandQueue, event: &LifeCycle, data: &T, env: &Env) {
+    pub(crate) fn lifecycle(
+        &mut self,
+        queue: &mut CommandQueue,
+        event: &LifeCycle,
+        data: &T,
+        env: &Env,
+    ) {
         let mut ctx = LifeCycleCtx {
             command_queue: queue,
             children: Bloom::default(),
@@ -223,7 +229,7 @@ impl<T: Data> Window<T> {
         }
     }
 
-    pub fn update(&mut self, win_ctx: &mut dyn WinCtx, data: &T, env: &Env) {
+    pub(crate) fn update(&mut self, win_ctx: &mut dyn WinCtx, data: &T, env: &Env) {
         self.update_title(data, env);
 
         let mut update_ctx = UpdateCtx {


### PR DESCRIPTION
This has two motivations.

Moving WindowHandle into the Window struct: win_handler.rs has
included a bunch of weird bookkeeping code intended to ensure
that we always have both a window and a handle. This patch
hopefully simplifies that, by making a distinction between a
'PendingWindow', that has been created in druid but not connected to
by the platform, and a 'Window', which is _always_ backed by a handle.
This means we don't need to check that we have both a window and a
handle; once a Window exists, it means that its handle also exists.
This hopefully makes the code cleaner and easier to follow along with.

Moving base event handling logic into Window struct: this is motivated
by wanting better testing. We test at the window level, so any logic
that exists in the Window struct is exercised by our tests; logic
outside of this (such as in DruidHandler and AppState) is not.

By moving more logic into the Window, our tests better reflect the
actual behaviour of the software.