### PR TITLE
Make WindowConnected be an Event, unify WidgetAdded and Register

### DIFF
--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -37,11 +37,10 @@ use druid::{
     TimerToken, UpdateCtx, Widget, WindowDesc,
 };
 
-const CYCLE_DURATION: Duration = Duration::from_millis(200);
+const CYCLE_DURATION: Duration = Duration::from_millis(100);
 
 const FREEZE_COLOR: Selector = Selector::new("identity-example.freeze-color");
 const UNFREEZE_COLOR: Selector = Selector::new("identity-example.unfreeze-color");
-const SET_INITIAL_TOKEN: Selector = Selector::new("identity-example.set-initial-token");
 
 /// Honestly: it's just a color in fancy clothing.
 #[derive(Debug, Clone, Data, Lens)]
@@ -102,7 +101,7 @@ impl Widget<OurData> for ColorWell {
                 ctx.invalidate();
             }
 
-            Event::Command(cmd) if cmd.selector == SET_INITIAL_TOKEN => {
+            Event::WindowConnected if self.randomize => {
                 self.token = ctx.request_timer(Instant::now() + CYCLE_DURATION);
             }
 
@@ -119,13 +118,7 @@ impl Widget<OurData> for ColorWell {
         }
     }
 
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &OurData, _: &Env) {
-        match event {
-            LifeCycle::WindowConnected if self.randomize => {
-                ctx.submit_command(SET_INITIAL_TOKEN, ctx.widget_id());
-            }
-            _ => (),
-        }
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &OurData, _: &Env) {
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &OurData, data: &OurData, _: &Env) {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -54,12 +54,11 @@ pub struct EventCtx<'a, 'b> {
 ///
 /// Certain methods on this context are only meaningful during the handling of
 /// specific lifecycle events; for instance [`register_child`]
-/// should only be called while handling [`LifeCycle::Register`].
+/// should only be called while handling [`LifeCycle::WidgetAdded`].
 ///
 /// [`lifecycle`]: widget/trait.Widget.html#tymethod.lifecycle
 /// [`register_child`]: #method.register_child
-/// [`LifeCycleCtx::register_child`]: #method.register_child
-/// [`LifeCycle::Register`]: enum.LifeCycle.html#variant.Register
+/// [`LifeCycle::WidgetAdded`]: enum.LifeCycle.html#variant.WidgetAdded
 pub struct LifeCycleCtx<'a> {
     pub(crate) command_queue: &'a mut CommandQueue,
     pub(crate) base_state: &'a mut BaseState,
@@ -374,7 +373,7 @@ impl<'a> LifeCycleCtx<'a> {
 
     /// Registers a child widget.
     ///
-    /// This should only be called in response to a `LifeCycle::Register` event.
+    /// This should only be called in response to a `LifeCycle::WidgetAdded` event.
     ///
     /// In general, you should not need to call this method; it is handled by
     /// the `WidgetPod`.

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -46,6 +46,16 @@ use crate::{Command, Target, WidgetId};
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Debug, Clone)]
 pub enum Event {
+    /// Sent to all widgets in a given window when that window is first instantiated.
+    ///
+    /// This should always be the first `Event` received, although widgets will
+    /// receive [`LifeCycle::WidgetAdded`] first.
+    ///
+    /// Widgets should handle this event if they need to do some addition setup
+    /// when a window is first created.
+    ///
+    /// [`LifeCycle::WidgetAdded`]: enum.LifeCycle.html#variant.WidgetAdded
+    WindowConnected,
     /// Called on the root widget when the window size changes.
     ///
     /// Discussion: it's not obvious this should be propagated to user
@@ -129,18 +139,10 @@ pub enum LifeCycle {
     /// Sent to a `Widget` when it is added to the widget tree. This should be
     /// the first message that each widget receives.
     ///
-    /// Widgets should handle this event if they need to do any one-time setup
-    /// that requires access to `Data`.
-    WidgetAdded,
-    /// Sent to all widgets in a given window when that window is first instantiated.
+    /// Widgets should handle this event in order to do any initial setup.
     ///
-    /// This is sent after `WidgetAdded`. Widgets should handle this event if
-    /// they need to do some addition setup when a window is first created.
-    WindowConnected,
-    /// Sent to a widget when it or any of its children have changed.
-    ///
-    /// This event is used to register widgets with the framework, as well
-    /// as to register widgets to participate in certain framework features.
+    /// In addition to setup, this event is also used by the framework to
+    /// track certain types of important widget state.
     ///
     /// ## Registering children
     ///
@@ -157,7 +159,7 @@ pub enum LifeCycle {
     /// [`LifeCycleCtx::register_child`]: struct.LifeCycleCtx.html#method.register_child
     /// [`WidgetPod`]: struct.WidgetPod.html
     /// [`LifeCycleCtx::register_for_focus`]: struct.LifeCycleCtx.html#method.register_for_focus
-    Register,
+    WidgetAdded,
     /// Called at the beginning of a new animation frame.
     ///
     /// On the first frame when transitioning from idle to animating, `interval`

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -127,9 +127,7 @@ impl<T: Data> Harness<'_, T> {
     /// Send the events that would normally be sent when the app starts.
     // should we do this automatically? Also these will change regularly?
     pub fn send_initial_events(&mut self) {
-        self.lifecycle(LifeCycle::WidgetAdded);
-        self.lifecycle(LifeCycle::Register);
-        self.lifecycle(LifeCycle::WindowConnected);
+        self.event(Event::WindowConnected);
         self.event(Event::Size(DEFAULT_SIZE));
     }
 
@@ -155,8 +153,7 @@ impl<T: Data> Harness<'_, T> {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn lifecycle(&mut self, event: LifeCycle) {
+    fn lifecycle(&mut self, event: LifeCycle) {
         self.inner.lifecycle(event)
     }
 
@@ -188,7 +185,6 @@ impl<T: Data> Inner<T> {
         );
     }
 
-    #[allow(dead_code)]
     fn lifecycle(&mut self, event: LifeCycle) {
         self.window
             .lifecycle(&mut self.cmds, &event, &self.data, &self.env);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -336,8 +336,7 @@ impl Widget<String> for TextBox {
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &String, _env: &Env) {
         match event {
-            LifeCycle::WidgetAdded => ctx.invalidate(),
-            LifeCycle::Register => ctx.register_for_focus(),
+            LifeCycle::WidgetAdded => ctx.register_for_focus(),
             // an open question: should we be able to schedule timers here?
             LifeCycle::FocusChanged(true) => ctx.submit_command(RESET_BLINK, ctx.widget_id()),
             _ => (),


### PR DESCRIPTION
Based on #510, which should go in first.

WindowConnected:

The distinction between Event events and LifeCycle events
is best expressed in terms of their source. Event events originate
in the platform; they are things like mouse movement, timers,
and key events.

LifeCycle events are things that are generated by the druid framework,
generally in the process of handling some other event or state change.

Under this framework, WindowConnected is more like an Event event than
like a LifeCycle event, and moving it there lets us delete some code,
which is generally a good sign.

WidgetAdded and Register:

In addition to that change, this also unifies the Register and WidgetAdded
events. These were pretty much always sent at the same time, and unifying
them should reduce confusion: from now on there is only WidgetAdded,
and that is the event that widgets need to handle to do their initial setup.