### PR TITLE
Remove duplicate state in Window struct

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -77,10 +77,8 @@ pub struct UpdateCtx<'a, 'b: 'a> {
     // invalidations, which would mean a structure very much like
     // `EventCtx` (and possibly using the same structure). But for
     // now keep it super-simple.
-    pub(crate) needs_inval: bool,
-    pub(crate) children_changed: bool,
     pub(crate) window_id: WindowId,
-    pub(crate) widget_id: WidgetId,
+    pub(crate) base_state: &'a mut BaseState,
 }
 
 /// A context provided to layout handling methods of widgets.
@@ -413,14 +411,14 @@ impl<'a, 'b> UpdateCtx<'a, 'b> {
     /// See [`EventCtx::invalidate`](struct.EventCtx.html#method.invalidate) for
     /// more discussion.
     pub fn invalidate(&mut self) {
-        self.needs_inval = true;
+        self.base_state.needs_inval = true;
     }
 
     /// Indicate that your children have changed.
     ///
     /// Widgets must call this method after adding a new child.
     pub fn children_changed(&mut self) {
-        self.children_changed = true;
+        self.base_state.children_changed = true;
     }
 
     /// Get an object which can create text layouts.
@@ -445,7 +443,7 @@ impl<'a, 'b> UpdateCtx<'a, 'b> {
 
     /// get the `WidgetId` of the current widget.
     pub fn widget_id(&self) -> WidgetId {
-        self.widget_id
+        self.base_state.id
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -128,6 +128,12 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
     }
 
+    /// Read-only access to state. We don't mark the field as `pub` because
+    /// we want to control mutation.
+    pub(crate) fn state(&self) -> &BaseState {
+        &self.state
+    }
+
     /// Query the "active" state of the widget.
     pub fn is_active(&self) -> bool {
         self.state.is_active
@@ -200,6 +206,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             let color = env.get_debug_color(id);
             ctx.stroke(rect, &color, 1.0);
         }
+
+        self.state.needs_inval = false;
     }
 
     /// Paint the widget, translating it by the origin of its layout rectangle.
@@ -490,19 +498,19 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             _ => (),
         }
 
-        let pre_childs_changed = ctx.children_changed;
-        let pre_inval = ctx.needs_inval;
-        ctx.children_changed = false;
-        ctx.needs_inval = false;
+        let mut child_ctx = UpdateCtx {
+            window: ctx.window,
+            text_factory: ctx.text_factory,
+            base_state: &mut self.state,
+            window_id: ctx.window_id,
+        };
 
         self.inner
-            .update(ctx, self.old_data.as_ref().unwrap(), data, env);
+            .update(&mut child_ctx, self.old_data.as_ref().unwrap(), data, env);
         self.old_data = Some(data.clone());
         self.env = Some(env.clone());
 
-        self.state.children_changed |= ctx.children_changed;
-        ctx.children_changed |= pre_childs_changed;
-        ctx.needs_inval |= pre_inval;
+        ctx.base_state.merge_up(&self.state)
     }
 }
 

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -125,15 +125,15 @@ fn participate_in_autofocus() {
     Harness::create("my test text".to_string(), widget, |harness| {
         harness.send_initial_events();
         // verify that we start out with four widgets registered for focus
-        assert_eq!(harness.window().focus_widgets, vec![id_1, id_2, id_3, id_4]);
+        assert_eq!(harness.window().focus_chain(), &[id_1, id_2, id_3, id_4]);
 
         // tell the replacer widget to swap its children
         harness.submit_command(REPLACE_CHILD, None);
 
         // verify that the two new children are registered for focus.
         assert_eq!(
-            harness.window().focus_widgets,
-            vec![id_1, id_2, id_3, id_5, id_6]
+            harness.window().focus_chain(),
+            &[id_1, id_2, id_3, id_5, id_6]
         );
     })
 }

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -47,10 +47,7 @@ pub struct Window<T: Data> {
     pub(crate) menu: Option<MenuDesc<T>>,
     pub(crate) context_menu: Option<MenuDesc<T>>,
     pub(crate) last_anim: Option<Instant>,
-    pub(crate) needs_inval: bool,
-    pub(crate) children_changed: bool,
     pub(crate) focus: Option<WidgetId>,
-    pub(crate) focus_widgets: Vec<WidgetId>,
     pub(crate) handle: WindowHandle,
     // delegate?
 }
