### PR TITLE
Remove needless generic bounds

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -44,7 +44,7 @@ pub(crate) type CommandQueue = VecDeque<(Target, Command)>;
 /// widget can process a diff between the old value and the new.
 ///
 /// [`update`]: widget/trait.Widget.html#tymethod.update
-pub struct WidgetPod<T: Data, W: Widget<T>> {
+pub struct WidgetPod<T, W> {
     state: BaseState,
     old_data: Option<T>,
     env: Option<Env>,
@@ -115,7 +115,7 @@ pub(crate) enum FocusChange {
     Previous,
 }
 
-impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
+impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// Create a new widget pod.
     ///
     /// In a widget hierarchy, each widget is wrapped in a `WidgetPod`
@@ -234,7 +234,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let union_pant_rect = self.paint_rect().union(parent_bounds);
         union_pant_rect - parent_bounds
     }
+}
 
+impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// Paint a child widget.
     ///
     /// Generally called by container widgets as part of their [`paint`]
@@ -575,7 +577,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     }
 }
 
-impl<T: Data, W: Widget<T> + 'static> WidgetPod<T, W> {
+impl<T, W: Widget<T> + 'static> WidgetPod<T, W> {
     /// Box the contained widget.
     ///
     /// Convert a `WidgetPod` containing a widget of a specific concrete type

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -40,14 +40,14 @@ pub(crate) const DEFAULT_SIZE: Size = Size::new(400., 400.);
 /// if you want those functions run you will need to call them yourself.
 ///
 /// Also, timers don't work.  ¯\_(ツ)_/¯
-pub struct Harness<'a, T: Data> {
+pub struct Harness<'a, T> {
     piet: Piet<'a>,
     inner: Inner<T>,
 }
 
 /// All of the state except for the `Piet` (render context). We need to pass
 /// that in to get around some lifetime issues.
