### PR TITLE
Process commands and do update after external event

### DIFF
--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -445,7 +445,11 @@ impl<T: Data> AppState<T> {
                 self.process_commands();
                 self.inner.borrow_mut().invalidate_and_finalize();
             }
-            EXT_EVENT_IDLE_TOKEN => self.process_ext_events(),
+            EXT_EVENT_IDLE_TOKEN => {
+                self.process_ext_events();
+                self.process_commands();
+                self.inner.borrow_mut().do_update();
+            }
             other => log::warn!("unexpected idle token {:?}", other),
         }
     }
@@ -468,7 +472,6 @@ impl<T: Data> AppState<T> {
                 None => break,
             }
         }
-        self.inner.borrow_mut().invalidate_and_finalize();
     }
 
     /// Handle a 'command' message from druid-shell. These map to  an item


### PR DESCRIPTION
Previously we skipped update and just went directly to
painting in this case, but that doesn't make any sense.

This also now processes any commands submitted while processing 
external events before returning.