### PR TITLE
Handle events that do not originate with a window

### DIFF
--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -108,7 +108,7 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    let mut app = Application::new();
+    let mut app = Application::new(None);
     let mut builder = WindowBuilder::new();
     let perf_test = PerfTest {
         size: Default::default(),

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -128,7 +128,7 @@ fn main() {
     menubar.add_dropdown(Menu::new(), "Application", true);
     menubar.add_dropdown(file_menu, "&File", true);
 
-    let mut app = Application::new();
+    let mut app = Application::new(None);
     let mut builder = WindowBuilder::new();
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");

--- a/druid-shell/src/application.rs
+++ b/druid-shell/src/application.rs
@@ -17,14 +17,33 @@
 use crate::clipboard::Clipboard;
 use crate::platform::application as platform;
 
+/// A top-level handler that is not associated with any window.
+///
+/// This is most important on macOS, where it is entirely normal for
+/// an application to exist with no open windows.
+///
+/// # Note
+///
+/// This is currently very limited in its functionality, and is currently
+/// designed to address a single case, which is handling menu commands when
+/// no window is open.
+///
+/// It is possible that this will expand to cover additional functionality
+/// in the future.
+pub trait AppHandler {
+    /// Called when a menu item is selected.
+    #[allow(unused_variables)]
+    fn command(&mut self, id: u32) {}
+}
+
 //TODO: we may want to make the user create an instance of this (Application::global()?)
 //but for now I'd like to keep changes minimal.
 /// The top level application object.
 pub struct Application(platform::Application);
 
 impl Application {
-    pub fn new() -> Application {
-        Application(platform::Application::new())
+    pub fn new(handler: Option<Box<dyn AppHandler>>) -> Application {
+        Application(platform::Application::new(handler))
     }
 
     /// Start the runloop.

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -49,7 +49,7 @@ mod mouse;
 mod platform;
 mod window;
 
-pub use application::Application;
+pub use application::{AppHandler, Application};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -22,6 +22,7 @@ use gtk::{Application as GtkApplication, GtkApplicationExt};
 
 use super::clipboard::Clipboard;
 use super::util;
+use crate::application::AppHandler;
 
 // XXX: The application needs to be global because WindowBuilder::build wants
 // to construct an ApplicationWindow, which needs the application, but
@@ -33,7 +34,7 @@ thread_local!(
 pub struct Application;
 
 impl Application {
-    pub fn new() -> Application {
+    pub fn new(_handler: Option<Box<dyn AppHandler>>) -> Application {
         gtk::init().expect("GTK initialization failed");
         util::assert_main_thread();
 

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -27,6 +27,8 @@ use winapi::um::winuser::{
     TranslateAcceleratorW, TranslateMessage, GA_ROOT, IDI_APPLICATION, MSG, WNDCLASSW,
 };
 
+use crate::application::AppHandler;
+
 use super::accels;
 use super::clipboard::Clipboard;
 use super::util::{self, ToWide, CLASS_NAME, OPTIONAL_FUNCTIONS};
@@ -35,7 +37,7 @@ use super::window::win_proc_dispatch;
 pub struct Application;
 
 impl Application {
-    pub fn new() -> Application {
+    pub fn new(_handler: Option<Box<dyn AppHandler>>) -> Application {
         Application::init();
         Application
     }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -16,8 +16,9 @@
 
 use druid::widget::{Align, Button, Flex, Label, Padding};
 use druid::{
-    AppDelegate, AppLauncher, Command, ContextMenu, Data, DelegateCtx, Env, Event, EventCtx,
-    LocalizedString, MenuDesc, MenuItem, Selector, Widget, WindowDesc, WindowId,
+    commands as sys_cmds, AppDelegate, AppLauncher, Command, ContextMenu, Data, DelegateCtx, Env,
+    Event, EventCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, Widget, WindowDesc,
+    WindowId,
 };
 
 use log::info;
@@ -53,14 +54,8 @@ trait EventCtxExt {
 impl EventCtxExt for EventCtx<'_> {
     fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>) {
         let cmd = Command::new(druid::commands::SET_MENU, menu);
-        self.submit_command(cmd, None);
-    }
-}
-
-impl EventCtxExt for DelegateCtx<'_> {
-    fn set_menu<T: 'static>(&mut self, menu: MenuDesc<T>) {
-        let cmd = Command::new(druid::commands::SET_MENU, menu);
-        self.submit_command(cmd, None);
+        let target = self.window_id();
+        self.submit_command(cmd, target);
     }
 }
 
@@ -91,37 +86,13 @@ struct Delegate;
 impl AppDelegate<State> for Delegate {
     fn event(
         &mut self,
-        event: Event,
-        data: &mut State,
-        _env: &Env,
         ctx: &mut DelegateCtx,
+        _window_id: WindowId,
+        event: Event,
+        _data: &mut State,
+        _env: &Env,
     ) -> Option<Event> {
         match event {
-            Event::TargetedCommand(_, ref cmd) if cmd.selector == druid::commands::NEW_FILE => {
-                let new_win = WindowDesc::new(ui_builder)
-                    .menu(make_menu(data))
-                    .window_size((data.selected as f64 * 100.0 + 300.0, 500.0));
-                let command = Command::new(druid::commands::NEW_WINDOW, new_win);
-                ctx.submit_command(command, None);
-                None
-            }
-            Event::TargetedCommand(_, ref cmd) if cmd.selector == MENU_COUNT_ACTION => {
-                data.selected = *cmd.get_object().unwrap();
-                ctx.set_menu(make_menu::<State>(data));
-                None
-            }
-            // wouldn't it be nice if a menu (like a button) could just mutate state
-            // directly if desired?
-            Event::TargetedCommand(_, ref cmd) if cmd.selector == MENU_INCREMENT_ACTION => {
-                data.menu_count += 1;
-                ctx.set_menu(make_menu::<State>(data));
-                None
-            }
-            Event::TargetedCommand(_, ref cmd) if cmd.selector == MENU_DECREMENT_ACTION => {
-                data.menu_count = data.menu_count.saturating_sub(1);
-                ctx.set_menu(make_menu::<State>(data));
-                None
-            }
             Event::MouseDown(ref mouse) if mouse.button.is_right() => {
                 let menu = ContextMenu::new(make_context_menu::<State>(), mouse.pos);
                 let cmd = Command::new(druid::commands::SHOW_CONTEXT_MENU, menu);
@@ -131,6 +102,51 @@ impl AppDelegate<State> for Delegate {
             other => Some(other),
         }
     }
+
+    fn command(
+        &mut self,
+        ctx: &mut DelegateCtx,
+        target: &Target,
+        cmd: &Command,
+        data: &mut State,
+        _env: &Env,
+    ) -> bool {
+        match (target, &cmd.selector) {
+            (_, &sys_cmds::NEW_FILE) => {
+                let new_win = WindowDesc::new(ui_builder)
+                    .menu(make_menu(data))
+                    .window_size((data.selected as f64 * 100.0 + 300.0, 500.0));
+                let command = Command::one_shot(sys_cmds::NEW_WINDOW, new_win);
+                ctx.submit_command(command, Target::Global);
+                false
+            }
+            (Target::Window(id), &MENU_COUNT_ACTION) => {
+                data.selected = *cmd.get_object().unwrap();
+                let menu = make_menu::<State>(data);
+                let cmd = Command::new(druid::commands::SET_MENU, menu);
+                ctx.submit_command(cmd, *id);
+                false
+            }
+            // wouldn't it be nice if a menu (like a button) could just mutate state
+            // directly if desired?
+            (Target::Window(id), &MENU_INCREMENT_ACTION) => {
+                data.menu_count = data.menu_count + 1;
+                let menu = make_menu::<State>(data);
+                let cmd = Command::new(druid::commands::SET_MENU, menu);
+                ctx.submit_command(cmd, *id);
+                false
+            }
+            (Target::Window(id), &MENU_DECREMENT_ACTION) => {
+                data.menu_count = data.menu_count.saturating_sub(1);
+                let menu = make_menu::<State>(data);
+                let cmd = Command::new(druid::commands::SET_MENU, menu);
+                ctx.submit_command(cmd, *id);
+                false
+            }
+            _ => true,
+        }
+    }
+
     fn window_added(
         &mut self,
         id: WindowId,

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -110,7 +110,7 @@ impl<T: Data> AppLauncher<T> {
     /// Returns an error if a window cannot be instantiated. This is usually
     /// a fatal error.
     pub fn launch(mut self, data: T) -> Result<(), PlatformError> {
-        let mut app = Application::new();
+        let mut app = Application::new(None);
         let mut env = theme::init();
         if let Some(f) = self.env_setup.take() {
             f(&mut env, &data);

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -85,6 +85,8 @@ pub enum ArgumentError {
 /// The target of a command.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Target {
+    /// The target is the top-level application.
+    Global,
     /// The target is a window; the event will be delivered to all
     /// widgets in that window.
     Window(WindowId),

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -446,6 +446,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     recurse = child_ctx.base_state.children.contains(id);
                     Event::TargetedCommand(*target, cmd.clone())
                 }
+                Target::Global => panic!("Target::Global should be converted before WidgetPod"),
             },
         };
         child_ctx.base_state.needs_inval = false;

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -19,8 +19,6 @@ use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
-use log::{info, warn};
-
 use crate::kurbo::{Size, Vec2};
 use crate::piet::Piet;
 use crate::shell::{
@@ -52,13 +50,28 @@ pub(crate) const EXT_EVENT_IDLE_TOKEN: IdleToken = IdleToken::new(2);
 /// it publicly.
 pub struct DruidHandler<T> {
     /// The shared app state.
-    app_state: Rc<RefCell<AppState<T>>>,
+    app_state: AppState<T>,
     /// The id for the current window.
     window_id: WindowId,
 }
 
+/// The top level event handler.
+///
+/// This corresponds to the `AppHandler` trait in druid-shell, which is only
+/// used to handle events that are not associated with a window.
+///
+/// Currently, this means only menu items on macOS when no window is open.
+pub(crate) struct AppHandler<T> {
+    app_state: AppState<T>,
+}
+
 /// State shared by all windows in the UI.
+#[derive(Clone)]
 pub(crate) struct AppState<T> {
+    inner: Rc<RefCell<Inner<T>>>,
+}
+
+struct Inner<T> {
     delegate: Option<Box<dyn AppDelegate<T>>>,
     command_queue: CommandQueue,
     ext_event_host: ExtEventHost,
@@ -95,53 +108,71 @@ impl<T> Windows<T> {
         self.windows.values_mut()
     }
 
+    fn get(&self, id: WindowId) -> Option<&Window<T>> {
+        self.windows.get(&id)
+    }
+
     fn get_mut(&mut self, id: WindowId) -> Option<&mut Window<T>> {
         self.windows.get_mut(&id)
     }
 }
 
-impl<T: Data> AppState<T> {
+impl<T> AppHandler<T> {
+    pub(crate) fn new(app_state: AppState<T>) -> Self {
+        Self { app_state }
+    }
+}
+
+impl<T> AppState<T> {
     pub(crate) fn new(
         data: T,
         env: Env,
         delegate: Option<Box<dyn AppDelegate<T>>>,
         ext_event_host: ExtEventHost,
-    ) -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(AppState {
+    ) -> Self {
+        let inner = Rc::new(RefCell::new(Inner {
             delegate,
             command_queue: VecDeque::new(),
             ext_event_host,
             data,
             env,
             windows: Windows::default(),
-        }))
+        }));
+
+        AppState { inner }
+    }
+}
+
+impl<T: Data> Inner<T> {
+    fn get_menu_cmd(&self, window_id: Option<WindowId>, cmd_id: u32) -> Option<Command> {
+        match window_id {
+            Some(id) => self.windows.get(id).and_then(|w| w.get_menu_cmd(cmd_id)),
+            None => {
+                log::warn!("cannot get menu command without window_id");
+                None
+            }
+        }
     }
 
-    fn get_menu_cmd(&self, window_id: WindowId, cmd_id: u32) -> Option<Command> {
-        self.windows
-            .windows
-            .get(&window_id)
-            .and_then(|w| w.get_menu_cmd(cmd_id))
+    fn append_command(&mut self, target: Target, cmd: Command) {
+        self.command_queue.push_back((target, cmd));
     }
 
     /// A helper fn for setting up the `DelegateCtx`. Takes a closure with
     /// an arbitrary return type `R`, and returns `Some(R)` if an `AppDelegate`
     /// is configured.
-    fn with_delegate<R, F>(&mut self, id: WindowId, f: F) -> Option<R>
+    fn with_delegate<R, F>(&mut self, f: F) -> Option<R>
     where
         F: FnOnce(&mut Box<dyn AppDelegate<T>>, &mut T, &Env, &mut DelegateCtx) -> R,
     {
-        let AppState {
+        let Inner {
             ref mut delegate,
             ref mut command_queue,
             ref mut data,
             ref env,
             ..
         } = self;
-        let mut ctx = DelegateCtx {
-            source_id: id,
-            command_queue,
-        };
+        let mut ctx = DelegateCtx { command_queue };
         if let Some(delegate) = delegate {
             Some(f(delegate, data, env, &mut ctx))
         } else {
@@ -151,11 +182,16 @@ impl<T: Data> AppState<T> {
 
     fn delegate_event(&mut self, id: WindowId, event: Event) -> Option<Event> {
         if self.delegate.is_some() {
-            self.with_delegate(id, |del, data, env, ctx| del.event(event, data, env, ctx))
+            self.with_delegate(|del, data, env, ctx| del.event(ctx, id, event, data, env))
                 .unwrap()
         } else {
             Some(event)
         }
+    }
+
+    fn delegate_cmd(&mut self, target: &Target, cmd: &Command) -> bool {
+        self.with_delegate(|del, data, env, ctx| del.command(ctx, target, cmd, data, env))
+            .unwrap_or(true)
     }
 
     fn connect(&mut self, id: WindowId, handle: WindowHandle) {
@@ -167,22 +203,14 @@ impl<T: Data> AppState<T> {
             self.set_ext_event_idle_handler(id);
         }
 
-        self.with_delegate(id, |del, data, env, ctx| {
-            del.window_added(id, data, env, ctx)
-        });
-    }
-
-    pub(crate) fn add_window(&mut self, id: WindowId, window: PendingWindow<T>) {
-        self.windows.add(id, window);
+        self.with_delegate(|del, data, env, ctx| del.window_added(id, data, env, ctx));
     }
 
     /// Called after this window has been closed by the platform.
     ///
     /// We clean up resources and notifiy the delegate, if necessary.
     fn remove_window(&mut self, window_id: WindowId) {
-        self.with_delegate(window_id, |del, data, env, ctx| {
-            del.window_removed(window_id, data, env, ctx)
-        });
+        self.with_delegate(|del, data, env, ctx| del.window_removed(window_id, data, env, ctx));
         self.windows.remove(window_id);
 
         // if we are closing the window that is currently responsible for
@@ -239,52 +267,63 @@ impl<T: Data> AppState<T> {
         }
     }
 
-    fn do_event(&mut self, source_id: WindowId, event: Event) -> bool {
+    fn dispatch_cmd(&mut self, target: Target, cmd: Command) {
+        if !self.delegate_cmd(&target, &cmd) {
+            return;
+        }
+
+        match target {
+            Target::Window(id) => {
+                // first handle special window-level events
+                match cmd.selector {
+                    sys_cmd::SET_MENU => return self.set_menu(id, &cmd),
+                    sys_cmd::SHOW_CONTEXT_MENU => return self.show_context_menu(id, &cmd),
+                    _ => (),
+                }
+                if let Some(w) = self.windows.get_mut(id) {
+                    let event = Event::Command(cmd);
+                    w.event(&mut self.command_queue, event, &mut self.data, &self.env);
+                }
+            }
+            // in this case we send it to every window that might contain
+            // this widget, breaking if the event is handled.
+            Target::Widget(id) => {
+                for w in self.windows.iter_mut().filter(|w| w.may_contain_widget(id)) {
+                    let event = Event::TargetedCommand(id.into(), cmd.clone());
+                    if w.event(&mut self.command_queue, event, &mut self.data, &self.env) {
+                        break;
+                    }
+                }
+            }
+            Target::Global => {
+                for w in self.windows.iter_mut() {
+                    let event = Event::Command(cmd.clone());
+                    if w.event(&mut self.command_queue, event, &mut self.data, &self.env) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn do_window_event(&mut self, source_id: WindowId, event: Event) -> bool {
+        match event {
+            Event::Command(..) | Event::TargetedCommand(..) => {
+                panic!("commands should be dispatched via dispatch_cmd");
+            }
+            _ => (),
+        }
+
         // if the event was swallowed by the delegate we consider it handled?
         let event = match self.delegate_event(source_id, event) {
             Some(event) => event,
             None => return true,
         };
 
-        if let Event::TargetedCommand(_target, ref cmd) = event {
-            match cmd.selector {
-                sys_cmd::SET_MENU => {
-                    self.set_menu(source_id, cmd);
-                    return true;
-                }
-                sys_cmd::SHOW_CONTEXT_MENU => {
-                    self.show_context_menu(source_id, cmd);
-                    return true;
-                }
-                _ => (),
-            }
-        }
-
-        let AppState {
-            ref mut command_queue,
-            ref mut windows,
-            ref mut data,
-            ref env,
-            ..
-        } = self;
-
-        match event {
-            Event::TargetedCommand(Target::Widget(_), _) => {
-                let mut any_handled = false;
-
-                for window in windows.iter_mut() {
-                    let handled = window.event(command_queue, event.clone(), data, env);
-                    any_handled |= handled;
-                    if handled {
-                        break;
-                    }
-                }
-                any_handled
-            }
-            _ => match windows.get_mut(source_id) {
-                Some(win) => win.event(command_queue, event, data, env),
-                None => false,
-            },
+        if let Some(win) = self.windows.get_mut(source_id) {
+            win.event(&mut self.command_queue, event, &mut self.data, &self.env)
+        } else {
+            false
         }
     }
 
@@ -339,14 +378,37 @@ impl<T: Data> AppState<T> {
 impl<T: Data> DruidHandler<T> {
     /// Note: the root widget doesn't go in here, because it gets added to the
     /// app state.
-    pub(crate) fn new_shared(
-        app_state: Rc<RefCell<AppState<T>>>,
-        window_id: WindowId,
-    ) -> DruidHandler<T> {
+    pub(crate) fn new_shared(app_state: AppState<T>, window_id: WindowId) -> DruidHandler<T> {
         DruidHandler {
             app_state,
             window_id,
         }
+    }
+}
+
+impl<T: Data> AppState<T> {
+    pub(crate) fn data(&self) -> T {
+        self.inner.borrow().data.clone()
+    }
+
+    pub(crate) fn env(&self) -> Env {
+        self.inner.borrow().env.clone()
+    }
+
+    pub(crate) fn add_window(&self, id: WindowId, window: PendingWindow<T>) {
+        self.inner.borrow_mut().windows.add(id, window);
+    }
+
+    fn connect_window(&mut self, window_id: WindowId, handle: WindowHandle) {
+        self.inner.borrow_mut().connect(window_id, handle)
+    }
+
+    fn remove_window(&mut self, window_id: WindowId) {
+        self.inner.borrow_mut().remove_window(window_id)
+    }
+
+    fn window_got_focus(&mut self, window_id: WindowId) {
+        self.inner.borrow_mut().window_got_focus(window_id)
     }
 
     /// Send an event to the widget hierarchy.
@@ -355,16 +417,31 @@ impl<T: Data> DruidHandler<T> {
     ///
     /// This is principally because in certain cases (such as keydown on Windows)
     /// the OS needs to know if an event was handled.
-    fn do_event(&mut self, event: Event) -> bool {
-        let result = self.app_state.borrow_mut().do_event(self.window_id, event);
+    fn do_window_event(&mut self, event: Event, window_id: WindowId) -> bool {
+        let result = self.inner.borrow_mut().do_window_event(window_id, event);
         self.process_commands();
-        self.app_state.borrow_mut().do_update();
+        self.inner.borrow_mut().do_update();
         result
+    }
+
+    fn paint_window(&mut self, window_id: WindowId, piet: &mut Piet) -> bool {
+        self.inner.borrow_mut().paint(window_id, piet)
+    }
+
+    fn idle(&mut self, token: IdleToken) {
+        match token {
+            RUN_COMMANDS_TOKEN => {
+                self.process_commands();
+                self.inner.borrow_mut().invalidate_and_finalize();
+            }
+            EXT_EVENT_IDLE_TOKEN => self.process_ext_events(),
+            other => log::warn!("unexpected idle token {:?}", other),
+        }
     }
 
     fn process_commands(&mut self) {
         loop {
-            let next_cmd = self.app_state.borrow_mut().command_queue.pop_front();
+            let next_cmd = self.inner.borrow_mut().command_queue.pop_front();
             match next_cmd {
                 Some((target, cmd)) => self.handle_cmd(target, cmd),
                 None => break,
@@ -374,60 +451,53 @@ impl<T: Data> DruidHandler<T> {
 
     fn process_ext_events(&mut self) {
         loop {
-            let ext_cmd = self.app_state.borrow_mut().ext_event_host.recv();
+            let ext_cmd = self.inner.borrow_mut().ext_event_host.recv();
             match ext_cmd {
-                Some((targ, cmd)) => {
-                    let targ = targ.unwrap_or_else(|| self.window_id.into());
-                    self.handle_cmd(targ, cmd);
-                }
+                Some((targ, cmd)) => self.handle_cmd(targ.unwrap_or(Target::Global), cmd),
                 None => break,
             }
         }
-        self.app_state.borrow_mut().invalidate_and_finalize();
+        self.inner.borrow_mut().invalidate_and_finalize();
     }
 
-    fn handle_system_cmd(&mut self, cmd_id: u32) {
-        let cmd = self.app_state.borrow().get_menu_cmd(self.window_id, cmd_id);
+    /// Handle a 'command' message from druid-shell. These map to  an item
+    /// in an application, window, or context (right-click) menu.
+    ///
+    /// If the menu is  associated with a window (the general case) then
+    /// the `window_id` will be `Some(_)`, otherwise (such as if no window
+    /// is open but a menu exists, as on macOS) it will be `None`.
+    fn handle_system_cmd(&mut self, cmd_id: u32, window_id: Option<WindowId>) {
+        let cmd = self.inner.borrow().get_menu_cmd(window_id, cmd_id);
+        let target = window_id.map(Into::into).unwrap_or(Target::Global);
         match cmd {
-            Some(cmd) => self
-                .app_state
-                .borrow_mut()
-                .command_queue
-                .push_back((self.window_id.into(), cmd)),
-            None => warn!("No command for menu id {}", cmd_id),
+            Some(cmd) => self.inner.borrow_mut().append_command(target, cmd),
+            None => log::warn!("No command for menu id {}", cmd_id),
         }
         self.process_commands()
     }
 
-    /// Handle a command. Top level commands (e.g. for creating and destroying windows)
-    /// have their logic here; other commands are passed to the window.
+    /// Handle a command. Top level commands (e.g. for creating and destroying
+    /// windows) have their logic here; other commands are passed to the window.
     fn handle_cmd(&mut self, target: Target, cmd: Command) {
-        if let Target::Window(window_id) = target {
-            match &cmd.selector {
-                &sys_cmd::SHOW_OPEN_PANEL => self.show_open_panel(cmd, window_id),
-                &sys_cmd::SHOW_SAVE_PANEL => self.show_save_panel(cmd, window_id),
-                &sys_cmd::NEW_WINDOW => {
-                    if let Err(e) = self.new_window(cmd) {
-                        log::error!("failed to create window: '{}'", e);
-                    }
-                }
-                &sys_cmd::CLOSE_WINDOW => self.request_close_window(cmd, window_id),
-                &sys_cmd::SHOW_WINDOW => self.show_window(cmd),
-                &sys_cmd::QUIT_APP => self.quit(),
-                &sys_cmd::HIDE_APPLICATION => self.hide_app(),
-                &sys_cmd::HIDE_OTHERS => self.hide_others(),
-                &sys_cmd::PASTE => self.do_paste(window_id),
-                sel => {
-                    info!("handle_cmd {}", sel);
-                    let event = Event::TargetedCommand(target, cmd);
-                    self.app_state.borrow_mut().do_event(window_id, event);
+        use Target as T;
+        match (target, &cmd.selector) {
+            // these are handled the same no matter where they  come from
+            (_, &sys_cmd::QUIT_APP) => self.quit(),
+            (_, &sys_cmd::HIDE_APPLICATION) => self.hide_app(),
+            (_, &sys_cmd::HIDE_OTHERS) => self.hide_others(),
+            (_, &sys_cmd::NEW_WINDOW) => {
+                if let Err(e) = self.new_window(cmd) {
+                    log::error!("failed to create window: '{}'", e);
                 }
             }
-        } else {
-            info!("handle_cmd {} -> widget", cmd.selector);
-            let event = Event::TargetedCommand(target, cmd);
-            // TODO: self.window_id the correct source identifier here?
-            self.app_state.borrow_mut().do_event(self.window_id, event);
+            // these should come from a window
+            // FIXME: we need to be  able to open a file without a window handle
+            (T::Window(id), &sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
+            (T::Window(id), &sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
+            (T::Window(id), &sys_cmd::CLOSE_WINDOW) => self.request_close_window(cmd, id),
+            (T::Window(_), &sys_cmd::SHOW_WINDOW) => self.show_window(cmd),
+            (T::Window(id), &sys_cmd::PASTE) => self.do_paste(id),
+            _sel => self.inner.borrow_mut().dispatch_cmd(target, cmd),
         }
     }
 
@@ -440,7 +510,7 @@ impl<T: Data> DruidHandler<T> {
         //a crash. as a workaround we take a clone of the window handle.
         //it's less clear what the better solution would be.
         let handle = self
-            .app_state
+            .inner
             .borrow_mut()
             .windows
             .get_mut(window_id)
@@ -450,7 +520,7 @@ impl<T: Data> DruidHandler<T> {
         if let Some(info) = result {
             let cmd = Command::new(sys_cmd::OPEN_FILE, info);
             let event = Event::TargetedCommand(window_id.into(), cmd);
-            self.app_state.borrow_mut().do_event(window_id, event);
+            self.inner.borrow_mut().do_window_event(window_id, event);
         }
     }
 
@@ -460,7 +530,7 @@ impl<T: Data> DruidHandler<T> {
             .map(|opts| opts.to_owned())
             .unwrap_or_default();
         let handle = self
-            .app_state
+            .inner
             .borrow_mut()
             .windows
             .get_mut(window_id)
@@ -469,32 +539,32 @@ impl<T: Data> DruidHandler<T> {
         if let Some(info) = result {
             let cmd = Command::new(sys_cmd::SAVE_FILE, info);
             let event = Event::TargetedCommand(window_id.into(), cmd);
-            self.app_state.borrow_mut().do_event(window_id, event);
+            self.inner.borrow_mut().do_window_event(window_id, event);
         }
     }
 
     fn new_window(&mut self, cmd: Command) -> Result<(), Box<dyn std::error::Error>> {
         let desc = cmd.take_object::<WindowDesc<T>>()?;
-        let window = desc.build_native(&self.app_state)?;
+        let window = desc.build_native(self)?;
         window.show();
         Ok(())
     }
 
     fn request_close_window(&mut self, cmd: Command, window_id: WindowId) {
         let id = cmd.get_object().unwrap_or(&window_id);
-        self.app_state.borrow_mut().request_close_window(*id);
+        self.inner.borrow_mut().request_close_window(*id);
     }
 
     fn show_window(&mut self, cmd: Command) {
         let id: WindowId = *cmd
             .get_object()
             .expect("show window selector missing window id");
-        self.app_state.borrow_mut().show_window(id);
+        self.inner.borrow_mut().show_window(id);
     }
 
     fn do_paste(&mut self, window_id: WindowId) {
         let event = Event::Paste(Application::clipboard());
-        self.app_state.borrow_mut().do_event(window_id, event);
+        self.inner.borrow_mut().do_window_event(window_id, event);
     }
 
     fn quit(&self) {
@@ -512,84 +582,85 @@ impl<T: Data> DruidHandler<T> {
     }
 }
 
+impl<T: Data> crate::shell::AppHandler for AppHandler<T> {
+    fn command(&mut self, id: u32) {
+        self.app_state.handle_system_cmd(id, None)
+    }
+}
+
 impl<T: Data> WinHandler for DruidHandler<T> {
     fn connect(&mut self, handle: &WindowHandle) {
         //NOTE: this method predates `connected`, and we call delegate methods here.
         //it's possible that we should move those calls to occur in connected?
         self.app_state
-            .borrow_mut()
-            .connect(self.window_id, handle.clone());
+            .connect_window(self.window_id, handle.clone());
     }
 
     fn connected(&mut self) {
         let event = Event::WindowConnected;
-        self.do_event(event);
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn paint(&mut self, piet: &mut Piet) -> bool {
-        self.app_state.borrow_mut().paint(self.window_id, piet)
+        self.app_state.paint_window(self.window_id, piet)
     }
 
     fn size(&mut self, width: u32, height: u32) {
         let event = Event::Size(Size::new(f64::from(width), f64::from(height)));
-        self.do_event(event);
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn command(&mut self, id: u32) {
-        self.handle_system_cmd(id);
+        self.app_state.handle_system_cmd(id, Some(self.window_id));
     }
 
     fn mouse_down(&mut self, event: &MouseEvent) {
         // TODO: double-click detection (or is this done in druid-shell?)
         let event = Event::MouseDown(event.clone().into());
-        self.do_event(event);
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn mouse_up(&mut self, event: &MouseEvent) {
         let event = Event::MouseUp(event.clone().into());
-        self.do_event(event);
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn mouse_move(&mut self, event: &MouseEvent) {
         let event = Event::MouseMoved(event.clone().into());
-        self.do_event(event);
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn key_down(&mut self, event: KeyEvent) -> bool {
-        self.do_event(Event::KeyDown(event))
+        self.app_state
+            .do_window_event(Event::KeyDown(event), self.window_id)
     }
 
     fn key_up(&mut self, event: KeyEvent) {
-        self.do_event(Event::KeyUp(event));
+        self.app_state
+            .do_window_event(Event::KeyUp(event), self.window_id);
     }
 
     fn wheel(&mut self, delta: Vec2, mods: KeyModifiers) {
         let event = Event::Wheel(WheelEvent { delta, mods });
-        self.do_event(event);
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn zoom(&mut self, delta: f64) {
         let event = Event::Zoom(delta);
-        self.do_event(event);
+        self.app_state.do_window_event(event, self.window_id);
     }
 
     fn got_focus(&mut self) {
-        self.app_state.borrow_mut().window_got_focus(self.window_id);
+        self.app_state.window_got_focus(self.window_id);
     }
 
     fn timer(&mut self, token: TimerToken) {
-        self.do_event(Event::Timer(token));
+        self.app_state
+            .do_window_event(Event::Timer(token), self.window_id);
     }
 
     fn idle(&mut self, token: IdleToken) {
-        match token {
-            RUN_COMMANDS_TOKEN => {
-                self.process_commands();
-                self.app_state.borrow_mut().invalidate_and_finalize();
-            }
-            EXT_EVENT_IDLE_TOKEN => self.process_ext_events(),
-            other => log::warn!("unexpected idle token {:?}", other),
-        }
+        self.app_state.idle(token);
     }
 
     fn as_any(&mut self) -> &mut dyn Any {
@@ -597,7 +668,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
     }
 
     fn destroy(&mut self) {
-        self.app_state.borrow_mut().remove_window(self.window_id);
+        self.app_state.remove_window(self.window_id);
     }
 }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -92,6 +92,10 @@ impl<T: Data> Window<T> {
         &self.root.state().focus_chain
     }
 
+    pub(crate) fn may_contain_widget(&self, widget_id: WidgetId) -> bool {
+        self.root.state().children.contains(&widget_id)
+    }
+
     pub(crate) fn set_menu(&mut self, mut menu: MenuDesc<T>, data: &T, env: &Env) {
         let platform_menu = menu.build_window_menu(data, env);
         self.handle.set_menu(platform_menu);


### PR DESCRIPTION
This adds a simple `AppHandler` trait to `druid-shell` and a corresponding implementation to `druid`, which together let the application handle events (right now  this is only menu commands) that do not originate in a window.

This is very specifically intended to address the case, on macOS, where no windows are open but there is still an application menu.

This involved quite a bit of refactoring, because we had baked in the assumption that all events originated with a window at a very low level.

This has exposed a few new issues; in particular the mechanism for opening a file is currently implemented on `WindowHandle`, so there's no way to open a file from an empty window, but it is  at least now possible to quit an application on mac after closing its last window.

closes #114 