-struct Inner<T: Data> {
+struct Inner<T> {
     data: T,
     env: Env,
     window: Window<T>,

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -55,7 +55,7 @@ pub struct ModularWidget<S, T> {
 }
 
 /// A widget that can replace its child on command
-pub struct ReplaceChild<T: Data> {
+pub struct ReplaceChild<T> {
     inner: WidgetPod<T, Box<dyn Widget<T>>>,
     replacer: Box<dyn Fn() -> Box<dyn Widget<T>>>,
 }

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -23,14 +23,14 @@ use crate::{
 use crate::piet::UnitPoint;
 
 /// A widget that aligns its child.
-pub struct Align<T: Data> {
+pub struct Align<T> {
     align: UnitPoint,
     child: WidgetPod<T, Box<dyn Widget<T>>>,
     width_factor: Option<f64>,
     height_factor: Option<f64>,
 }
 
-impl<T: Data> Align<T> {
+impl<T> Align<T> {
     /// Create widget with alignment.
     ///
     /// Note that the `align` parameter is specified as a `UnitPoint` in

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -26,7 +26,7 @@ struct BorderStyle {
 }
 
 /// A widget that provides simple visual styling options to a child.
-pub struct Container<T: Data> {
+pub struct Container<T> {
     background: Option<PaintBrush>,
     border: Option<BorderStyle>,
     corner_radius: f64,

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -21,14 +21,14 @@ use crate::{
 };
 
 /// A widget that switches between two possible child views.
-pub struct Either<T: Data> {
+pub struct Either<T> {
     closure: Box<dyn Fn(&T, &Env) -> bool>,
     true_branch: WidgetPod<T, Box<dyn Widget<T>>>,
     false_branch: WidgetPod<T, Box<dyn Widget<T>>>,
     current: bool,
 }
 
-impl<T: Data> Either<T> {
+impl<T> Either<T> {
     /// Create a new widget that switches between two views.
     ///
     /// The given closure is evaluated on data change. If its value is `true`, then

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -14,8 +14,6 @@
 
 //! A widget that accepts a closure to update the environment for its child.
 
-use std::marker::PhantomData;
-
 use crate::kurbo::Size;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
@@ -23,13 +21,12 @@ use crate::{
 };
 
 /// A widget that accepts a closure to update the environment for its child.
-pub struct EnvScope<T: Data, W: Widget<T>> {
+pub struct EnvScope<T, W> {
     f: Box<dyn Fn(&mut Env, &T)>,
     child: W,
-    phantom: PhantomData<T>,
 }
 
-impl<T: Data, W: Widget<T>> EnvScope<T, W> {
+impl<T, W> EnvScope<T, W> {
     /// Create a widget that updates the environment for its child.
     ///
     /// Accepts a closure that sets Env values.
@@ -55,7 +52,6 @@ impl<T: Data, W: Widget<T>> EnvScope<T, W> {
         EnvScope {
             f: Box::new(f),
             child,
-            phantom: Default::default(),
         }
     }
 }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -22,12 +22,12 @@ use crate::{
 };
 
 /// A container with either horizontal or vertical layout.
-pub struct Flex<T: Data> {
+pub struct Flex<T> {
     direction: Axis,
     children: Vec<ChildWidget<T>>,
 }
 
-struct ChildWidget<T: Data> {
+struct ChildWidget<T> {
     widget: WidgetPod<T, Box<dyn Widget<T>>>,
     params: Params,
 }
@@ -65,7 +65,7 @@ impl Axis {
     }
 }
 
-impl<T: Data> Flex<T> {
+impl<T> Flex<T> {
     /// Create a new horizontal stack.
     ///
     /// The child widgets are laid out horizontally, from left to right.

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// A list widget for a variable-size collection of items.
-pub struct List<T: Data> {
+pub struct List<T> {
     closure: Box<dyn Fn() -> Box<dyn Widget<T>>>,
     children: Vec<WidgetPod<T, Box<dyn Widget<T>>>>,
 }
@@ -60,7 +60,7 @@ impl<T: Data> List<T> {
 }
 
 /// This iterator enables writing List widget for any `Data`.
-pub trait ListIter<T: Data>: Data {
+pub trait ListIter<T>: Data {
     /// Iterate over each data child.
     fn for_each(&self, cb: impl FnMut(&T, usize));
 

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// A widget that just adds padding around its child.
-pub struct Padding<T: Data> {
+pub struct Padding<T> {
     left: f64,
     right: f64,
     top: f64,
@@ -30,7 +30,7 @@ pub struct Padding<T: Data> {
     child: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T: Data> Padding<T> {
+impl<T> Padding<T> {
     /// Create a new widget with the specified padding. This can either be an instance
     /// of [`kurbo::Insets`], a f64 for uniform padding, a 2-tuple for axis-uniform padding
     /// or 4-tuple with (left, top, right, bottom) values.

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -14,8 +14,6 @@
 
 //! A radio button widget.
 
-use std::marker::PhantomData;
-
 use crate::kurbo::{Circle, Point, Rect, Size};
 use crate::theme;
 use crate::widget::{Align, Flex, Label, LabelText, Padding};
@@ -26,13 +24,11 @@ use crate::{
 
 /// A group of radio buttons
 #[derive(Debug, Clone)]
-pub struct RadioGroup<T: Data + PartialEq> {
-    phantom: PhantomData<T>,
-}
+pub struct RadioGroup;
 
-impl<T: Data + PartialEq> RadioGroup<T> {
+impl RadioGroup {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
-    pub fn new(
+    pub fn new<T: Data + PartialEq>(
         variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
     ) -> impl Widget<T> {
         let mut col = Flex::column();
@@ -45,7 +41,7 @@ impl<T: Data + PartialEq> RadioGroup<T> {
 }
 
 /// A single radio button
-pub struct Radio<T: Data + PartialEq> {
+pub struct Radio<T> {
     variant: T,
     child_label: WidgetPod<T, Box<dyn Widget<T>>>,
 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -105,7 +105,7 @@ impl ScrollBarsState {
 /// when the child's bounds are larger than the viewport.
 ///
 /// The child is laid out with completely unconstrained layout bounds.
-pub struct Scroll<T: Data, W: Widget<T>> {
+pub struct Scroll<T, W> {
     child: WidgetPod<T, W>,
     child_size: Size,
     scroll_offset: Vec2,
@@ -113,7 +113,7 @@ pub struct Scroll<T: Data, W: Widget<T>> {
     scroll_bars: ScrollBarsState,
 }
 
-impl<T: Data, W: Widget<T>> Scroll<T, W> {
+impl<T, W: Widget<T>> Scroll<T, W> {
     /// Create a new scroll container.
     ///
     /// This method will allow scrolling in all directions if child's bounds

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -31,13 +31,13 @@ use crate::{
 /// If not given a child, SizedBox will try to size itself as close to the specified height
 /// and width as possible given the parent's constraints. If height or width is not set,
 /// it will be treated as zero.
-pub struct SizedBox<T: Data> {
+pub struct SizedBox<T> {
     inner: Option<Box<dyn Widget<T>>>,
     width: Option<f64>,
     height: Option<f64>,
 }
 
-impl<T: Data> SizedBox<T> {
+impl<T> SizedBox<T> {
     /// Construct container with child, and both width and height not set.
     pub fn new(inner: impl Widget<T> + 'static) -> Self {
         Self {

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 ///A container containing two other widgets, splitting the area either horizontally or vertically.
-pub struct Split<T: Data> {
+pub struct Split<T> {
     split_direction: Axis,
     draggable: bool,
     split_point: f64,
@@ -31,7 +31,7 @@ pub struct Split<T: Data> {
     child2: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T: Data> Split<T> {
+impl<T> Split<T> {
     ///Create a new split panel.
     fn new(
         split_direction: Axis,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -50,7 +50,7 @@ pub(crate) const EXT_EVENT_IDLE_TOKEN: IdleToken = IdleToken::new(2);
 ///
 /// This is something of an internal detail and possibly we don't want to surface
 /// it publicly.
-pub struct DruidHandler<T: Data> {
+pub struct DruidHandler<T> {
     /// The shared app state.
     app_state: Rc<RefCell<AppState<T>>>,
     /// The id for the current window.
@@ -58,7 +58,7 @@ pub struct DruidHandler<T: Data> {
 }
 
 /// State shared by all windows in the UI.
-pub(crate) struct AppState<T: Data> {
+pub(crate) struct AppState<T> {
     delegate: Option<Box<dyn AppDelegate<T>>>,
     command_queue: CommandQueue,
     ext_event_host: ExtEventHost,
@@ -68,12 +68,12 @@ pub(crate) struct AppState<T: Data> {
 }
 
 /// All active windows.
-struct Windows<T: Data> {
+struct Windows<T> {
     pending: HashMap<WindowId, PendingWindow<T>>,
     windows: HashMap<WindowId, Window<T>>,
 }
 
-impl<T: Data> Windows<T> {
+impl<T> Windows<T> {
     fn connect(&mut self, id: WindowId, handle: WindowHandle) {
         if let Some(pending) = self.pending.remove(&id) {
             let win = pending.into_window(id, handle);
@@ -602,7 +602,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
     }
 }
 
-impl<T: Data> Default for Windows<T> {
+impl<T> Default for Windows<T> {
     fn default() -> Self {
         Windows {
             windows: HashMap::new(),

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -33,14 +33,14 @@ use crate::{
 pub struct WindowId(u64);
 
 /// Internal window state that is waiting for a window handle to show up.
-pub(crate) struct PendingWindow<T: Data> {
+pub(crate) struct PendingWindow<T> {
     root: WidgetPod<T, Box<dyn Widget<T>>>,
     title: LocalizedString<T>,
     menu: Option<MenuDesc<T>>,
 }
 
 /// Per-window state not owned by user code.
-pub struct Window<T: Data> {
+pub struct Window<T> {
     pub(crate) id: WindowId,
     pub(crate) root: WidgetPod<T, Box<dyn Widget<T>>>,
     pub(crate) title: LocalizedString<T>,
@@ -53,7 +53,7 @@ pub struct Window<T: Data> {
     // delegate?
 }
 
-impl<T: Data> PendingWindow<T> {
+impl<T> PendingWindow<T> {
     pub(crate) fn new(
         root: impl Widget<T> + 'static,
         title: LocalizedString<T>,


### PR DESCRIPTION
We had allowed certain generic bounds to infect certain of
our types. This removes that wherever possible, maintaining
the separation of data and behaviour.