### PR TITLE
Add ability to inspect all widgets' BaseState during tests

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -448,6 +448,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     self.state.children.contains(&widget)
                 }
             }
+            #[cfg(test)]
+            LifeCycle::DebugInspectState(f) => {
+                f.call(&self.state);
+                true
+            }
             _ => true,
         };
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -73,4 +73,4 @@ pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};
 
 #[cfg(test)]
-pub(crate) use event::StateCell;
+pub(crate) use event::{StateCell, StateCheckFn};

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -108,6 +108,14 @@ impl<T: Data> Harness<'_, T> {
         cell.take()
     }
 
+    /// Inspect the `BaseState` of each widget in the tree.
+    ///
+    /// The provided closure will be called on each widget.
+    pub(crate) fn inspect_state(&mut self, f: impl Fn(&BaseState) + 'static) {
+        let checkfn = StateCheckFn::new(f);
+        self.lifecycle(LifeCycle::DebugInspectState(checkfn))
+    }
+
     /// Send a command to a target.
     pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
         let target = target.into().unwrap_or_else(|| self.inner.window.id.into());

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -123,6 +123,10 @@ fn participate_in_autofocus() {
     );
 
     Harness::create("my test text".to_string(), widget, |harness| {
+        // verify that all widgets are marked as having children_changed
+        // (this should always be true for a new widget)
+        harness.inspect_state(|state| assert!(state.children_changed));
+
         harness.send_initial_events();
         // verify that we start out with four widgets registered for focus
         assert_eq!(harness.window().focus_widgets, vec![id_1, id_2, id_3, id_4]);
@@ -135,6 +139,9 @@ fn participate_in_autofocus() {
             harness.window().focus_widgets,
             vec![id_1, id_2, id_3, id_5, id_6]
         );
+
+        // verify that no widgets still report that their children changed:
+        harness.inspect_state(|state| assert!(!state.children_changed))
     })
 }
 


### PR DESCRIPTION
This is another little testing helper I thought would be useful: basically you can send a closure to each widget that will be called with that widget's state, which is useful for verifying invariants that are supposed to hold across the entire graph.