### PR TITLE
Always deliver mouse events to hot or active contents of Scroll

### DIFF
--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -233,12 +233,14 @@ pub struct WheelEvent {
 
 impl Event {
     /// Transform the event for the contents of a scrolling container.
-    pub fn transform_scroll(&self, offset: Vec2, viewport: Rect) -> Option<Event> {
-        // TODO: need to wire this up so that it always propagates mouse events
-        // if the widget is active.
+    ///
+    /// the `force` flag is used to ensure an event is delivered even
+    /// if the cursor is out of the viewport, such as if the contents are active
+    /// or hot.
+    pub fn transform_scroll(&self, offset: Vec2, viewport: Rect, force: bool) -> Option<Event> {
         match self {
             Event::MouseDown(mouse_event) => {
-                if viewport.winding(mouse_event.pos) != 0 {
+                if force || viewport.winding(mouse_event.pos) != 0 {
                     let mut mouse_event = mouse_event.clone();
                     mouse_event.pos += offset;
                     Some(Event::MouseDown(mouse_event))
@@ -247,7 +249,7 @@ impl Event {
                 }
             }
             Event::MouseUp(mouse_event) => {
-                if viewport.winding(mouse_event.pos) != 0 {
+                if force || viewport.winding(mouse_event.pos) != 0 {
                     let mut mouse_event = mouse_event.clone();
                     mouse_event.pos += offset;
                     Some(Event::MouseUp(mouse_event))
@@ -256,7 +258,7 @@ impl Event {
                 }
             }
             Event::MouseMoved(mouse_event) => {
-                if viewport.winding(mouse_event.pos) != 0 {
+                if force || viewport.winding(mouse_event.pos) != 0 {
                     let mut mouse_event = mouse_event.clone();
                     mouse_event.pos += offset;
                     Some(Event::MouseMoved(mouse_event))

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -349,7 +349,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 _ => unreachable!(),
             }
         } else {
-            let child_event = event.transform_scroll(self.scroll_offset, viewport);
+            let force_event = self.child.is_hot() || self.child.is_active();
+            let child_event = event.transform_scroll(self.scroll_offset, viewport, force_event);
             if let Some(child_event) = child_event {
                 self.child.event(ctx, &child_event, data, env)
             };


### PR DESCRIPTION
This fixes an issue where the content of a scroll widget would
not receive the first mouse event after the mouse had moved
out of the widget's layout rect.

This is related to, but subtley different from (in ways I am
confused by and am not going to look into right now) #492.

That is to say: I believe there is another bug in the scroll
logic, but I haven't been able to figure out what it is.

This PR also includes a commit that changes the list example to demonstrate the problem, which which also illustrates the remaining problem?