### PR TITLE
Don't always clear needs_inval before forwarding an event

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -449,7 +449,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 Target::Global => panic!("Target::Global should be converted before WidgetPod"),
             },
         };
-        child_ctx.base_state.needs_inval = false;
         if let Some(is_hot) = hot_changed {
             let hot_changed_event = LifeCycle::HotChanged(is_hot);
             let mut lc_ctx = child_ctx.make_lifecycle_ctx();


### PR DESCRIPTION
This flag can be cleared during painting, but should persist between
events; specifically it should not be cleared when a Command is
handled after a non-command event, which could cause us to
ignore an invalidation that occured during the handling of the first
event.