### PR TITLE
Use common code for svg and image filling

### DIFF
--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -24,16 +24,14 @@ fn main() {
 }
 
 #[cfg(feature = "svg")]
-use log::error;
-
-#[cfg(feature = "svg")]
-use druid::{
-    widget::{Flex, Svg, SvgData, WidgetExt},
-    AppLauncher, LocalizedString, Widget, WindowDesc,
-};
-
-#[cfg(feature = "svg")]
 fn main() {
+    use log::error;
+
+    use druid::{
+        widget::{FillStrat, Flex, Svg, SvgData, WidgetExt},
+        AppLauncher, LocalizedString, Widget, WindowDesc,
+    };
+
     let main_window = WindowDesc::new(ui_builder)
         .title(LocalizedString::new("svg-demo-window-title").with_placeholder("Rawr!"));
     let data = 0_u32;
@@ -41,22 +39,22 @@ fn main() {
         .use_simple_logger()
         .launch(data)
         .expect("launch failed");
-}
 
-#[cfg(feature = "svg")]
-fn ui_builder() -> impl Widget<u32> {
-    let tiger_svg = match include_str!("tiger.svg").parse::<SvgData>() {
-        Ok(svg) => svg,
-        Err(err) => {
-            error!("{}", err);
-            error!("Using an empty SVG instead.");
-            SvgData::default()
-        }
-    };
+    fn ui_builder() -> impl Widget<u32> {
+        let tiger_svg = match include_str!("tiger.svg").parse::<SvgData>() {
+            Ok(svg) => svg,
+            Err(err) => {
+                error!("{}", err);
+                error!("Using an empty SVG instead.");
+                SvgData::default()
+            }
+        };
 
-    let mut col = Flex::column();
+        let mut col = Flex::column();
 
-    col.add_child(Svg::new(tiger_svg.clone()).fix_width(100.0).center(), 1.0);
-    col.add_child(Svg::new(tiger_svg), 1.0);
-    col
+        col.add_child(Svg::new(tiger_svg.clone()).fix_width(100.0).center(), 1.0);
+        col.add_child(Svg::new(tiger_svg.clone()).fill_mode(FillStrat::Fill), 1.0);
+        col.add_child(Svg::new(tiger_svg), 1.0);
+        col
+    }
 }

--- a/druid/src/widget/common.rs
+++ b/druid/src/widget/common.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Affine, Size};
+
+// These are based on https://api.flutter.dev/flutter/painting/BoxFit-class.html
+#[derive(Clone, Copy, PartialEq)]
+pub enum FillStrat {
+    /// As large as posible without changing aspect ratio of image and all of image shown
+    Contain,
+    /// As large as posible with no dead space so that some of the image may be clipped
+    Cover,
+    /// Fill the widget with no dead space, aspect ratio of widget is used
+    Fill,
+    /// Fill the hight with the images aspect ratio, some of the image may be clipped
+    FitHeight,
+    /// Fill the width with the images aspect ratio, some of the image may be clipped
+    FitWidth,
+    /// Do not scale
+    None,
+    /// Scale down to fit but do not scale up
+    ScaleDown,
+}
+
+impl Default for FillStrat {
+    fn default() -> Self {
+        FillStrat::Contain
+    }
+}
+
+impl FillStrat {
+    /// Calculate an origin and scale for an image with a given `FillStrat`.
+    ///
+    /// This takes some properties of a widget and a fill strategy and returns an affine matrix
+    /// used to position and scale the image in the widget.
+    pub fn affine_to_fill(self, parent: Size, fit_box: Size) -> Affine {
+        let raw_scalex = parent.width / fit_box.width;
+        let raw_scaley = parent.height / fit_box.height;
+
+        let (scalex, scaley) = match self {
+            FillStrat::Contain => {
+                let scale = raw_scalex.min(raw_scaley);
+                (scale, scale)
+            }
+            FillStrat::Cover => {
+                let scale = raw_scalex.max(raw_scaley);
+                (scale, scale)
+            }
+            FillStrat::Fill => (raw_scalex, raw_scaley),
+            FillStrat::FitHeight => (raw_scaley, raw_scaley),
+            FillStrat::FitWidth => (raw_scalex, raw_scalex),
+            FillStrat::ScaleDown => {
+                let scale = raw_scalex.min(raw_scaley).min(1.0);
+                (scale, scale)
+            }
+            FillStrat::None => (1.0, 1.0),
+        };
+
+        let origin_x = (parent.width - (fit_box.width * scalex)) / 2.0;
+        let origin_y = (parent.height - (fit_box.height * scaley)) / 2.0;
+
+        Affine::new([scalex, 0., 0., scaley, origin_x, origin_y])
+    }
+}

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -17,6 +17,7 @@
 mod align;
 mod button;
 mod checkbox;
