### PR TITLE
Simple layout invalidation

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -141,6 +141,20 @@ impl<'a, 'b> EventCtx<'a, 'b> {
         self.base_state.needs_inval = true;
     }
 
+    /// Request a layout pass.
+    ///
+    /// A Widget's [`layout`] method is always called when the widget tree
+    /// changes, or the window is resized.
+    ///
+    /// If your widget would like to have layout called at any other time,
+    /// (such as if it would like to change the layout of children in
+    /// response to some event) it must call this method.
+    ///
+    /// [`layout`]: trait.Widget.html#tymethod.layout
+    pub fn request_layout(&mut self) {
+        self.base_state.needs_layout = true;
+    }
+
     /// Indicate that your children have changed.
     ///
     /// Widgets must call this method after adding a new child.
@@ -374,6 +388,15 @@ impl<'a> LifeCycleCtx<'a> {
         self.base_state.needs_inval = true;
     }
 
+    /// Request layout.
+    ///
+    /// See [`EventCtx::request_layout`] for more information.
+    ///
+    /// [`EventCtx::request_layout`]: struct.EventCtx.html#method.request_layout
+    pub fn request_layout(&mut self) {
+        self.base_state.needs_layout = true;
+    }
+
     /// Returns the current widget's `WidgetId`.
     pub fn widget_id(&self) -> WidgetId {
         self.base_state.id
@@ -435,6 +458,15 @@ impl<'a, 'b> UpdateCtx<'a, 'b> {
     /// [`paint`]: trait.Widget.html#tymethod.paint
     pub fn request_paint(&mut self) {
         self.base_state.needs_inval = true;
+    }
+
+    /// Request layout.
+    ///
+    /// See [`EventCtx::request_layout`] for more information.
+    ///
+    /// [`EventCtx::request_layout`]: struct.EventCtx.html#method.request_layout
+    pub fn request_layout(&mut self) {
+        self.base_state.needs_layout = true;
     }
 
     /// Indicate that your children have changed.

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -155,6 +155,7 @@ impl<T: Data> Widget<T> for Split<T> {
                 Event::MouseMoved(mouse) => {
                     if ctx.is_active() {
                         self.update_splitter(ctx.size(), mouse.pos);
+                        ctx.request_layout();
                         ctx.request_paint();
                     }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -119,7 +119,7 @@ impl TextBox {
         self.selection.end
     }
 
-    /// Edit a selection using a `Movement`.    
+    /// Edit a selection using a `Movement`.
     fn move_selection(&mut self, mvmnt: Movement, text: &mut String, modify: bool) {
         // This movement function should ensure all movements are legit.
         // If they aren't, that's a problem with the movement function.

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -261,8 +261,13 @@ impl<T: Data> Window<T> {
         data: &T,
         env: &Env,
     ) {
+        // FIXME: only do AnimFrame if root has requested_anim?
         self.lifecycle(queue, &LifeCycle::AnimFrame(0), data, env);
-        self.layout(piet, data, env);
+
+        if self.root.state().needs_layout {
+            self.layout(piet, data, env);
+        }
+
         piet.clear(env.get(crate::theme::WINDOW_BACKGROUND_COLOR));
         self.paint(piet, data, env);
 


### PR DESCRIPTION
This adds minimal layout invalidation, where we will not call
layout() unless the widget tree has changed, the  window has
been resized, or a widget has explicitly called ctx.request_layout().

closes #400