### PR TITLE
Fix scrollbar hit-testing

### DIFF
--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -256,19 +256,19 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     fn point_hits_vertical_bar(&self, viewport: Rect, pos: Point, env: &Env) -> bool {
         if viewport.height() < self.child_size.height {
             let bounds = self.calc_vertical_bar_bounds(viewport, &env);
-            return pos.y > bounds.y0 && pos.y < bounds.y1 && pos.x > bounds.x0;
+            bounds.contains(pos)
+        } else {
+            false
         }
-
-        false
     }
 
     fn point_hits_horizontal_bar(&self, viewport: Rect, pos: Point, env: &Env) -> bool {
         if viewport.width() < self.child_size.width {
             let bounds = self.calc_horizontal_bar_bounds(viewport, &env);
-            return pos.x > bounds.x0 && pos.x < bounds.x1 && pos.y > bounds.y0;
+            bounds.contains(pos)
+        } else {
+            false
         }
-
-        false
     }
 }
 


### PR DESCRIPTION
So this should *actually* fix #492? The bug was subtle: when testing
if the mouse was hovered over the scrollbar, we were not checking
that it did not extend past the scrollbar to be outside the widget,
presuming (I assume) that we would not receive such events; but this
led to us incorrectly supressing the last mouse move event (the event
that moved the mouse outside of our bounds) and so not correctly
fading the scrollbars or updating our children (so they could mark
themselves as non-hot).