+mod common;
 mod container;
 mod either;
 mod env_scope;
@@ -46,10 +47,11 @@ mod widget_ext;
 
 #[cfg(feature = "image")]
 #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
-pub use self::image::{FillStrat, Image, ImageData};
+pub use self::image::{Image, ImageData};
 pub use align::Align;
 pub use button::Button;
 pub use checkbox::Checkbox;
+pub use common::FillStrat;
 pub use container::Container;
 pub use either::Either;
 pub use env_scope::EnvScope;

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -40,7 +40,7 @@ impl<T: Data> Svg<T> {
     /// Create an SVG-drawing widget from SvgData.
     ///
     /// The SVG will scale to fit its box constraints.
-    pub fn new(svg_data: SvgData) -> impl Widget<T> {
+    pub fn new(svg_data: SvgData) -> Self {
         Svg {
             svg_data,
             phantom: Default::default(),

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -24,14 +24,16 @@ use log::error;
 use usvg;
 
 use crate::{
-    kurbo::BezPath, Affine, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx,
-    LifeCycle, LifeCycleCtx, PaintCtx, Point, Rect, RenderContext, Size, UpdateCtx, Widget,
+    kurbo::BezPath, widget::common::FillStrat, Affine, BoxConstraints, Color, Data, Env, Event,
+    EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Rect, RenderContext, Size, UpdateCtx,
+    Widget,
 };
 
 /// A widget that renders a SVG
 pub struct Svg<T> {
     svg_data: SvgData,
     phantom: PhantomData<T>,
+    fill: FillStrat,
 }
 
 impl<T: Data> Svg<T> {
@@ -42,6 +44,7 @@ impl<T: Data> Svg<T> {
         Svg {
             svg_data,
             phantom: Default::default(),
+            fill: FillStrat::default(),
         }
     }
 
@@ -60,6 +63,17 @@ impl<T: Data> Svg<T> {
                 return Size::ZERO;
             }
         };
+    }
+
+    /// A builder-style method for specifying the fill strategy.
+    pub fn fill_mode(mut self, mode: FillStrat) -> Self {
+        self.fill = mode;
+        self
+    }
+
+    /// Modify the widget's `FillStrat`.
+    pub fn set_fill(&mut self, newfil: FillStrat) {
+        self.fill = newfil;
     }
 }
 
@@ -86,21 +100,14 @@ impl<T: Data> Widget<T> for Svg<T> {
         }
     }
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &T, _env: &Env) {
-        //TODO: options for aspect ratio or scaling based on height
-        let scalex = paint_ctx.size().width / self.get_size().width;
-        let scaley = paint_ctx.size().height / self.get_size().height;
-        let scale = scalex.min(scaley);
-
-        let origin_x = (paint_ctx.size().width - (self.get_size().width * scale)) / 2.0;
-        let origin_y = (paint_ctx.size().height - (self.get_size().height * scale)) / 2.0;
-        let origin = Point::new(origin_x, origin_y);
+        let offset_matrix = self.fill.affine_to_fill(paint_ctx.size(), self.get_size());
 
         let clip_rect = Rect::ZERO.with_size(paint_ctx.size());
 
         // The SvgData's to_piet function dose not clip to the svg's size
         // CairoRenderContext is very like druids but with some extra goodies like clip
         paint_ctx.clip(clip_rect);
-        self.svg_data.to_piet(scale, origin, paint_ctx);
+        self.svg_data.to_piet(offset_matrix, paint_ctx);
     }
 }
 
@@ -132,9 +139,8 @@ impl SvgData {
     }
 
     /// Convert SvgData into Piet draw instructions
-    pub fn to_piet(&self, scale: f64, offset: Point, paint_ctx: &mut PaintCtx) {
+    pub fn to_piet(&self, offset_matrix: Affine, paint_ctx: &mut PaintCtx) {
         let root = self.tree.root();
-        let offset_matrix = Affine::new([scale, 0., 0., scale, offset.x, offset.y]);
         for n in root.children() {
             match *n.borrow() {
                 usvg::NodeKind::Path(ref p) => {


### PR DESCRIPTION
This lets the svg widget use all of of the fill options in image.

It also takes some good ideas from @cmyr as to how to tidy up the code.