### PR TITLE
Allow setting child spacing in Flex widget

### DIFF
--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -56,6 +56,7 @@ struct EnvImpl {
 ///
 /// [`ValueType`]: trait.ValueType.html
 /// [`Env`]: struct.Env.html
+#[derive(Clone)]
 pub struct Key<T> {
     key: &'static str,
     value_type: PhantomData<T>,
@@ -486,5 +487,11 @@ impl<T: Into<Value>> From<T> for KeyOrValue<T> {
 impl<T: Into<Value>> From<Key<T>> for KeyOrValue<T> {
     fn from(key: Key<T>) -> KeyOrValue<T> {
         KeyOrValue::Key(key)
+    }
+}
+
+impl<T: Into<Value> + Default> Default for KeyOrValue<T> {
+    fn default() -> Self {
+        KeyOrValue::Concrete(T::default().into())
     }
 }

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -55,6 +55,9 @@ pub const SCROLL_BAR_PAD: Key<f64> = Key::new("scroll_bar_pad");
 pub const SCROLL_BAR_RADIUS: Key<f64> = Key::new("scroll_bar_radius");
 pub const SCROLL_BAR_EDGE_WIDTH: Key<f64> = Key::new("scroll_bar_edge_width");
 
+/// The default horizontal spacing that should be used between control widgets.
+pub const CONTROL_SPACING_HORIZ: Key<f64> = Key::new("druid.theme.default-control-spacing");
+
 /// An initial theme.
 pub fn init() -> Env {
     let mut env = Env::default()
@@ -87,7 +90,8 @@ pub fn init() -> Env {
         .adding(SCROLL_BAR_WIDTH, 8.)
         .adding(SCROLL_BAR_PAD, 2.)
         .adding(SCROLL_BAR_RADIUS, 5.)
-        .adding(SCROLL_BAR_EDGE_WIDTH, 1.);
+        .adding(SCROLL_BAR_EDGE_WIDTH, 1.)
+        .adding(CONTROL_SPACING_HORIZ, 8.0);
 
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
This lets you specify the space betweeeen children. There are a number
of ways we could do this; I've chosen the simplest, but also the
least flexible.

If you need to customize the padding, you can manually add SizedBox
widgets where needed.

<img width="649" alt="Screen Shot 2020-03-04 at 3 29 58 PM" src="https://user-images.githubusercontent.com/3330916/75920278-0514a600-5e2d-11ea-9e03-3934842e9ab9.png">