### PR TITLE
[tests] Make Harness::get_state panic on failure

### DIFF
--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -100,9 +100,16 @@ impl<T: Data> Harness<'_, T> {
         &self.inner.data
     }
 
-    /// Retrieve a copy of this widget's `BaseState`, if possible.
-    //FIXME: make this unwrap, and add a `try_get_state` variant?
-    pub(crate) fn get_state(&mut self, widget: WidgetId) -> Option<BaseState> {
+    /// Retrieve a copy of this widget's `BaseState`, or die trying.
+    pub(crate) fn get_state(&mut self, widget: WidgetId) -> BaseState {
+        match self.try_get_state(widget) {
+            Some(thing) => thing,
+            None => panic!("get_state failed for widget {:?}", widget),
+        }
+    }
+
+    /// Attempt to retrieve a copy of this widget's `BaseState`.
+    pub(crate) fn try_get_state(&mut self, widget: WidgetId) -> Option<BaseState> {
         let cell = StateCell::default();
         let state_cell = cell.clone();
         self.lifecycle(LifeCycle::DebugRequestState { widget, state_cell });

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -32,7 +32,7 @@ fn simple_layout() {
     Harness::create(true, widget, |harness| {
         harness.send_initial_events();
         harness.just_layout();
-        let state = harness.get_state(id_1).expect("failed to retrieve id_1");
+        let state = harness.get_state(id_1);
         assert_eq!(
             state.layout_rect.x0,
             ((DEFAULT_SIZE.width - BOX_WIDTH) / 2.) - PADDING
@@ -62,13 +62,13 @@ fn row_column() {
     Harness::create((), widget, |harness| {
         harness.send_initial_events();
         harness.just_layout();
-        let state1 = harness.get_state(id1).expect("id1");
+        let state1 = harness.get_state(id1);
         assert_eq!(state1.layout_rect.origin(), Point::ZERO);
-        let state2 = harness.get_state(id2).expect("id2");
+        let state2 = harness.get_state(id2);
         assert_eq!(state2.layout_rect.origin(), Point::new(0., 200.));
-        let state3 = harness.get_state(id3).expect("id3");
+        let state3 = harness.get_state(id3);
         assert_eq!(state3.layout_rect.origin(), Point::ZERO);
-        let state5 = harness.get_state(id5).expect("id5");
+        let state5 = harness.get_state(id5);
         assert_eq!(state5.layout_rect.origin(), Point::new(0., 200.));
     })
 }
@@ -94,7 +94,7 @@ fn simple_paint_rect() {
         harness.send_initial_events();
         harness.just_layout();
 
-        let state = harness.get_state(id1).expect("id1");
+        let state = harness.get_state(id1);
 
         // offset by padding
         assert_eq!(state.layout_rect.origin(), Point::new(10., 10.,));
@@ -106,7 +106,7 @@ fn simple_paint_rect() {
         assert_eq!(state.paint_rect().size(), Size::new(100., 140.,));
 
         // now does the container widget correctly propogate the child's paint rect?
-        let state = harness.get_state(id2).expect("id2");
+        let state = harness.get_state(id2);
 
         assert_eq!(state.layout_rect.origin(), Point::ZERO);
         // offset by padding, but then inset by paint insets
@@ -161,7 +161,7 @@ fn flex_paint_rect_overflow() {
         harness.send_initial_events();
         harness.just_layout();
 
-        let state = harness.get_state(id).unwrap();
+        let state = harness.get_state(id);
         assert_eq!(state.layout_rect.origin(), Point::new(10., 10.,));
         assert_eq!(state.paint_rect().origin(), Point::new(-10., -10.,));
         assert_eq!(

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -73,9 +73,9 @@ fn propogate_hot() {
         // each widget received the expected HotChanged messages.
 
         harness.event(Event::MouseMoved(make_mouse(10., 10.)));
-        assert!(harness.get_state(root).unwrap().is_hot);
-        assert!(harness.get_state(empty).unwrap().is_hot);
-        assert!(!harness.get_state(pad).unwrap().is_hot);
+        assert!(harness.get_state(root).is_hot);
+        assert!(harness.get_state(empty).is_hot);
+        assert!(!harness.get_state(pad).is_hot);
 
         assert_matches!(root_rec.next(), Record::L(LifeCycle::HotChanged(true)));
         assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
@@ -83,10 +83,10 @@ fn propogate_hot() {
 
         harness.event(Event::MouseMoved(make_mouse(210., 10.)));
 
-        assert!(harness.get_state(root).unwrap().is_hot);
-        assert!(!harness.get_state(empty).unwrap().is_hot);
-        assert!(!harness.get_state(button).unwrap().is_hot);
-        assert!(harness.get_state(pad).unwrap().is_hot);
+        assert!(harness.get_state(root).is_hot);
+        assert!(!harness.get_state(empty).is_hot);
+        assert!(!harness.get_state(button).is_hot);
+        assert!(harness.get_state(pad).is_hot);
 
         assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
         assert_matches!(padding_rec.next(), Record::L(LifeCycle::HotChanged(true)));
@@ -94,10 +94,10 @@ fn propogate_hot() {
         assert!(root_rec.is_empty() && padding_rec.is_empty() && button_rec.is_empty());
 
         harness.event(Event::MouseMoved(make_mouse(260., 60.)));
-        assert!(harness.get_state(root).unwrap().is_hot);
-        assert!(!harness.get_state(empty).unwrap().is_hot);
-        assert!(harness.get_state(button).unwrap().is_hot);
-        assert!(harness.get_state(pad).unwrap().is_hot);
+        assert!(harness.get_state(root).is_hot);
+        assert!(!harness.get_state(empty).is_hot);
+        assert!(harness.get_state(button).is_hot);
+        assert!(harness.get_state(pad).is_hot);
 
         assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
         assert_matches!(padding_rec.next(), Record::E(Event::MouseMoved(_)));
@@ -106,10 +106,10 @@ fn propogate_hot() {
         assert!(root_rec.is_empty() && padding_rec.is_empty() && button_rec.is_empty());
 
         harness.event(Event::MouseMoved(make_mouse(10., 10.)));
-        assert!(harness.get_state(root).unwrap().is_hot);
-        assert!(harness.get_state(empty).unwrap().is_hot);
-        assert!(!harness.get_state(button).unwrap().is_hot);
-        assert!(!harness.get_state(pad).unwrap().is_hot);
+        assert!(harness.get_state(root).is_hot);
+        assert!(harness.get_state(empty).is_hot);
+        assert!(!harness.get_state(button).is_hot);
+        assert!(!harness.get_state(pad).is_hot);
 
         assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
         assert_matches!(padding_rec.next(), Record::L(LifeCycle::HotChanged(false)));
@@ -273,13 +273,13 @@ fn child_tracking() {
 
     Harness::create(true, widget, |harness| {
         harness.send_initial_events();
-        let root = harness.get_state(id_4).unwrap();
+        let root = harness.get_state(id_4);
         assert_eq!(root.children.entry_count(), 3);
         assert!(root.children.contains(&id_1));
         assert!(root.children.contains(&id_2));
         assert!(root.children.contains(&id_3));
 
-        let split = harness.get_state(id_3).unwrap();
+        let split = harness.get_state(id_3);
         assert!(split.children.contains(&id_1));
         assert!(split.children.contains(&id_2));
         assert_eq!(split.children.entry_count(), 2);


### PR DESCRIPTION
It previously returned an option, which we would invariably unwrap.
This should make tests a bit cleaner and a bit easier to read.