### PR TITLE
Don't invalidate fade on scrollbar hover

### DIFF
--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -322,9 +322,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     } else {
                         self.scroll_bars.hovered = BarHoveredState::Horizontal;
                     }
-
-                    self.scroll_bars.opacity = env.get(theme::SCROLL_BAR_MAX_OPACITY);
-                    self.scroll_bars.timer_id = TimerToken::INVALID; // Cancel any fade out in progress
+                    self.reset_scrollbar_fade(ctx, &env);
                     ctx.invalidate();
                 }
                 Event::MouseDown(event) => {


### PR DESCRIPTION
Previously we attempted to always have the scrollbars be visible if
the mouse is over them, which would cause them to never fade if
the mouse moved directly from a scrollbar out of the window.

This fixes that by allowing the scrollbars to fade even if hovered,
which feels more natural to me in any case.

fixes #492