### PR TITLE
Fix test breakage

### DIFF
--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -35,7 +35,7 @@ fn propogate_hot() {
     let padding_rec = Recording::default();
     let button_rec = Recording::default();
 
-    let widget = Split::horizontal(
+    let widget = Split::vertical(
         SizedBox::empty().with_id(empty),
         Button::new("hot", |_, _, _| {})
             .record(&button_rec)


### PR DESCRIPTION
This was caused by the swap in the meaning of horizontal & vertical
in the split widget.