### PR TITLE
Separate paint rects from layout rects

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -23,8 +23,8 @@ use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::piet::Piet;
 use crate::piet::RenderContext;
 use crate::{
-    Affine, Command, Cursor, Rect, Size, Target, Text, TimerToken, WidgetId, WinCtx, WindowHandle,
-    WindowId,
+    Affine, Command, Cursor, Insets, Rect, Size, Target, Text, TimerToken, WidgetId, WinCtx,
+    WindowHandle, WindowId,
 };
 
 /// A mutable context provided to event handling methods of widgets.
@@ -90,6 +90,7 @@ pub struct UpdateCtx<'a, 'b: 'a> {
 /// during widget layout.
 pub struct LayoutCtx<'a, 'b: 'a> {
     pub(crate) text_factory: &'a mut Text<'b>,
+    pub(crate) paint_insets: Insets,
     pub(crate) window_id: WindowId,
 }
 
@@ -467,6 +468,21 @@ impl<'a, 'b> LayoutCtx<'a, 'b> {
     /// Get the window id.
     pub fn window_id(&self) -> WindowId {
         self.window_id
+    }
+
+    /// Set explicit paint [`Insets`] for this widget.
+    ///
+    /// You are not required to set explicit paint bounds unless you need
+    /// to paint outside of your layout bounds. In this case, the argument
+    /// should be an [`Insets`] struct that indicates where your widget
+    /// needs to overpaint, relative to its bounds.
+    ///
+    /// For more information, see [`WidgetPod::paint_insets`].
+    ///
+    /// [`Insets`]: struct.Insets.html
+    /// [`WidgetPod::paint_insets`]: struct.WidgetPod.html#method.paint_insets
+    pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
+        self.paint_insets = insets.into().nonnegative();
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
 use log;
 
 use crate::bloom::Bloom;
-use crate::kurbo::{Affine, Point, Rect, Shape, Size};
+use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size};
 use crate::piet::RenderContext;
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
@@ -43,7 +43,7 @@ pub(crate) type CommandQueue = VecDeque<(Target, Command)>;
 /// needs to propagate, and to provide the previous data so that a
 /// widget can process a diff between the old value and the new.
 ///