@@ -78,10 +75,7 @@ impl<T: Data> PendingWindow<T> {
             menu,
             context_menu: None,
             last_anim: None,
-            needs_inval: false,
-            children_changed: false,
             focus: None,
-            focus_widgets: Vec::new(),
             handle,
         }
     }
@@ -91,6 +85,10 @@ impl<T: Data> Window<T> {
     /// `true` iff any child requested an animation frame during the last `AnimFrame` event.
     pub(crate) fn wants_animation_frame(&self) -> bool {
         self.last_anim.is_some()
+    }
+
+    pub(crate) fn focus_chain(&self) -> &[WidgetId] {
+        &self.root.state().focus_chain
     }
 
     pub(crate) fn set_menu(&mut self, mut menu: MenuDesc<T>, data: &T, env: &Env) {
@@ -174,7 +172,6 @@ impl<T: Data> Window<T> {
             win_ctx.set_cursor(&cursor);
         }
 
-        self.needs_inval |= base_state.needs_inval;
         // If children are changed during the handling of an event,
         // we need to send WidgetAdded and Register now, so that they
         // are ready for update/layout.
@@ -205,12 +202,6 @@ impl<T: Data> Window<T> {
         }
 
         self.root.lifecycle(&mut ctx, event, data, env);
-        self.needs_inval |= ctx.base_state.needs_inval;
-        self.children_changed |= ctx.base_state.children_changed;
-
-        if let LifeCycle::Register = event {
-            self.focus_widgets = std::mem::take(&mut ctx.base_state.focus_chain);
-        }
     }
 
     /// AnimFrame has special logic, so we implement it separately.
@@ -233,18 +224,15 @@ impl<T: Data> Window<T> {
     pub(crate) fn update(&mut self, win_ctx: &mut dyn WinCtx, data: &T, env: &Env) {
         self.update_title(data, env);
 
+        let mut base_state = BaseState::new(self.root.id());
         let mut update_ctx = UpdateCtx {
             text_factory: win_ctx.text_factory(),
+            base_state: &mut base_state,
             window: &self.handle,
-            needs_inval: false,
-            children_changed: false,
             window_id: self.id,
-            widget_id: self.root.id(),
         };
 
         self.root.update(&mut update_ctx, data, env);
-        self.needs_inval |= update_ctx.needs_inval;
-        self.children_changed |= update_ctx.children_changed;
     }
 
     pub(crate) fn invalidate_and_finalize(
@@ -253,14 +241,11 @@ impl<T: Data> Window<T> {
         data: &T,
         env: &Env,
     ) {
-        if self.needs_inval {
+        if self.root.state().needs_inval {
             self.handle.invalidate();
-            // TODO: should we just clear this after paint?
-            self.needs_inval = false;
         }
-        if self.children_changed {
+        if self.root.state().children_changed {
             self.lifecycle(queue, &LifeCycle::Register, data, env);
-            self.children_changed = false;
         }
     }
 
@@ -338,18 +323,18 @@ impl<T: Data> Window<T> {
             FocusChange::Focus(id) => Some(id),
             FocusChange::Next => self
                 .focus
-                .and_then(|id| self.focus_widgets.iter().position(|i| i == &id))
+                .and_then(|id| self.focus_chain().iter().position(|i| i == &id))
                 .map(|idx| {
-                    let next_idx = (idx + 1) % self.focus_widgets.len();
-                    self.focus_widgets[next_idx]
+                    let next_idx = (idx + 1) % self.focus_chain().len();
+                    self.focus_chain()[next_idx]
                 }),
             FocusChange::Previous => self
                 .focus
-                .and_then(|id| self.focus_widgets.iter().position(|i| i == &id))
+                .and_then(|id| self.focus_chain().iter().position(|i| i == &id))
                 .map(|idx| {
-                    let len = self.focus_widgets.len();
+                    let len = self.focus_chain().len();
                     let prev_idx = (idx + len - 1) % len;
-                    self.focus_widgets[prev_idx]
+                    self.focus_chain()[prev_idx]
                 }),
         }
     }


### PR DESCRIPTION
The Window struct had a bunch of state that duplicated things
that were available through the BaseState of the root widget.

This removes the duplicates, and makes BaseState canonical.

In addition, it makes two small related changes:

- It moves to using BaseState in UpdateCtx, removing duplicate state
there, and
- We now always set needs_inval to false after painting.