### PR TITLE
Use KeyOrValue to set Label size and color

### DIFF
--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Example of dynamic text styling
+
 use druid::widget::{Alignment, Flex, Label, Parse, Stepper, TextBox, WidgetExt};
 use druid::{
-    theme, AppLauncher, Data, Lens, LensExt, LensWrap, LocalizedString, PlatformError, Widget,
+    theme, AppLauncher, Data, Key, Lens, LensExt, LensWrap, LocalizedString, PlatformError, Widget,
     WindowDesc,
 };
+
+// This is a custom key we'll use with Env to set and get our text size.
+const MY_CUSTOM_TEXT_SIZE: Key<f64> = Key::new("styled_text.custom_text_size");
 
 #[derive(Clone, Lens, Data)]
 struct AppData {
@@ -46,14 +51,16 @@ fn ui_builder() -> impl Widget<AppData> {
         Label::new(|data: &String, _env: &_| format!("Default: {}", data)).lens(AppData::text);
 
     // The text_color and text_size builder methods can override the defaults
-    // with either a theme key (like we're doing here), or a concrete value
-    // (Color and f64, respectively).
+    // provided by the theme by passing in a Key or a concrete value.
+    //
+    // In this example, text_color receives a Key from the theme, while
+    // text_size gets a custom key which we set with the env_scope wrapper.
     let styled_label =
         Label::new(|data: &AppData, _env: &_| format!("Size {:.1}: {}", data.size, data.text))
             .text_color(theme::PRIMARY_LIGHT)
-            .text_size(theme::TEXT_SIZE_LARGE)
+            .text_size(MY_CUSTOM_TEXT_SIZE)
             .env_scope(|env: &mut druid::Env, data: &AppData| {
-                env.set(theme::TEXT_SIZE_LARGE, data.size)
+                env.set(MY_CUSTOM_TEXT_SIZE, data.size)
             });
 
     let stepper = Stepper::new()

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -65,7 +65,7 @@ fn ui_builder() -> impl Widget<AppData> {
 
     let stepper_textbox = LensWrap::new(
         Parse::new(TextBox::new()),
-        AppData::size.map(|x| Some(*x), |x, y| *x = y.unwrap_or(0.0)),
+        AppData::size.map(|x| Some(*x), |x, y| *x = y.unwrap_or(24.0)),
     );
 
     let stepper_row = Flex::row()

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -1,0 +1,83 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use druid::widget::{Alignment, Flex, Label, Parse, Stepper, TextBox, WidgetExt};
+use druid::{
+    theme, AppLauncher, Data, Lens, LensExt, LensWrap, LocalizedString, PlatformError, Widget,
+    WindowDesc,
+};
+
+#[derive(Clone, Lens, Data)]
+struct AppData {
+    text: String,
+    size: f64,
+}
+fn main() -> Result<(), PlatformError> {
+    let main_window = WindowDesc::new(ui_builder).title(
+        LocalizedString::new("styled-text-demo-window-title").with_placeholder("Type Styler"),
+    );
+    let data = AppData {
+        text: "This is what text looks like".to_string(),
+        size: 24.0,
+    };
+
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(data)?;
+
+    Ok(())
+}
+
+fn ui_builder() -> impl Widget<AppData> {
+    // This is druid's default text style.
+    // It's set by theme::LABEL_COLOR and theme::TEXT_SIZE_NORMAL
+    let label =
+        Label::new(|data: &String, _env: &_| format!("Default: {}", data)).lens(AppData::text);
+
+    // The text_color and text_size builder methods can override the defaults
+    // with either a theme key (like we're doing here), or a concrete value
+    // (Color and f64, respectively).
+    let styled_label =
+        Label::new(|data: &AppData, _env: &_| format!("Size {:.1}: {}", data.size, data.text))
+            .text_color(theme::PRIMARY_LIGHT)
+            .text_size(theme::TEXT_SIZE_LARGE)
+            .env_scope(|env: &mut druid::Env, data: &AppData| {
+                env.set(theme::TEXT_SIZE_LARGE, data.size)
+            });
+
+    let stepper = Stepper::new()
+        .max(100.0)
+        .min(0.0)
+        .step(1.0)
+        .wrap(false)
+        .lens(AppData::size);
+
+    let stepper_textbox = LensWrap::new(
+        Parse::new(TextBox::new()),
+        AppData::size.map(|x| Some(*x), |x, y| *x = y.unwrap_or(0.0)),
+    );
+
+    let stepper_row = Flex::row()
+        .alignment(Alignment::Center)
+        .with_child(stepper_textbox, 0.0)
+        .with_child(stepper, 0.0);
+
+    let input = TextBox::new().lens(AppData::text);
+
+    Flex::column()
+        .with_child(label.center(), 1.0)
+        .with_child(styled_label.center(), 1.0)
+        .with_child(stepper_row.center(), 1.0)
+        .with_child(input.padding(5.0).center(), 1.0)
+}

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -41,6 +41,7 @@ pub const CURSOR_COLOR: Key<Color> = Key::new("cursor_color");
 
 pub const FONT_NAME: Key<&str> = Key::new("font_name");
 pub const TEXT_SIZE_NORMAL: Key<f64> = Key::new("text_size_normal");
+pub const TEXT_SIZE_LARGE: Key<f64> = Key::new("text_size_large");
 pub const BASIC_WIDGET_HEIGHT: Key<f64> = Key::new("basic_widget_height");
 pub const BORDERED_WIDGET_HEIGHT: Key<f64> = Key::new("bordered_widget_height");
 
@@ -77,6 +78,7 @@ pub fn init() -> Env {
         .adding(SELECTION_COLOR, Color::rgb8(0xf3, 0x00, 0x21))
         .adding(CURSOR_COLOR, Color::WHITE)
         .adding(TEXT_SIZE_NORMAL, 15.0)
+        .adding(TEXT_SIZE_LARGE, 24.0)
         .adding(BASIC_WIDGET_HEIGHT, 18.0)
         .adding(BORDERED_WIDGET_HEIGHT, 24.0)
         .adding(TEXTBOX_BORDER_RADIUS, 2.)

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -94,15 +94,6 @@ impl<T: Data> Label<T> {
         self
     }
 
-    /// Set the text color.
-    ///
-    /// The argument can be either a `Color` or a [`Key<Color>`].
-    ///
-    /// [`Key<Color>`]: struct.Key.html
-    pub fn set_text_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
-        self.color = color.into();
-    }
-
     /// Builder-style method for setting the text size.
     ///
     /// The argument can be either an `f64` or a [`Key<f64>`].
@@ -111,6 +102,15 @@ impl<T: Data> Label<T> {
     pub fn text_size(mut self, size: impl Into<KeyOrValue<f64>>) -> Self {
         self.size = size.into();
         self
+    }
+
+    /// Set the text color.
+    ///
+    /// The argument can be either a `Color` or a [`Key<Color>`].
+    ///
+    /// [`Key<Color>`]: struct.Key.html
+    pub fn set_text_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
+        self.color = color.into();
     }
 
     /// Set the text size.

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -84,16 +84,42 @@ impl<T: Data> Label<T> {
         self
     }
 
-    /// Set text color.
+    /// Builder-style method for setting the text color.
+    ///
+    /// The argument can be either a `Color` or a [`Key<Color>`].
+    ///
+    /// [`Key<Color>`]: struct.Key.html
     pub fn text_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
         self.color = color.into();
         self
     }
 
-    /// Set text size.
+    /// Set the text color.
+    ///
+    /// The argument can be either a `Color` or a [`Key<Color>`].
+    ///
+    /// [`Key<Color>`]: struct.Key.html
+    pub fn set_text_color(&mut self, color: impl Into<KeyOrValue<Color>>) {
+        self.color = color.into();
+    }
+
+    /// Builder-style method for setting the text size.
+    ///
+    /// The argument can be either an `f64` or a [`Key<f64>`].
+    ///
+    /// [`Key<f64>`]: struct.Key.html
     pub fn text_size(mut self, size: impl Into<KeyOrValue<f64>>) -> Self {
         self.size = size.into();
         self
+    }
+
+    /// Set the text size.
+    ///
+    /// The argument can be either an `f64` or a [`Key<f64>`].
+    ///
+    /// [`Key<f64>`]: struct.Key.html
+    pub fn set_text_size(&mut self, size: impl Into<KeyOrValue<f64>>) {
+        self.size = size.into();
     }
 
     fn get_layout(&mut self, t: &mut PietText, env: &Env) -> PietTextLayout {

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -16,12 +16,12 @@
 
 use crate::kurbo::{Point, Rect, Size};
 use crate::piet::{
-    FontBuilder, PietText, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
-    UnitPoint,
+    Color, FontBuilder, PietText, PietTextLayout, RenderContext, Text, TextLayout,
+    TextLayoutBuilder, UnitPoint,
 };
 use crate::theme;
 use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    BoxConstraints, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle, LifeCycleCtx,
     LocalizedString, PaintCtx, UpdateCtx, Widget,
 };
 
@@ -47,6 +47,8 @@ pub struct Dynamic<T> {
 pub struct Label<T> {
     text: LabelText<T>,
     align: UnitPoint,
+    color: KeyOrValue<Color>,
+    size: KeyOrValue<f64>,
 }
 
 impl<T: Data> Label<T> {
@@ -71,6 +73,8 @@ impl<T: Data> Label<T> {
         Self {
             text,
             align: UnitPoint::LEFT,
+            color: theme::LABEL_COLOR.into(),
+            size: theme::TEXT_SIZE_NORMAL.into(),
         }
     }
 
@@ -80,9 +84,21 @@ impl<T: Data> Label<T> {
         self
     }
 
+    /// Set text color.
+    pub fn text_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
+        self.color = color.into();
+        self
+    }
+
+    /// Set text size.
+    pub fn text_size(mut self, size: impl Into<KeyOrValue<f64>>) -> Self {
+        self.size = size.into();
+        self
+    }
+
     fn get_layout(&mut self, t: &mut PietText, env: &Env) -> PietTextLayout {
         let font_name = env.get(theme::FONT_NAME);
-        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
+        let font_size = self.size.resolve(env);
 
         // TODO: caching of both the format and the layout
         let font = t.new_font_by_name(font_name, font_size).build().unwrap();
@@ -148,14 +164,14 @@ impl<T: Data> Widget<T> for Label<T> {
     ) -> Size {
         bc.debug_check("Label");
 
-        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
+        let font_size = self.size.resolve(env);
         let text_layout = self.get_layout(layout_ctx.text(), env);
         // This magical 1.2 constant helps center the text vertically in the rect it's given
         bc.constrain(Size::new(text_layout.width(), font_size * 1.2))
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, _data: &T, env: &Env) {
-        let font_size = env.get(theme::TEXT_SIZE_NORMAL);
+        let font_size = self.size.resolve(env);
         let text_layout = self.get_layout(paint_ctx.text(), env);
 
         // Find the origin for the text
@@ -170,7 +186,9 @@ impl<T: Data> Widget<T> for Label<T> {
         //Make sure we don't draw the text too low
         origin.y = origin.y.min(paint_ctx.size().height);
 
-        paint_ctx.draw_text(&text_layout, origin, &env.get(theme::LABEL_COLOR));
+        let color = self.color.resolve(env);
+
+        paint_ctx.draw_text(&text_layout, origin, &color);
     }
 }
 


### PR DESCRIPTION
First stop on the `KeyOrValue` tour!

This is a direct followup to #592, which implemented but did not use `KeyOrValue`.

Had a little fun with the demo. Is this our first example of dynamic styling? Stepper seemed more appropriate than a slider here, but I would like to improve the numeric textbox behavior.