### PR TITLE
Swap horizontal and vertical descriptors. Fix up documentation to match.

### DIFF
--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -19,10 +19,10 @@ use druid::widget::{Align, Container, Label, Padding, Split};
 use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
-    let fixed_horizontal = Padding::new(
+    let fixed_vertical = Padding::new(
         10.0,
         Container::new(
-            Split::horizontal(
+            Split::vertical(
                 Align::centered(Label::new("Left Split")),
                 Align::centered(Label::new("Right Split")),
             )
@@ -30,10 +30,10 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    let fixed_vertical = Padding::new(
+    let fixed_horizontal = Padding::new(
         10.0,
         Container::new(
-            Split::vertical(
+            Split::horizontal(
                 Align::centered(Label::new("Top Split")),
                 Align::centered(Label::new("Bottom Split")),
             )
@@ -42,12 +42,12 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    let draggable_horizontal = Padding::new(
+    let draggable_vertical = Padding::new(
         10.0,
         Container::new(
-            Split::horizontal(
+            Split::vertical(
                 Align::centered(Label::new("Split A")),
-                Split::horizontal(
+                Split::vertical(
                     Align::centered(Label::new("Split B")),
                     Align::centered(Label::new("Split C")),
                 )
@@ -58,15 +58,15 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    let draggable_vertical = Padding::new(
+    let draggable_horizontal = Padding::new(
         10.0,
         Container::new(
-            Split::vertical(
-                Split::vertical(fixed_horizontal, fixed_vertical)
+            Split::horizontal(
+                Split::horizontal(fixed_vertical, fixed_horizontal)
                     .split_point(0.33)
                     .splitter_size(5.0)
                     .draggable(true),
-                draggable_horizontal,
+                draggable_vertical,
             )
             .split_point(0.75)
             .splitter_size(5.0)
@@ -74,7 +74,7 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    draggable_vertical
+    draggable_horizontal
 }
 
 fn main() {


### PR DESCRIPTION
As discussed on Zulip - it appears that convention when naming splits is the opposite of what I had - which way the splitter runs, rather than which dimension it divides. This adjusts the `Split`'s functionality to match that.

Users will need to swap their invocations to get the same layouts.