### PR TITLE
Make LifeCycle::Register be fully incremental

### DIFF
--- a/druid/src/bloom.rs
+++ b/druid/src/bloom.rs
@@ -29,7 +29,7 @@ const OFFSET_ONE: u64 = 0xcbf2_9ce4_8422_2325;
 const OFFSET_TWO: u64 = 0xe10_3ad8_2dad_8028;
 
 /// A very simple Bloom filter optimized for small values.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub(crate) struct Bloom<T: ?Sized> {
     bits: u64,
     data: PhantomData<T>,
@@ -59,7 +59,6 @@ impl<T: ?Sized + Hash> Bloom<T> {
     }
 
     /// Remove all entries from the filter.
-    #[cfg(test)]
     pub fn clear(&mut self) {
         self.bits = 0;
         self.entry_count = 0;
@@ -107,6 +106,12 @@ impl<T: ?Sized + Hash> Bloom<T> {
         let mut hasher = FnvHasher::with_key(seed);
         item.hash(&mut hasher);
         hasher.finish()
+    }
+}
+
+impl<T: ?Sized> std::fmt::Debug for Bloom<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Bloom: {:064b}: ({})", self.bits, self.entry_count)
     }
 }
 

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -108,6 +108,13 @@ impl<T: Data> Harness<'_, T> {
         cell.take()
     }
 
+    /// Send a command to a target.
+    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
+        let target = target.into().unwrap_or_else(|| self.inner.window.id.into());
+        let event = Event::TargetedCommand(target, cmd.into());
+        self.event(event);
+    }
+
     /// Send the events that would normally be sent when the app starts.
     // should we do this automatically? Also these will change regularly?
     pub fn send_initial_events(&mut self) {

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -16,6 +16,7 @@
 //!
 //! This includes tools for making throwaway widgets more easily.
 
+use crate::widget::WidgetExt;
 use crate::*;
 
 pub type EventFn<S, T> = dyn FnMut(&mut S, &mut EventCtx, &Event, &T, &Env);
@@ -23,6 +24,8 @@ pub type LifeCycleFn<S, T> = dyn FnMut(&mut S, &mut LifeCycleCtx, &LifeCycle, &T
 pub type UpdateFn<S, T> = dyn FnMut(&mut S, &mut UpdateCtx, &T, &T, &Env);
 pub type LayoutFn<S, T> = dyn FnMut(&mut S, &mut LayoutCtx, &BoxConstraints, &T, &Env) -> Size;
 pub type PaintFn<S, T> = dyn FnMut(&mut S, &mut PaintCtx, &T, &Env);
+
+pub const REPLACE_CHILD: Selector = Selector::new("druid-test.replace-child");
 
 /// A widget that can be constructed from individual functions, builder-style.
 ///
@@ -34,6 +37,12 @@ pub struct ModularWidget<S, T> {
     update: Option<Box<UpdateFn<S, T>>>,
     layout: Option<Box<LayoutFn<S, T>>>,
     paint: Option<Box<PaintFn<S, T>>>,
+}
+
+/// A widget that can replace its child on command
+pub struct ReplaceChild<T: Data> {
+    inner: WidgetPod<T, Box<dyn Widget<T>>>,
+    replacer: Box<dyn Fn() -> Box<dyn Widget<T>>>,
 }
 
 #[allow(dead_code)]
@@ -122,5 +131,45 @@ impl<S, T: Data> Widget<T> for ModularWidget<S, T> {
         if let Some(f) = self.paint.as_mut() {
             f(&mut self.state, ctx, data, env)
         }
+    }
+}
+
+impl<T: Data> ReplaceChild<T> {
+    pub fn new<W: Widget<T> + 'static>(
+        inner: impl Widget<T> + 'static,
+        f: impl Fn() -> W + 'static,
+    ) -> Self {
+        let inner = WidgetPod::new(inner.boxed());
+        let replacer = Box::new(move || f().boxed());
+        ReplaceChild { inner, replacer }
+    }
+}
+
+impl<T: Data> Widget<T> for ReplaceChild<T> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        if let Event::Command(cmd) = event {
+            if cmd.selector == REPLACE_CHILD {
+                self.inner = WidgetPod::new((self.replacer)());
+                ctx.children_changed();
+                return;
+            }
+        }
+        self.inner.event(ctx, event, data, env)
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.inner.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
+        self.inner.update(ctx, data, env)
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        self.inner.layout(ctx, bc, data, env)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        self.inner.paint(ctx, data, env)
     }
 }


### PR DESCRIPTION
This is based off of #508, which should be merged first.

This moves to storing the intermediate state for widget focusing
in `BaseState`, so that it does not need to always be recomputed
from scratch anytime a child changes.

Along the way it also moves to making LifeCycleCtx take a reference
to BaseState, instead of redundantly storing its own copies of
everything.

It also fixes a bug, surfaced in testing, whereby widgets added during
an event() call would not receive WidgetAdded or Register before update().