### PR TITLE
fix gtk quit panic #505

### DIFF
--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -83,7 +83,7 @@ impl Application {
                 }
                 Some(_) => {
                     // we still have an active window, close the run loop
-                    gtk::main_quit();
+                    app.quit();
                 }
             }
         });


### PR DESCRIPTION
#505 is a druid issue, 

[related gtk issue](https://github.com/gtk-rs/gtk/issues/964)

I've tested, I cannot reproduce the crash after this change and app is closing now.