### PR TITLE
Move debug_paint_layout to WidgetExt

### DIFF
--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -49,14 +49,13 @@ fn build_app() -> impl Widget<u32> {
         col.add_child(Button::new(format!("Button #{}", i), Button::noop), weight);
     }
 
-    col
+    col.debug_paint_layout()
 }
 
 fn main() {
     let window = WindowDesc::new(build_app)
         .title(LocalizedString::new("layout-demo-window-title").with_placeholder("Very flexible"));
     AppLauncher::with_window(window)
-        .debug_paint_layout()
         .use_simple_logger()
         .launch(0u32)
         .expect("launch failed");

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -35,7 +35,6 @@ fn main() {
         right: Arc::new(vec![1, 2, 3]),
     };
     AppLauncher::with_window(main_window)
-        .debug_paint_layout()
         .use_simple_logger()
         .launch(data)
         .expect("launch failed");
@@ -116,5 +115,6 @@ fn ui_builder() -> impl Widget<AppData> {
 
     root.add_child(lists, 1.0);
 
-    root
+    // Mark the widget as needing its layout rects painted
+    root.debug_paint_layout()
 }

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -96,10 +96,9 @@ impl<T: Data> AppLauncher<T> {
     /// Paint colorful rectangles for layout debugging.
     ///
     /// The rectangles are drawn around each widget's layout rect.
+    #[deprecated(since = "0.5.0", note = "Use WidgetExt::debug_paint_layout instead.")]
     pub fn debug_paint_layout(self) -> Self {
-        self.configure_env(|env, _| {
-            env.set(Env::DEBUG_PAINT, true);
-        })
+        self
     }
 
     /// Build the windows and start the runloop.

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -22,8 +22,8 @@ use crate::{
 
 /// A widget that accepts a closure to update the environment for its child.
 pub struct EnvScope<T, W> {
-    f: Box<dyn Fn(&mut Env, &T)>,
-    child: W,
+    pub(crate) f: Box<dyn Fn(&mut Env, &T)>,
+    pub(crate) child: W,
 }
 
 impl<T, W> EnvScope<T, W> {


### PR DESCRIPTION
This lets us choose to only debug a subset of the tree,
and fixes an issue where we would overwrite an existing `modify_env`
closure in the AppLauncher.