### PR TITLE
Make WindowDesc be single use

### DIFF
--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -496,7 +496,7 @@ impl<T: Data> DruidHandler<T> {
     }
 
     fn new_window(&mut self, cmd: Command) -> Result<(), Box<dyn std::error::Error>> {
-        let desc = cmd.get_object::<WindowDesc<T>>()?;
+        let desc = cmd.take_object::<WindowDesc<T>>()?;
         let window = desc.build_native(&self.app_state)?;
         window.show();
         Ok(())


### PR DESCRIPTION
This is based off of #518.

WindowDesc::build_native now takes self by value, so that multiple windows
cannot be constructed from a single WindowDesc.

As potential followup, we could probably combine WindowDesc with PendingWindow.

fixes #403