-/// [`update`]: trait.Widget.html#tymethod.update
+/// [`update`]: widget/trait.Widget.html#tymethod.update
 pub struct WidgetPod<T: Data, W: Widget<T>> {
     state: BaseState,
     old_data: Option<T>,
@@ -64,12 +64,16 @@ pub struct WidgetPod<T: Data, W: Widget<T>> {
 /// that, widgets will generally not interact with it directly,
 /// but it is an important part of the [`WidgetPod`] struct.
 ///
-/// [`paint`]: trait.Widget.html#tymethod.paint
+/// [`paint`]: widget/trait.Widget.html#tymethod.paint
 /// [`WidgetPod`]: struct.WidgetPod.html
 #[derive(Clone)]
 pub(crate) struct BaseState {
     pub(crate) id: WidgetId,
     pub(crate) layout_rect: Rect,
+    /// The insets applied to the layout rect to generate the paint rect.
+    /// In general, these will be zero; the exception is for things like
+    /// drop shadows or overflowing text.
+    paint_insets: Insets,
 
     // TODO: consider using bitflags for the booleans.
 
@@ -172,11 +176,63 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         self.state.layout_rect = layout_rect;
     }
 
-    /// Get the layout rectangle.
-    ///
-    /// This will be same value as set by `set_layout_rect`.
+    #[deprecated(since = "0.5.0", note = "use layout_rect() instead")]
+    #[doc(hidden)]
     pub fn get_layout_rect(&self) -> Rect {
         self.state.layout_rect
+    }
+
+    /// The layout rectangle.
+    ///
+    /// This will be same value as set by `set_layout_rect`.
+    pub fn layout_rect(&self) -> Rect {
+        self.state.layout_rect
+    }
+
+    /// Get the widget's paint [`Rect`].
+    ///
+    /// This is the [`Rect`] that widget has indicated it needs to paint in.
+    /// This is the same as the [`layout_rect`] with the [`paint_insets`] applied;
+    /// in the general case it is the same as the [`layout_rect`].
+    ///
+    /// [`layout_rect`]: #method.layout_rect
+    /// [`Rect`]: struct.Rect.html
+    /// [`paint_insets`]: #method.paint_insets
+    pub fn paint_rect(&self) -> Rect {
+        self.state.paint_rect()
+    }
+
+    /// Return the paint [`Insets`] for this widget.
+    ///
+    /// If these [`Insets`] are nonzero, they describe the area beyond a widget's
+    /// layout rect where it needs to paint.
+    ///
+    /// These are generally zero; exceptions are widgets that do things like
+    /// paint a drop shadow.
+    ///
+    /// A widget can set its insets by calling [`set_paint_insets`] during its
+    /// [`layout`] method.
+    ///
+    /// [`Insets`]: struct.Insets.html
+    /// [`set_paint_insets`]: struct.LayoutCtx.html#method.set_paint_insets
+    /// [`layout`]: widget/trait.Widget.html#tymethod.layout
+    pub fn paint_insets(&self) -> Insets {
+        self.state.paint_insets
+    }
+
+    /// Given a parents layout size, determine the appropriate paint `Insets`
+    /// for the parent.
+    ///
+    /// This is a convenience method to be used from the [`layout`] method
+    /// of a `Widget` that manages a child; it allows the parent to correctly
+    /// propogate a child's desired paint rect, if it extends beyond the bounds
+    /// of the parent's layout rect.
+    ///
+    /// [`layout`]: widget/trait.Widget.html#tymethod.layout
+    pub fn compute_parent_paint_rect(&self, parent_size: Size) -> Insets {
+        let parent_bounds = Rect::ZERO.with_size(parent_size);
+        let union_pant_rect = self.paint_rect().union(parent_bounds);
+        union_pant_rect - parent_bounds
     }
 
     /// Paint a child widget.
@@ -187,8 +243,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Note that this method does not apply the offset of the layout rect.
     /// If that is desired, use [`paint_with_offset`] instead.
     ///
-    /// [`layout`]: trait.Widget.html#method.layout
-    /// [`paint`]: trait.Widget.html#method.paint
+    /// [`layout`]: widget/trait.Widget.html#tymethod.layout
+    /// [`paint`]: widget/trait.Widget.html#tymethod.paint
     /// [`paint_with_offset`]: #method.paint_with_offset
     pub fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {
         let mut ctx = PaintCtx {
@@ -235,7 +291,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         env: &Env,
         paint_if_not_visible: bool,
     ) {
-        if !paint_if_not_visible && !paint_ctx.region().intersects(self.state.layout_rect) {
+        if !paint_if_not_visible && !paint_ctx.region().intersects(self.state.paint_rect()) {
             return;
         }
 
@@ -269,7 +325,10 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         data: &T,
         env: &Env,
     ) -> Size {
-        self.inner.layout(layout_ctx, bc, data, &env)
+        layout_ctx.paint_insets = Insets::ZERO;
+        let size = self.inner.layout(layout_ctx, bc, data, &env);
+        self.state.paint_insets = layout_ctx.paint_insets;
+        size
     }
 
     /// Propagate an event.
@@ -536,6 +595,7 @@ impl BaseState {
         BaseState {
             id,
             layout_rect: Rect::ZERO,
+            paint_insets: Insets::ZERO,
             needs_inval: false,
             is_hot: false,
             is_active: false,
@@ -562,6 +622,15 @@ impl BaseState {
     #[inline]
     pub(crate) fn size(&self) -> Size {
         self.layout_rect.size()
+    }
+
+    /// The paint region for this widget.
+    ///
+    /// For more information, see [`WidgetPod::paint_rect`].
+    ///
+    /// [`WidgetPod::paint_rect`]: struct.WidgetPod.html#method.paint_rect
+    pub(crate) fn paint_rect(&self) -> Rect {
+        self.layout_rect + self.paint_insets
     }
 }
 

--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -169,7 +169,8 @@ impl Env {
     }
 
     /// Given an id, returns one of 18 distinct colors
-    pub(crate) fn get_debug_color(&self, id: u64) -> Color {
+    #[doc(hidden)]
+    pub fn get_debug_color(&self, id: u64) -> Color {
         let color_num = id as usize % self.0.debug_colors.len();
         self.0.debug_colors[color_num].clone()
     }

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -306,8 +306,39 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
     }
 }
 
+// easily make a bunch of WidgetIds
+pub fn widget_id2() -> (WidgetId, WidgetId) {
+    (WidgetId::next(), WidgetId::next())
+}
+
+pub fn widget_id3() -> (WidgetId, WidgetId, WidgetId) {
+    (WidgetId::next(), WidgetId::next(), WidgetId::next())
+}
+
 pub fn widget_id4() -> (WidgetId, WidgetId, WidgetId, WidgetId) {
     (
+        WidgetId::next(),
+        WidgetId::next(),
+        WidgetId::next(),
+        WidgetId::next(),
+    )
+}
+
+#[allow(dead_code)]
+pub fn widget_id5() -> (WidgetId, WidgetId, WidgetId, WidgetId, WidgetId) {
+    (
+        WidgetId::next(),
+        WidgetId::next(),
+        WidgetId::next(),
+        WidgetId::next(),
+        WidgetId::next(),
+    )
+}
+
+pub fn widget_id6() -> (WidgetId, WidgetId, WidgetId, WidgetId, WidgetId, WidgetId) {
+    (
+        WidgetId::next(),
+        WidgetId::next(),
         WidgetId::next(),
         WidgetId::next(),
         WidgetId::next(),

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -1,0 +1,172 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests related to layout.
+
+use super::*;
+
+#[test]
+fn simple_layout() {
+    const BOX_WIDTH: f64 = 200.;
+    const PADDING: f64 = 10.;
+
+    let id_1 = WidgetId::next();
+
+    let widget = Split::vertical(Label::new("hi"), Label::new("there"))
+        .fix_size(BOX_WIDTH, BOX_WIDTH)
+        .padding(10.0)
+        .with_id(id_1)
+        .center();
+
+    Harness::create(true, widget, |harness| {
+        harness.send_initial_events();
+        harness.just_layout();
+        let state = harness.get_state(id_1).expect("failed to retrieve id_1");
+        assert_eq!(
+            state.layout_rect.x0,
+            ((DEFAULT_SIZE.width - BOX_WIDTH) / 2.) - PADDING
+        );
+    })
+}
+
+#[test]
+fn row_column() {
+    let (id1, id2, id3, id4, id5, id6) = widget_id6();
+    let widget = Flex::row()
+        .with_child(
+            Flex::column()
+                .with_child(SizedBox::empty().with_id(id1), 1.0)
+                .with_child(SizedBox::empty().with_id(id2), 1.0),
+            1.0,
+        )
+        .with_child(
+            Flex::column()
+                .with_child(SizedBox::empty().with_id(id3), 1.0)
+                .with_child(SizedBox::empty().with_id(id4), 1.0)
+                .with_child(SizedBox::empty().with_id(id5), 1.0)
+                .with_child(SizedBox::empty().with_id(id6), 1.0),
+            1.0,
+        );
+
+    Harness::create((), widget, |harness| {
+        harness.send_initial_events();
+        harness.just_layout();
+        let state1 = harness.get_state(id1).expect("id1");
+        assert_eq!(state1.layout_rect.origin(), Point::ZERO);
+        let state2 = harness.get_state(id2).expect("id2");
+        assert_eq!(state2.layout_rect.origin(), Point::new(0., 200.));
+        let state3 = harness.get_state(id3).expect("id3");
+        assert_eq!(state3.layout_rect.origin(), Point::ZERO);
+        let state5 = harness.get_state(id5).expect("id5");
+        assert_eq!(state5.layout_rect.origin(), Point::new(0., 200.));
+    })
+}
+
+#[test]
+fn simple_paint_rect() {
+    let (id1, id2) = widget_id2();
+
+    let widget = ModularWidget::<(), ()>::new(())
+        .layout_fn(|_, ctx, bc, _, _| {
+            // this widget paints twenty points above below its layout bounds
+            ctx.set_paint_insets(Insets::uniform_xy(0., 20.));
+            bc.max()
+        })
+        .with_id(id1)
+        .fix_size(100., 100.)
+        .padding(10.0)
+        .with_id(id2)
+        .background(Color::BLACK)
+        .center();
+
+    Harness::create((), widget, |harness| {
+        harness.send_initial_events();
+        harness.just_layout();
+
+        let state = harness.get_state(id1).expect("id1");
+
+        // offset by padding
+        assert_eq!(state.layout_rect.origin(), Point::new(10., 10.,));
+        // offset by padding, but then inset by paint insets
+        assert_eq!(state.paint_rect().origin(), Point::new(10., -10.,));
+        // layout size is fixed
+        assert_eq!(state.layout_rect.size(), Size::new(100., 100.,));
+        // paint size is modified by insets
+        assert_eq!(state.paint_rect().size(), Size::new(100., 140.,));
+
+        // now does the container widget correctly propogate the child's paint rect?
+        let state = harness.get_state(id2).expect("id2");
+
+        assert_eq!(state.layout_rect.origin(), Point::ZERO);
+        // offset by padding, but then inset by paint insets
+        assert_eq!(state.paint_rect().origin(), Point::new(0., -10.,));
+        // 100 + 10 on each side
+        assert_eq!(state.layout_rect.size(), Size::new(120., 120.,));
+        // paint size is modified by insets
+        assert_eq!(state.paint_rect().size(), Size::new(120., 140.,));
+    })
+}
+
+#[test]
+/// Does a Flex correctly compute the union of multiple children's paint rects?
+fn flex_paint_rect_overflow() {
+    let id = WidgetId::next();
+
+    let widget = Flex::row()
+        .with_child(
+            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
+                ctx.set_paint_insets(Insets::new(20., 0., 0., 0.));
+                bc.constrain(Size::new(10., 10.))
+            }),
+            1.0,
+        )
+        .with_child(
+            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
+                ctx.set_paint_insets(Insets::new(0., 20., 0., 0.));
+                bc.constrain(Size::new(10., 10.))
+            }),
+            1.0,
+        )
+        .with_child(
+            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
+                ctx.set_paint_insets(Insets::new(0., 0., 0., 20.));
+                bc.constrain(Size::new(10., 10.))
+            }),
+            1.0,
+        )
+        .with_child(
+            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
+                ctx.set_paint_insets(Insets::new(0., 0., 20., 0.));
+                bc.constrain(Size::new(10., 10.))
+            }),
+            1.0,
+        )
+        .with_id(id)
+        .fix_height(200.)
+        .padding(10.)
+        .center();
+
+    Harness::create((), widget, |harness| {
+        harness.send_initial_events();
+        harness.just_layout();
+
+        let state = harness.get_state(id).unwrap();
+        assert_eq!(state.layout_rect.origin(), Point::new(10., 10.,));
+        assert_eq!(state.paint_rect().origin(), Point::new(-10., -10.,));
+        assert_eq!(
+            state.paint_rect().size(),
+            (state.layout_rect + Insets::uniform(20.)).size()
+        );
+    })
+}

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -16,6 +16,7 @@
 
 mod harness;
 mod helpers;
