### PR TITLE
No inner align in control widgets

### DIFF
--- a/druid/examples/slider.rs
+++ b/druid/examples/slider.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use druid::widget::{
-    Align, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider, WidgetExt,
+    Align, Alignment, Button, Checkbox, Flex, Label, Padding, ProgressBar, Slider, WidgetExt,
 };
 use druid::{AppLauncher, Data, Lens, LensWrap, LocalizedString, UnitPoint, Widget, WindowDesc};
 
@@ -34,8 +34,9 @@ fn build_widget() -> impl Widget<DemoState> {
     let checkbox = LensWrap::new(Checkbox::new(), DemoState::double);
     let checkbox_label = Label::new("double the value");
     let row = Flex::row()
-        .with_child(checkbox, 0.0)
-        .with_child(Padding::new(5.0, checkbox_label), 1.0);
+        .alignment(Alignment::End)
+        .with_child(checkbox.center().padding(5.0), 0.0)
+        .with_child(checkbox_label, 0.0);
 
     let bar = LensWrap::new(ProgressBar::new(), DemoState::value);
     let slider = LensWrap::new(Slider::new(), DemoState::value);

--- a/druid/examples/switch.rs
+++ b/druid/examples/switch.rs
@@ -52,9 +52,9 @@ fn build_widget() -> impl Widget<DemoState> {
     label_row.add_child(Padding::new(5.0, label), 0.0);
 
     col.add_child(Padding::new(5.0, row), 1.0);
-    col.add_child(Padding::new(5.0, textbox_row), 1.0);
+    col.add_child(Padding::new(5.0, textbox_row), 0.0);
     col.add_child(Padding::new(5.0, label_row), 1.0);
-    col
+    col.debug_paint_layout()
 }
 
 fn main() {

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -43,7 +43,7 @@ fn build_widget() -> impl Widget<String> {
             env.set(theme::CURSOR_COLOR, Color::WHITE);
             env.set(theme::SELECTION_COLOR, Color::rgb8(100, 100, 100));
         },
-        TextBox::with_placeholder("placeholder"),
+        TextBox::new().with_placeholder("placeholder"),
     );
     let label = Label::new(|data: &String, _env: &_| format!("value: {}", data));
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -667,10 +667,10 @@ mod tests {
         fn make_widgets() -> impl Widget<Option<u32>> {
             Split::vertical(
                 Flex::<Option<u32>>::row()
-                    .with_child(TextBox::raw().with_id(ID_1).parse(), 1.0)
-                    .with_child(TextBox::raw().with_id(ID_2).parse(), 1.0)
-                    .with_child(TextBox::raw().with_id(ID_3).parse(), 1.0),
-                Scroll::new(TextBox::raw().parse()),
+                    .with_child(TextBox::new().with_id(ID_1).parse(), 1.0)
+                    .with_child(TextBox::new().with_id(ID_2).parse(), 1.0)
+                    .with_child(TextBox::new().with_id(ID_3).parse(), 1.0),
+                Scroll::new(TextBox::new().parse()),
             )
         }
 

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -194,8 +194,8 @@ fn adding_child_lifecycle() {
     let record_new_child = Recording::default();
     let record_new_child2 = record_new_child.clone();
 
-    let replacer = ReplaceChild::new(TextBox::raw(), move || {
-        Split::vertical(TextBox::raw(), TextBox::raw().record(&record_new_child2))
+    let replacer = ReplaceChild::new(TextBox::new(), move || {
+        Split::vertical(TextBox::new(), TextBox::new().record(&record_new_child2))
     });
 
     let widget = Split::vertical(Label::new("hi").record(&record), replacer);
@@ -224,15 +224,15 @@ fn participate_in_autofocus() {
 
     // this widget starts with a single child, and will replace them with a split
     // when we send it a command.
-    let replacer = ReplaceChild::new(TextBox::raw().with_id(id_4), move || {
-        Split::vertical(TextBox::raw().with_id(id_5), TextBox::raw().with_id(id_6))
+    let replacer = ReplaceChild::new(TextBox::new().with_id(id_4), move || {
+        Split::vertical(TextBox::new().with_id(id_5), TextBox::new().with_id(id_6))
     });
 
     let widget = Split::vertical(
         Flex::row()
-            .with_child(TextBox::raw().with_id(id_1), 1.0)
-            .with_child(TextBox::raw().with_id(id_2), 1.0)
-            .with_child(TextBox::raw().with_id(id_3), 1.0),
+            .with_child(TextBox::new().with_id(id_1), 1.0)
+            .with_child(TextBox::new().with_id(id_2), 1.0)
+            .with_child(TextBox::new().with_id(id_3), 1.0),
         replacer,
     );
 
@@ -292,8 +292,8 @@ fn register_after_adding_child() {
     let (id_1, id_2, id_3, id_4, id_5, id_6) = widget_id6();
     let id_7 = WidgetId::next();
 
-    let replacer = ReplaceChild::new(TextBox::raw().with_id(id_1), move || {
-        Split::vertical(TextBox::raw().with_id(id_2), TextBox::raw().with_id(id_3)).with_id(id_7)
+    let replacer = ReplaceChild::new(TextBox::new().with_id(id_1), move || {
+        Split::vertical(TextBox::new().with_id(id_2), TextBox::new().with_id(id_3)).with_id(id_7)
     })
     .with_id(id_6);
 

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -17,19 +17,19 @@
 use crate::kurbo::{BezPath, Point, RoundedRect, Size};
 use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
 use crate::theme;
-use crate::widget::Align;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
     Widget,
 };
 
-/// A checkbox that toggles a boolean
+/// A checkbox that toggles a `bool`.
 #[derive(Debug, Clone, Default)]
 pub struct Checkbox;
 
 impl Checkbox {
-    pub fn new() -> impl Widget<bool> {
-        Align::vertical(UnitPoint::CENTER, Self::default())
+    /// Create a new `Checkbox`.
+    pub fn new() -> Checkbox {
+        Default::default()
     }
 }
 

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -29,7 +29,7 @@ pub struct Checkbox;
 impl Checkbox {
     /// Create a new `Checkbox`.
     pub fn new() -> Checkbox {
-        Default::default()
+        Checkbox::default()
     }
 }
 

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -16,19 +16,21 @@
 
 use crate::kurbo::{Point, RoundedRect, Size};
 use crate::theme;
-use crate::widget::Align;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
     PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
 };
 
 /// A progress bar, displaying a numeric progress value.
+///
+/// This type impls `Widget<f64>`, expecting a float in the range `0.0..1.0`.
 #[derive(Debug, Clone, Default)]
-pub struct ProgressBar {}
+pub struct ProgressBar;
 
 impl ProgressBar {
-    pub fn new() -> impl Widget<f64> {
-        Align::vertical(UnitPoint::CENTER, Self::default())
+    /// Return a new `ProgressBar`.
+    pub fn new() -> ProgressBar {
+        Self::default()
     }
 }
 

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -16,7 +16,7 @@
 
 use crate::kurbo::{Circle, Point, Rect, Size};
 use crate::theme;
-use crate::widget::{Align, Flex, Label, LabelText, Padding};
+use crate::widget::{Flex, Label, LabelText, Padding, WidgetExt};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
     PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget, WidgetPod,
@@ -46,14 +46,13 @@ pub struct Radio<T> {
     child_label: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
-impl<T: Data + PartialEq> Radio<T> {
+impl<T: Data> Radio<T> {
     /// Create a lone Radio button from label text and an enum variant
-    pub fn new(label: impl Into<LabelText<T>>, variant: T) -> impl Widget<T> {
-        let radio = Self {
+    pub fn new(label: impl Into<LabelText<T>>, variant: T) -> Radio<T> {
+        Radio {
             variant,
-            child_label: WidgetPod::new(Label::new(label)).boxed(),
-        };
-        Align::vertical(UnitPoint::LEFT, radio)
+            child_label: WidgetPod::new(Label::new(label).boxed()),
+        }
     }
 }
 

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -16,13 +16,15 @@
 
 use crate::kurbo::{Circle, Point, Rect, RoundedRect, Shape, Size};
 use crate::theme;
-use crate::widget::Align;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
     PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,
 };
 
 /// A slider, allowing interactive update of a numeric value.
+///
+/// This slider implements `Widget<f64>`, and works on values clamped
+/// in the range 0..1.0.
 #[derive(Debug, Clone, Default)]
 pub struct Slider {
     knob_pos: Point,
@@ -31,8 +33,9 @@ pub struct Slider {
 }
 
 impl Slider {
-    pub fn new() -> impl Widget<f64> {
-        Align::vertical(UnitPoint::CENTER, Self::default())
+    /// Create a new `Slider`.
+    pub fn new() -> Slider {
+        Default::default()
     }
 }
 

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -19,7 +19,6 @@ use crate::piet::{
     FontBuilder, LinearGradient, RenderContext, Text, TextLayout, TextLayoutBuilder, UnitPoint,
 };
 use crate::theme;
-use crate::widget::Align;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
     Widget,
@@ -28,7 +27,7 @@ use crate::{
 const SWITCH_PADDING: f64 = 3.;
 const SWITCH_WIDTH_RATIO: f64 = 2.75;
 
-/// A switch that toggles a boolean.
+/// A switch that toggles a `bool`.
 #[derive(Debug, Clone, Default)]
 pub struct Switch {
     knob_pos: Point,
@@ -38,8 +37,9 @@ pub struct Switch {
 }
 
 impl Switch {
-    pub fn new() -> impl Widget<bool> {
-        Align::vertical(UnitPoint::CENTER, Self::default())
+    /// Create a new `Switch`.
+    pub fn new() -> Switch {
+        Self::default()
     }
 
     fn knob_hit_test(&self, knob_width: f64, mouse_pos: Point) -> bool {
@@ -191,8 +191,7 @@ impl Widget<bool> for Switch {
         _data: &bool,
         env: &Env,
     ) -> Size {
-        let width =
-            (2. * SWITCH_PADDING + env.get(theme::BORDERED_WIDGET_HEIGHT)) * SWITCH_WIDTH_RATIO;
+        let width = env.get(theme::BORDERED_WIDGET_HEIGHT) * SWITCH_WIDTH_RATIO;
         bc.constrain(Size::new(width, env.get(theme::BORDERED_WIDGET_HEIGHT)))
     }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -24,10 +24,8 @@ use crate::{
 use crate::kurbo::{Affine, Line, Point, RoundedRect, Size, Vec2};
 use crate::piet::{
     FontBuilder, PietText, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
-    UnitPoint,
 };
 use crate::theme;
-use crate::widget::Align;
 
 use crate::text::{movement, offset_for_delete_backwards, EditableText, Movement, Selection};
 
@@ -51,19 +49,7 @@ pub struct TextBox {
 
 impl TextBox {
     /// Create a new TextBox widget
-    pub fn new() -> impl Widget<String> {
-        Align::vertical(UnitPoint::CENTER, Self::raw())
-    }
-
-    /// Create a new TextBox widget with placeholder
-    pub fn with_placeholder<T: Into<String>>(placeholder: T) -> impl Widget<String> {
-        let mut textbox = Self::raw();
-        textbox.placeholder = placeholder.into();
-        Align::vertical(UnitPoint::CENTER, textbox)
-    }
-
-    /// Create a new TextBox widget with no Align wrapper
-    pub fn raw() -> TextBox {
+    pub fn new() -> TextBox {
         Self {
             width: 0.0,
             hscroll_offset: 0.,
@@ -72,6 +58,18 @@ impl TextBox {
             cursor_on: false,
             placeholder: String::new(),
         }
+    }
+
+    /// Builder-style method to set the `TextBox`'s placeholder text.
+    pub fn with_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = placeholder.into();
+        self
+    }
+
+    #[deprecated(since = "0.5.0", note = "Use TxtBox::new instead")]
+    #[doc(hidden)]
+    pub fn raw() -> TextBox {
+        Self::new()
     }
 
     /// Calculate the PietTextLayout from the given text, font, and font size
@@ -456,6 +454,12 @@ impl Widget<String> for TextBox {
     }
 }
 
+impl Default for TextBox {
+    fn default() -> Self {
+        TextBox::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -464,7 +468,7 @@ mod tests {
     /// can still be used to insert characters.
     #[test]
     fn data_can_be_changed_externally() {
-        let mut widget = TextBox::raw();
+        let mut widget = TextBox::new();
         let mut data = "".to_string();
 
         // First insert some chars
@@ -486,7 +490,7 @@ mod tests {
     /// Test backspace on the combo character o̷
     #[test]
     fn backspace_combining() {
-        let mut widget = TextBox::raw();
+        let mut widget = TextBox::new();
         let mut data = "".to_string();
 
         widget.insert(&mut data, "\u{0073}\u{006F}\u{0337}\u{0073}");
@@ -500,7 +504,7 @@ mod tests {
     /// Devanagari codepoints are 3 utf-8 code units each.
     #[test]
     fn backspace_devanagari() {
-        let mut widget = TextBox::raw();
+        let mut widget = TextBox::new();
         let mut data = "".to_string();
 
         widget.insert(&mut data, "हिन्दी");

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -66,7 +66,7 @@ impl TextBox {
         self
     }
 
-    #[deprecated(since = "0.5.0", note = "Use TxtBox::new instead")]
+    #[deprecated(since = "0.5.0", note = "Use TextBox::new instead")]
     #[doc(hidden)]
     pub fn raw() -> TextBox {
         Self::new()


### PR DESCRIPTION
This removes inner alignment wrappers from control widgets; alignment should be handled explicitly by the user.


cc @futurepaul: can you think of anything (examples etc) that this might break, that we should update alongside?