### PR TITLE
Add Env::DEBUG_WIDGET helper

### DIFF
--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -102,6 +102,37 @@ pub struct ValueTypeError {
 }
 
 impl Env {
+    /// State for whether or not to paint colorful rectangles for layout
+    /// debugging.
+    ///
+    /// Set by the `debug_paint_layout()` method on [`WidgetExt`]'.
+    ///
+    /// [`WidgetExt`]: widget/trait.WidgetExt.html
+    pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("druid.built-in.debug-paint");
+
+    /// A key used to tell widgets to print additional debug information.
+    ///
+    /// This does nothing by default; however you can check this key while
+    /// debugging a widget to limit println spam.
+    ///
+    /// For convenience, this key can be set with the [`WidgetExt::debug_widget`]
+    /// method.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use druid::Env;
+    /// # let env = Env::default();
+    /// # let widget_id = 0;
+    /// # let my_rect = druid::Rect::ZERO;
+    /// if env.get(Env::DEBUG_WIDGET) {
+    ///     eprintln!("widget {:?} bounds: {:?}", widget_id, my_rect);
+    /// }
+    /// ```
+    ///
+    /// [`WidgetExt::debug_widget`]: widget/trait.WidgetExt.html#method.debug_widget
+    pub const DEBUG_WIDGET: Key<bool> = Key::new("druid.built-in.debug-widget");
+
     /// Gets a value from the environment, expecting it to be present.
     ///
     /// Note that the return value is a reference for "expensive" types such
@@ -174,14 +205,6 @@ impl Env {
         let color_num = id as usize % self.0.debug_colors.len();
         self.0.debug_colors[color_num].clone()
     }
-
-    /// State for whether or not to paint colorful rectangles for layout
-    /// debugging.
-    ///
-    /// Set by the `debug_paint_layout()` method on [`AppLauncher`]'.
-    ///
-    /// [`AppLauncher`]: struct.AppLauncher.html
-    pub(crate) const DEBUG_PAINT: Key<bool> = Key::new("debug_paint");
 }
 
 impl<T> Key<T> {
@@ -320,7 +343,9 @@ impl Default for Env {
             debug_colors,
         };
 
-        Env(Arc::new(inner)).adding(Env::DEBUG_PAINT, false)
+        Env(Arc::new(inner))
+            .adding(Env::DEBUG_PAINT, false)
+            .adding(Env::DEBUG_WIDGET, false)
     }
 }
 

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -118,7 +118,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// [`Env`] with the provided closure.
     ///
     /// [`EnvScope`]: struct.Container.html
-    /// [`Env`]: struct.Env.html
+    /// [`Env`]: ../struct.Env.html
     fn env_scope(self, f: impl Fn(&mut Env, &T) + 'static) -> EnvScope<T, Self> {
         EnvScope::new(f, self)
     }
@@ -128,6 +128,16 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// [`layout`]: trait.Widget.html#tymethod.layout
     fn debug_paint_layout(self) -> EnvScope<T, Self> {
         EnvScope::new(|env, _| env.set(Env::DEBUG_PAINT, true), self)
+    }
+
+    /// Set the [`DEBUG_WIDGET`] env variable for this widget (and its descendants).
+    ///
+    /// This does nothing by default, but you can use this variable while
+    /// debugging to only print messages from particular instances of a widget.
+    ///
+    /// [`DEBUG_WIDGET`]: ../struct.Env.html#associatedconstant.DEBUG_WIDGET
+    fn debug_widget(self) -> EnvScope<T, Self> {
+        EnvScope::new(|env, _| env.set(Env::DEBUG_WIDGET, true), self)
     }
 
     /// Wrap this widget in a [`LensWrap`] widget for the provided [`Lens`].


### PR DESCRIPTION
Something I've wanted for a while, and just needed while doing some runebender stuff:

The intention is that, during debugging, you can set this key to
`true` for some widget and then check it in the Widget methods
to limit linespam when doing println debugging.