+mod layout_tests;
 
 use std::cell::Cell;
 use std::rc::Rc;
@@ -139,7 +140,7 @@ fn take_focus() {
             })
     }
 
-    let (id_1, id_2, _id_3) = (WidgetId::next(), WidgetId::next(), WidgetId::next());
+    let (id_1, id_2, _id_3) = widget_id3();
 
     // we use these so that we can check the widget's internal state
     let left_focus: Rc<Cell<Option<bool>>> = Default::default();
@@ -172,33 +173,8 @@ fn take_focus() {
 }
 
 #[test]
-fn simple_layout() {
-    const BOX_WIDTH: f64 = 200.;
-    const PADDING: f64 = 10.;
-
-    let id_1 = WidgetId::next();
-
-    let widget = Split::vertical(Label::new("hi"), Label::new("there"))
-        .fix_size(BOX_WIDTH, BOX_WIDTH)
-        .padding(10.0)
-        .with_id(id_1)
-        .center();
-
-    Harness::create(true, widget, |harness| {
-        harness.send_initial_events();
-        harness.just_layout();
-        let state = harness.get_state(id_1).expect("failed to retrieve id_1");
-        assert_eq!(
-            state.layout_rect.x0,
-            ((DEFAULT_SIZE.width - BOX_WIDTH) / 2.) - PADDING
-        );
-    })
-}
-
-#[test]
 fn participate_in_autofocus() {
-    let (id_1, id_2, id_3) = (WidgetId::next(), WidgetId::next(), WidgetId::next());
-    let (id_4, id_5, id_6) = (WidgetId::next(), WidgetId::next(), WidgetId::next());
+    let (id_1, id_2, id_3, id_4, id_5, id_6) = widget_id6();
 
     // this widget starts with a single child, and will replace them with a split
     // when we send it a command.
@@ -239,8 +215,7 @@ fn participate_in_autofocus() {
 
 #[test]
 fn child_tracking() {
-    let (id_1, id_2, id_3) = (WidgetId::next(), WidgetId::next(), WidgetId::next());
-    let id_4 = WidgetId::next();
+    let (id_1, id_2, id_3, id_4) = widget_id4();
 
     let widget = Split::vertical(
         SizedBox::empty().with_id(id_1),

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -127,6 +127,9 @@ impl<T: Data> Widget<T> for Align<T> {
             .resolve(Rect::new(0., 0., extra_width, extra_height));
         self.child
             .set_layout_rect(Rect::from_origin_size(origin, size));
+
+        let my_insets = self.child.compute_parent_paint_rect(my_size);
+        layout_ctx.set_paint_insets(my_insets);
         my_size
     }
 

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -104,10 +104,14 @@ impl<T: Data> Widget<T> for Container<T> {
         self.inner
             .set_layout_rect(Rect::from_origin_size(origin, size));
 
-        Size::new(
+        let my_size = Size::new(
             size.width + 2.0 * border_width,
             size.height + 2.0 * border_width,
-        )
+        );
+
+        let my_insets = self.inner.compute_parent_paint_rect(my_size);
+        ctx.set_paint_insets(my_insets);
+        my_size
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -89,11 +89,13 @@ impl<T: Data> Widget<T> for Either<T> {
             let size = self.true_branch.layout(layout_ctx, bc, data, env);
             self.true_branch
                 .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+            layout_ctx.set_paint_insets(self.true_branch.paint_insets());
             size
         } else {
             let size = self.false_branch.layout(layout_ctx, bc, data, env);
             self.false_branch
                 .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+            layout_ctx.set_paint_insets(self.true_branch.paint_insets());
             size
         }
     }

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -193,6 +193,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         let mut width = bc.min().width;
         let mut y = 0.0;
 
+        let mut paint_rect = Rect::ZERO;
         let mut children = self.children.iter_mut();
         data.for_each(|child_data, _| {
             let child = match children.next() {
@@ -208,11 +209,15 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
             let child_size = child.layout(layout_ctx, &child_bc, child_data, env);
             let rect = Rect::from_origin_size(Point::new(0.0, y), child_size);
             child.set_layout_rect(rect);
+            paint_rect = paint_rect.union(child.paint_rect());
             width = width.max(child_size.width);
             y += child_size.height;
         });
 
-        bc.constrain(Size::new(width, y))
+        let my_size = bc.constrain(Size::new(width, y));
+        let insets = paint_rect - Rect::ZERO.with_size(my_size);
+        layout_ctx.set_paint_insets(insets);
+        my_size
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -102,7 +102,11 @@ impl<T: Data> Widget<T> for Padding<T> {
         let origin = Point::new(self.left, self.top);
         self.child
             .set_layout_rect(Rect::from_origin_size(origin, size));
-        Size::new(size.width + hpad, size.height + vpad)
+
+        let my_size = Size::new(size.width + hpad, size.height + vpad);
+        let my_insets = self.child.compute_parent_paint_rect(my_size);
+        layout_ctx.set_paint_insets(my_insets);
+        my_size
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &T, env: &Env) {

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -259,6 +259,10 @@ impl<T: Data> Widget<T> for Split<T> {
         };
         self.child1.set_layout_rect(child1_rect);
         self.child2.set_layout_rect(child2_rect);
+
+        let paint_rect = self.child1.paint_rect().union(self.child2.paint_rect());
+        let insets = paint_rect - Rect::ZERO.with_size(my_size);
+        ctx.set_paint_insets(insets);
         my_size
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -17,7 +17,7 @@
 use std::mem;
 use std::time::Instant;
 
-use crate::kurbo::{Point, Rect, Size};
+use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::piet::{Piet, RenderContext};
 use crate::shell::{Counter, Cursor, WinCtx, WindowHandle};
 
@@ -279,6 +279,7 @@ impl<T: Data> Window<T> {
         let mut layout_ctx = LayoutCtx {
             text_factory: piet.text(),
             window_id: self.id,
+            paint_insets: Insets::ZERO,
         };
         let bc = BoxConstraints::tight(self.size);
         let size = self.root.layout(&mut layout_ctx, &bc, data, env);


### PR DESCRIPTION
This is based off of #512, which should be merged first.

This introduces the idea of a 'paint rect', which is the region
that a widget wishes to paint inside. In the general case this is
equivalent to the widget's layout rect; the exceptions are cases
where widgets explicitly wish to paint outside of their bounds.

the paint region is specified as Insets relative to the layout rect.
Widgets that need an explicit paint region specify that region when
handling the Widget::layout method.

closes #401