### PR TITLE
Fix incorrectly propogating is_hot to parents

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -554,7 +554,6 @@ impl BaseState {
         self.needs_inval |= child_state.needs_inval;
         self.request_anim |= child_state.request_anim;
         self.request_timer |= child_state.request_timer;
-        self.is_hot |= child_state.is_hot;
         self.has_active |= child_state.has_active;
         self.children_changed |= child_state.children_changed;
         self.request_focus = self.request_focus.or(child_state.request_focus);

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -290,7 +290,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
-        let inval = ctx.needs_inval;
+        let inval = ctx.base_state.needs_inval;
         self.recording.push(Record::Update(inval));
     }
 
@@ -304,4 +304,13 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
         self.inner.paint(ctx, data, env);
         self.recording.push(Record::Paint)
     }
+}
+
+pub fn widget_id4() -> (WidgetId, WidgetId, WidgetId, WidgetId) {
+    (
+        WidgetId::next(),
+        WidgetId::next(),
+        WidgetId::next(),
+        WidgetId::next(),
+    )
 }


### PR DESCRIPTION
This was a simple bug; we were treating `is_hot` as something
that should be propogated from children to parents, where it is
actually calculated directly for each widget.

fixes #493