### PR TITLE
Make druid-shell::platform private, and remove unused items

### DIFF
--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -46,9 +46,7 @@ mod keyboard;
 mod keycodes;
 mod menu;
 mod mouse;
-//TODO: don't expose this directly? currently making this private causes
-//a bunch of compiler warnings, so let's revisit that later.
-pub mod platform;
+mod platform;
 mod runloop;
 mod window;
 

--- a/druid-shell/src/platform/mac/runloop.rs
+++ b/druid-shell/src/platform/mac/runloop.rs
@@ -42,11 +42,3 @@ impl RunLoop {
         }
     }
 }
-
-/// Request to quit the application, exiting the runloop.
-pub fn request_quit() {
-    unsafe {
-        // Is this threadsafe, or should we schedule on main loop?
-        let () = msg_send![NSApp(), terminate: nil];
-    }
-}

--- a/druid-shell/src/platform/windows/mod.rs
+++ b/druid-shell/src/platform/windows/mod.rs
@@ -108,10 +108,6 @@ impl HwndRenderTarget {
         Self::from_ptr(ComPtr::from_raw(raw))
     }
 
-    pub fn get_raw(&self) -> *mut ID2D1HwndRenderTarget {
-        self.ptr.as_raw()
-    }
-
     pub fn get_comptr(&self) -> &ComPtr<ID2D1HwndRenderTarget> {
         &self.ptr
     }
@@ -153,10 +149,6 @@ impl DxgiSurfaceRenderTarget {
         DxgiSurfaceRenderTarget {
             ptr: ComPtr::from_raw(raw),
         }
-    }
-
-    pub fn get_raw(&self) -> *mut ID2D1RenderTarget {
-        self.ptr.as_raw()
     }
 
     /// cast to DeviceContext

--- a/druid-shell/src/platform/windows/runloop.rs
+++ b/druid-shell/src/platform/windows/runloop.rs
@@ -16,44 +16,15 @@
 
 use std::mem;
 use std::ptr::null_mut;
-use std::sync::{Arc, Mutex};
-use winapi::um::winbase::*;
-use winapi::um::winnt::*;
 use winapi::um::winuser::*;
 
 use super::accels;
 
