### PR TITLE
Remove WinCtx type

### DIFF
--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -19,9 +19,7 @@ use time::Time;
 use piet_common::kurbo::{Line, Rect};
 use piet_common::{Color, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
-use druid_shell::{
-    Application, KeyEvent, RunLoop, WinCtx, WinHandler, WindowBuilder, WindowHandle,
-};
+use druid_shell::{Application, KeyEvent, RunLoop, WinHandler, WindowBuilder, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
@@ -37,7 +35,7 @@ impl WinHandler for PerfTest {
         self.handle = handle.clone();
     }
 
-    fn paint(&mut self, piet: &mut Piet, _ctx: &mut dyn WinCtx) -> bool {
+    fn paint(&mut self, piet: &mut Piet) -> bool {
         let (width, height) = self.size;
         let rect = Rect::new(0.0, 0.0, width, height);
         piet.fill(rect, &BG_COLOR);
@@ -80,19 +78,19 @@ impl WinHandler for PerfTest {
         true
     }
 
-    fn command(&mut self, id: u32, _ctx: &mut dyn WinCtx) {
+    fn command(&mut self, id: u32) {
         match id {
             0x100 => self.handle.close(),
             _ => println!("unexpected id {}", id),
         }
     }
 
-    fn key_down(&mut self, event: KeyEvent, _ctx: &mut dyn WinCtx) -> bool {
+    fn key_down(&mut self, event: KeyEvent) -> bool {
         println!("keydown: {:?}", event);
         false
     }
 
-    fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
+    fn size(&mut self, width: u32, height: u32) {
         let dpi = self.handle.get_dpi();
         let dpi_scale = dpi as f64 / 96.0;
         let width_f = (width as f64) / dpi_scale;
@@ -100,7 +98,7 @@ impl WinHandler for PerfTest {
         self.size = (width_f, height_f);
     }
 
-    fn destroy(&mut self, _ctx: &mut dyn WinCtx) {
+    fn destroy(&mut self) {
         Application::quit()
     }
 

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -19,7 +19,7 @@ use druid_shell::piet::{Color, RenderContext};
 
 use druid_shell::{
     Application, Cursor, FileDialogOptions, FileSpec, HotKey, KeyEvent, KeyModifiers, Menu,
-    MouseEvent, RunLoop, SysMods, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle,
+    MouseEvent, RunLoop, SysMods, TimerToken, WinHandler, WindowBuilder, WindowHandle,
 };
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
@@ -36,7 +36,7 @@ impl WinHandler for HelloState {
         self.handle = handle.clone();
     }
 
-    fn paint(&mut self, piet: &mut piet_common::Piet, _ctx: &mut dyn WinCtx) -> bool {
+    fn paint(&mut self, piet: &mut piet_common::Piet) -> bool {
         let (width, height) = self.size;
         let rect = Rect::new(0.0, 0.0, width, height);
         piet.fill(rect, &BG_COLOR);
@@ -44,7 +44,7 @@ impl WinHandler for HelloState {
         false
     }
 
-    fn command(&mut self, id: u32, ctx: &mut dyn WinCtx) {
+    fn command(&mut self, id: u32) {
         match id {
             0x100 => {
                 self.handle.close();
@@ -56,42 +56,42 @@ impl WinHandler for HelloState {
                     FileSpec::TEXT,
                     FileSpec::JPG,
                 ]);
-                let filename = ctx.open_file_sync(options);
+                let filename = self.handle.open_file_sync(options);
                 println!("result: {:?}", filename);
             }
             _ => println!("unexpected id {}", id),
         }
     }
 
-    fn key_down(&mut self, event: KeyEvent, ctx: &mut dyn WinCtx) -> bool {
+    fn key_down(&mut self, event: KeyEvent) -> bool {
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-        let id = ctx.request_timer(deadline);
+        let id = self.handle.request_timer(deadline);
         println!("keydown: {:?}, timer id = {:?}", event, id);
         false
     }
 
-    fn wheel(&mut self, delta: Vec2, mods: KeyModifiers, _ctx: &mut dyn WinCtx) {
+    fn wheel(&mut self, delta: Vec2, mods: KeyModifiers) {
         println!("mouse_wheel {:?} {:?}", delta, mods);
     }
 
-    fn mouse_move(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {
-        ctx.set_cursor(&Cursor::Arrow);
+    fn mouse_move(&mut self, event: &MouseEvent) {
+        self.handle.set_cursor(&Cursor::Arrow);
         println!("mouse_move {:?}", event);
     }
 
-    fn mouse_down(&mut self, event: &MouseEvent, _ctx: &mut dyn WinCtx) {
+    fn mouse_down(&mut self, event: &MouseEvent) {
         println!("mouse_down {:?}", event);
     }
 
-    fn mouse_up(&mut self, event: &MouseEvent, _ctx: &mut dyn WinCtx) {
+    fn mouse_up(&mut self, event: &MouseEvent) {
         println!("mouse_up {:?}", event);
     }
 
-    fn timer(&mut self, id: TimerToken, _ctx: &mut dyn WinCtx) {
+    fn timer(&mut self, id: TimerToken) {
         println!("timer fired: {:?}", id);
     }
 
-    fn size(&mut self, width: u32, height: u32, _ctx: &mut dyn WinCtx) {
+    fn size(&mut self, width: u32, height: u32) {
         let dpi = self.handle.get_dpi();
         let dpi_scale = dpi as f64 / 96.0;
         let width_f = (width as f64) / dpi_scale;
@@ -99,7 +99,7 @@ impl WinHandler for HelloState {
         self.size = (width_f, height_f);
     }
 
-    fn destroy(&mut self, _ctx: &mut dyn WinCtx) {
+    fn destroy(&mut self) {
         Application::quit()
     }
 

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -64,5 +64,5 @@ pub use menu::Menu;
 pub use mouse::{Cursor, MouseButton, MouseEvent};
 pub use runloop::RunLoop;
 pub use window::{
-    IdleHandle, IdleToken, Text, TimerToken, WinCtx, WinHandler, WindowBuilder, WindowHandle,
+    IdleHandle, IdleToken, Text, TimerToken, WinHandler, WindowBuilder, WindowHandle,
 };

--- a/druid-shell/src/platform/gtk/menu.rs
+++ b/druid-shell/src/platform/gtk/menu.rs
@@ -15,14 +15,12 @@
 //! GTK implementation of menus.
 
 use gdk::ModifierType;
-use gtk::AccelGroup;
-use gtk::GtkMenuExt;
-use gtk::Menu as GtkMenu;
-use gtk::MenuBar as GtkMenuBar;
-use gtk::MenuItem as GtkMenuItem;
-use gtk::{GtkMenuItemExt, MenuShellExt, SeparatorMenuItemBuilder, WidgetExt};
+use gtk::{
+    AccelGroup, GtkMenuExt, GtkMenuItemExt, Menu as GtkMenu, MenuBar as GtkMenuBar,
+    MenuItem as GtkMenuItem, MenuShellExt, SeparatorMenuItemBuilder, WidgetExt,
+};
 
-use super::window::{WinCtxImpl, WindowHandle};
+use super::window::WindowHandle;
 use crate::common_util::strip_access_key;
 use crate::hotkey::{HotKey, KeyCompare, RawMods};
 use crate::keyboard::KeyModifiers;
@@ -89,7 +87,7 @@ impl Menu {
                     let handle = handle.clone();
                     item.connect_activate(move |_| {
                         if let Some(state) = handle.state.upgrade() {
-                            state.handler.borrow_mut().command(id, &mut WinCtxImpl);
+                            state.handler.borrow_mut().command(id);
                         }
                     });
 

--- a/druid-shell/src/platform/gtk/menu.rs
+++ b/druid-shell/src/platform/gtk/menu.rs
@@ -88,10 +88,8 @@ impl Menu {
 
                     let handle = handle.clone();
                     item.connect_activate(move |_| {
-                        let mut ctx = WinCtxImpl::from(&handle);
-
                         if let Some(state) = handle.state.upgrade() {
-                            state.handler.borrow_mut().command(id, &mut ctx);
+                            state.handler.borrow_mut().command(id, &mut WinCtxImpl);
                         }
                     });
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -130,6 +130,46 @@ impl WindowHandle {
         self.0.set_menu(menu.into_inner())
     }
 
+    /// Get access to a type that can perform text layout.
+    pub fn text(&self) -> Text {
+        self.0.text()
+    }
+
+    /// Schedule a timer.
+    ///
+    /// This causes a [`WinHandler::timer()`] call at the deadline. The
+    /// return value is a token that can be used to associate the request
+    /// with the handler call.
+    ///
+    /// Note that this is not a precise timer. On Windows, the typical
+    /// resolution is around 10ms. Therefore, it's best used for things
+    /// like blinking a cursor or triggering tooltips, not for anything
+    /// requiring precision.
+    ///
+    /// [`WinHandler::timer()`]: trait.WinHandler.html#tymethod.timer
+    pub fn request_timer(&self, deadline: std::time::Instant) -> TimerToken {
+        self.0.request_timer(deadline)
+    }
+
+    /// Set the cursor icon.
+    pub fn set_cursor(&mut self, cursor: &Cursor) {
+        self.0.set_cursor(cursor)
+    }
+
+    /// Prompt the user to chose a file to open.
+    ///
+    /// Blocks while the user picks the file.
+    pub fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
+        self.0.open_file_sync(options)
+    }
+
+    /// Prompt the user to chose a path for saving.
+    ///
+    /// Blocks while the user picks a file.
+    pub fn save_as_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo> {
+        self.0.save_as_sync(options)
+    }
+
     /// Display a pop-up menu at the given position.
     ///
     /// `Point` is in the coordinate space of the window.
@@ -192,42 +232,7 @@ impl WindowBuilder {
 }
 
 /// A context supplied to most `WinHandler` methods.
-pub trait WinCtx<'a> {
-    /// Invalidate the entire window.
-    ///
-    /// TODO: finer grained invalidation.
-    fn invalidate(&mut self);
-
-    /// Get a reference to an object that can do text layout.
-    fn text_factory(&mut self) -> &mut Text<'a>;
-
-    /// Set the cursor icon.
-    fn set_cursor(&mut self, cursor: &Cursor);
-
-    /// Schedule a timer.
-    ///
-    /// This causes a [`WinHandler::timer()`] call at the deadline. The
-    /// return value is a token that can be used to associate the request
-    /// with the handler call.
-    ///
-    /// Note that this is not a precise timer. On Windows, the typical
-    /// resolution is around 10ms. Therefore, it's best used for things
-    /// like blinking a cursor or triggering tooltips, not for anything
-    /// requiring precision.
-    ///
-    /// [`WinHandler::timer()`]: trait.WinHandler.html#tymethod.timer
-    fn request_timer(&mut self, deadline: std::time::Instant) -> TimerToken;
-
-    /// Prompt the user to chose a file to open.
-    ///
-    /// Blocks while the user picks the file.
-    fn open_file_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo>;
-
-    /// Prompt the user to chose a path for saving.
-    ///
-    /// Blocks while the user picks a file.
-    fn save_as_sync(&mut self, options: FileDialogOptions) -> Option<FileInfo>;
-}
+pub trait WinCtx<'a> {}
 
 /// App behavior, supplied by the app.
 ///

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -231,9 +231,6 @@ impl WindowBuilder {
     }
 }
 
-/// A context supplied to most `WinHandler` methods.
-pub trait WinCtx<'a> {}
-
 /// App behavior, supplied by the app.
 ///
 /// Many of the "window procedure" messages map to calls to this trait.
@@ -252,17 +249,17 @@ pub trait WinHandler {
     ///
     /// The handler can implement this method to perform initial setup.
     #[allow(unused_variables)]
-    fn connected(&mut self, ctx: &mut dyn WinCtx) {}
+    fn connected(&mut self) {}
 
     /// Called when the size of the window is changed. Note that size
     /// is in physical pixels.
     #[allow(unused_variables)]
-    fn size(&mut self, width: u32, height: u32, ctx: &mut dyn WinCtx) {}
+    fn size(&mut self, width: u32, height: u32) {}
 
     /// Request the handler to paint the window contents. Return value
     /// indicates whether window is animating, i.e. whether another paint
     /// should be scheduled for the next animation frame.
-    fn paint(&mut self, piet: &mut piet_common::Piet, ctx: &mut dyn WinCtx) -> bool;
+    fn paint(&mut self, piet: &mut piet_common::Piet) -> bool;
 
     /// Called when the resources need to be rebuilt.
     ///
@@ -270,24 +267,24 @@ pub trait WinHandler {
     /// `GenericRenderTarget` on Direct2D. If we move to `DeviceContext`
     /// instead, then it's possible we don't need this.
     #[allow(unused_variables)]
-    fn rebuild_resources(&mut self, ctx: &mut dyn WinCtx) {}
+    fn rebuild_resources(&mut self) {}
 
     /// Called when a menu item is selected.
     #[allow(unused_variables)]
-    fn command(&mut self, id: u32, ctx: &mut dyn WinCtx) {}
+    fn command(&mut self, id: u32) {}
 
     /// Called on a key down event.
     ///
     /// Return `true` if the event is handled.
     #[allow(unused_variables)]
-    fn key_down(&mut self, event: KeyEvent, ctx: &mut dyn WinCtx) -> bool {
+    fn key_down(&mut self, event: KeyEvent) -> bool {
         false
     }
 
     /// Called when a key is released. This corresponds to the WM_KEYUP message
     /// on Windows, or keyUp(withEvent:) on macOS.
     #[allow(unused_variables)]
-    fn key_up(&mut self, event: KeyEvent, ctx: &mut dyn WinCtx) {}
+    fn key_up(&mut self, event: KeyEvent) {}
 
     /// Called on a mouse wheel event.
     ///
@@ -298,48 +295,48 @@ pub trait WinHandler {
     ///
     /// [WheelEvent]: https://w3c.github.io/uievents/#event-type-wheel
     #[allow(unused_variables)]
-    fn wheel(&mut self, delta: Vec2, mods: KeyModifiers, ctx: &mut dyn WinCtx) {}
+    fn wheel(&mut self, delta: Vec2, mods: KeyModifiers) {}
 
     /// Called when a platform-defined zoom gesture occurs (such as pinching
     /// on the trackpad).
     #[allow(unused_variables)]
-    fn zoom(&mut self, delta: f64, ctx: &mut dyn WinCtx) {}
+    fn zoom(&mut self, delta: f64) {}
 
     /// Called when the mouse moves.
     #[allow(unused_variables)]
-    fn mouse_move(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {}
+    fn mouse_move(&mut self, event: &MouseEvent) {}
 
     /// Called on mouse button down.
     #[allow(unused_variables)]
-    fn mouse_down(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {}
+    fn mouse_down(&mut self, event: &MouseEvent) {}
 
     /// Called on mouse button up.
     #[allow(unused_variables)]
-    fn mouse_up(&mut self, event: &MouseEvent, ctx: &mut dyn WinCtx) {}
+    fn mouse_up(&mut self, event: &MouseEvent) {}
 
     /// Called on timer event.
     ///
     /// This is called at (approximately) the requested deadline by a
-    /// [`WinCtx::request_timer()`] call. The token argument here is the same
+    /// [`WindowHandle::request_timer()`] call. The token argument here is the same
     /// as the return value of that call.
     ///
-    /// [`WinCtx::request_timer()`]: trait.WinCtx.html#tymethod.request_timer
+    /// [`WindowHandle::request_timer()`]: struct.WindowHandle.html#tymethod.request_timer
     #[allow(unused_variables)]
-    fn timer(&mut self, token: TimerToken, ctx: &mut dyn WinCtx) {}
+    fn timer(&mut self, token: TimerToken) {}
 
     /// Called when this window becomes the focused window.
     #[allow(unused_variables)]
-    fn got_focus(&mut self, ctx: &mut dyn WinCtx) {}
+    fn got_focus(&mut self) {}
 
     /// Called when the window is being destroyed. Note that this happens
     /// earlier in the sequence than drop (at WM_DESTROY, while the latter is
     /// WM_NCDESTROY).
     #[allow(unused_variables)]
-    fn destroy(&mut self, ctx: &mut dyn WinCtx) {}
+    fn destroy(&mut self) {}
 
     /// Called when a idle token is requested by [`IdleHandle::schedule_idle()`] call.
     #[allow(unused_variables)]
-    fn idle(&mut self, token: IdleToken, ctx: &mut dyn WinCtx) {}
+    fn idle(&mut self, token: IdleToken) {}
 
     /// Get a reference to the handler state. Used mostly by idle handlers.
     fn as_any(&mut self) -> &mut dyn Any;

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -50,7 +50,7 @@ trait EventCtxExt {
     fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>);
 }
 
-impl EventCtxExt for EventCtx<'_, '_> {
+impl EventCtxExt for EventCtx<'_> {
     fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>) {
         let cmd = Command::new(druid::commands::SET_MENU, menu);
         self.submit_command(cmd, None);

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -568,7 +568,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
 
         let mut child_ctx = UpdateCtx {
             window: ctx.window,
-            //text_factory: ctx.text_factory,
             base_state: &mut self.state,
             window_id: ctx.window_id,
         };

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -364,7 +364,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
         let had_active = self.state.has_active;
         let mut child_ctx = EventCtx {
-            win_ctx: ctx.win_ctx,
             cursor: ctx.cursor,
             command_queue: ctx.command_queue,
             window: &ctx.window,
@@ -569,7 +568,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
 
         let mut child_ctx = UpdateCtx {
             window: ctx.window,
-            text_factory: ctx.text_factory,
+            //text_factory: ctx.text_factory,
             base_state: &mut self.state,
             window_id: ctx.window_id,
         };

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -51,7 +51,7 @@ pub use piet::{Color, LinearGradient, PaintBrush, RadialGradient, RenderContext,
 pub use shell::{
     Application, Clipboard, ClipboardFormat, Cursor, Error as PlatformError, FileDialogOptions,
     FileInfo, FileSpec, FormatId, HotKey, KeyCode, KeyEvent, KeyModifiers, MouseButton, RawMods,
-    SysMods, Text, TimerToken, WinCtx, WindowHandle,
+    SysMods, Text, TimerToken, WindowHandle,
 };
 
 pub use crate::core::{BoxedWidget, WidgetPod};

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -201,7 +201,7 @@ impl Widget<String> for TextBox {
         // Guard against external changes in data?
         self.selection = self.selection.constrain_to(data);
 
-        let mut text_layout = self.get_layout(ctx.text(), &data, env);
+        let mut text_layout = self.get_layout(&mut ctx.text(), &data, env);
         match event {
             Event::MouseDown(mouse) => {
                 ctx.request_focus();
@@ -326,7 +326,7 @@ impl Widget<String> for TextBox {
                     }
                     _ => {}
                 }
-                text_layout = self.get_layout(ctx.text(), &data, env);
+                text_layout = self.get_layout(&mut ctx.text(), &data, env);
                 self.update_hscroll(&text_layout);
                 ctx.request_paint();
             }

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -227,7 +227,6 @@ impl<T: Data> Window<T> {
 
         let mut base_state = BaseState::new(self.root.id());
         let mut update_ctx = UpdateCtx {
-            //text_factory: win_ctx.text_factory(),
             base_state: &mut base_state,
             window: &self.handle,
             window_id: self.id,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 
 use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::piet::{Piet, RenderContext};
-use crate::shell::{Counter, Cursor, WinCtx, WindowHandle};
+use crate::shell::{Counter, Cursor, WindowHandle};
 
 use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::win_handler::RUN_COMMANDS_TOKEN;
@@ -121,7 +121,6 @@ impl<T: Data> Window<T> {
 
     pub(crate) fn event(
         &mut self,
-        win_ctx: &mut dyn WinCtx,
         queue: &mut CommandQueue,
         event: Event,
         data: &mut T,
@@ -149,7 +148,6 @@ impl<T: Data> Window<T> {
         let mut base_state = BaseState::new(self.root.id());
         let is_handled = {
             let mut ctx = EventCtx {
-                win_ctx,
                 cursor: &mut cursor,
                 command_queue: queue,
                 base_state: &mut base_state,
@@ -174,7 +172,7 @@ impl<T: Data> Window<T> {
         }
 
         if let Some(cursor) = cursor {
-            win_ctx.set_cursor(&cursor);
+            self.handle.set_cursor(&cursor);
         }
 
         // If children are changed during the handling of an event,
@@ -224,12 +222,12 @@ impl<T: Data> Window<T> {
         }
     }
 
-    pub(crate) fn update(&mut self, win_ctx: &mut dyn WinCtx, data: &T, env: &Env) {
+    pub(crate) fn update(&mut self, data: &T, env: &Env) {
         self.update_title(data, env);
 
         let mut base_state = BaseState::new(self.root.id());
         let mut update_ctx = UpdateCtx {
-            text_factory: win_ctx.text_factory(),
+            //text_factory: win_ctx.text_factory(),
             base_state: &mut base_state,
             window: &self.handle,
             window_id: self.id,


### PR DESCRIPTION
This removes `WinCtx` and moves all of its functionality over to `WindowHandle`.

yolo?