### PR TITLE
Implement 'one-shot' Commands

### DIFF
--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -109,6 +109,7 @@ impl Widget<OurData> for ColorWell {
             Event::Command(cmd) if cmd.selector == FREEZE_COLOR => {
                 self.frozen = cmd
                     .get_object::<Color>()
+                    .ok()
                     .cloned()
                     .expect("payload is always a Color")
                     .into();

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -496,7 +496,7 @@ impl<T: Data> DruidHandler<T> {
     }
 
     fn new_window(&mut self, cmd: Command) -> Result<(), Box<dyn std::error::Error>> {
-        let desc = cmd.get_object::<WindowDesc<T>>()?;
+        let desc = cmd.take_object::<WindowDesc<T>>()?;
         let window = desc.build_native(&self.app_state)?;
         window.show();
         Ok(())


### PR DESCRIPTION
This adds a way to construct a Command with an argument that can
only be taken by value, never borrowed; this means that the object
can only be used once. It also adds an error type to report the various
failure conditions when trying to access a command's argument.

This is intended to help address #403, but should be helpful in
other special cases as well.