-// TODO: remove this, it's been obsoleted by IdleHandle
-#[derive(Clone, Default)]
-pub struct RunLoopHandle(Arc<Mutex<RunLoopState>>);
-
-#[derive(Default)]
-struct RunLoopState {
-    listeners: Vec<Listener>,
-}
-
-// It's only safe to add listeners from the same thread as the runloop.
-unsafe impl Send for Listener {}
-struct Listener {
-    h: HANDLE,
-    callback: Box<dyn FnMut()>,
-}
-
-pub struct RunLoop {
-    handle: RunLoopHandle,
-}
+pub struct RunLoop;
 
 impl RunLoop {
     pub fn new() -> RunLoop {
-        RunLoop {
-            handle: Default::default(),
-        }
-    }
-
-    /// Get a handle to the run loop state so a client can add listeners,
-    /// etc.
-    pub fn get_handle(&self) -> RunLoopHandle {
-        self.handle.clone()
+        RunLoop
     }
 
     // WAIT_OBJECT_0 is defined as 0, so >= is technically meaningless
@@ -61,64 +32,24 @@ impl RunLoop {
     #[allow(clippy::absurd_extreme_comparisons)]
     pub fn run(&mut self) {
         unsafe {
+            // Handle windows messages
             loop {
-                let mut handles = Vec::new();
-                for listener in &self.handle.0.lock().unwrap().listeners {
-                    handles.push(listener.h);
+                let mut msg = mem::MaybeUninit::uninit();
+                let res = GetMessageW(msg.as_mut_ptr(), null_mut(), 0, 0);
+                if res <= 0 {
+                    return;
                 }
-                let len = handles.len() as u32;
-                let res =
-                    MsgWaitForMultipleObjectsEx(len, handles.as_ptr(), INFINITE, QS_ALLEVENTS, 0);
+                let mut msg: MSG = msg.assume_init();
+                let accels = accels::find_accels(GetAncestor(msg.hwnd, GA_ROOT));
+                let translated = accels.map_or(false, |it| {
+                    TranslateAcceleratorW(msg.hwnd, it.handle(), &mut msg) != 0
+                });
 
-                // Prioritize rpc results above windows messages
-                if res >= WAIT_OBJECT_0 && res < WAIT_OBJECT_0 + len {
-                    let ix = (res - WAIT_OBJECT_0) as usize;
-                    (&mut self.handle.0.lock().unwrap().listeners[ix].callback)();
-                }
-
-                // Handle windows messages
-                loop {
-                    let mut msg = mem::MaybeUninit::uninit();
-                    // Note: we could use PM_REMOVE here and avoid the GetMessage below
-                    let res = PeekMessageW(msg.as_mut_ptr(), null_mut(), 0, 0, PM_NOREMOVE);
-                    if res == 0 {
-                        break;
-                    }
-                    let res = GetMessageW(msg.as_mut_ptr(), null_mut(), 0, 0);
-                    if res <= 0 {
-                        return;
-                    }
-                    let mut msg: MSG = msg.assume_init();
-                    let accels = accels::find_accels(GetAncestor(msg.hwnd, GA_ROOT));
-                    let translated = accels.map_or(false, |it| {
-                        TranslateAcceleratorW(msg.hwnd, it.handle(), &mut msg) != 0
-                    });
-
-                    if !translated {
-                        TranslateMessage(&msg);
-                        DispatchMessageW(&msg);
-                    }
+                if !translated {
+                    TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
                 }
             }
         }
-    }
-}
-
-impl RunLoopHandle {
-    /// Add a listener for a Windows handle.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that the handle is valid, and that this function
-    /// is only called from the main thread.
-    pub unsafe fn add_handler<F>(&self, h: HANDLE, callback: F)
-    where
-        F: FnMut() + 'static,
-    {
-        let listener = Listener {
-            h,
-            callback: Box::new(callback),
-        };
-        self.0.lock().unwrap().listeners.push(listener);
     }
 }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -88,6 +88,7 @@ pub enum PresentStrategy {
     /// testing, it causes diagonal banding artifacts with Nvidia
     /// adapters, and incremental present doesn't work. However, it
     /// is compatible with GDI (such as menus).
+    #[allow(dead_code)]
     Sequential,
 
     /// Corresponds to the swap effect DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL.
@@ -710,16 +711,6 @@ impl WindowBuilder {
         self.handler = Some(handler);
     }
 
-    pub fn set_scroll(&mut self, hscroll: bool, vscroll: bool) {
-        self.dwStyle &= !(WS_HSCROLL | WS_VSCROLL);
-        if hscroll {
-            self.dwStyle |= WS_HSCROLL;
-        }
-        if vscroll {
-            self.dwStyle |= WS_VSCROLL;
-        }
-    }
-
     pub fn set_size(&mut self, size: Size) {
         self.size = size;
     }
@@ -730,10 +721,6 @@ impl WindowBuilder {
 
     pub fn set_menu(&mut self, menu: Menu) {
         self.menu = Some(menu);
-    }
-
-    pub fn set_present_strategy(&mut self, present_strategy: PresentStrategy) {
-        self.present_strategy = present_strategy;
     }
 
     pub fn build(self) -> Result<WindowHandle, Error> {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -70,7 +70,6 @@ pub struct LifeCycleCtx<'a> {
 ///
 /// [`request_paint`]: #method.request_paint
 pub struct UpdateCtx<'a> {
-    //pub(crate) text_factory: &'a mut Text<'b>,
     pub(crate) window: &'a WindowHandle,
     // Discussion: we probably want to propagate more fine-grained
     // invalidations, which would mean a structure very much like


### PR DESCRIPTION
This is just a bit of cleanup while I'm in druid-shell thinking
about AppHandler and related.