### PR TITLE
removed gtk::init() because application will initialize it

### DIFF
--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -35,9 +35,6 @@ pub struct Application;
 
 impl Application {
     pub fn new(_handler: Option<Box<dyn AppHandler>>) -> Application {
-        gtk::init().expect("GTK initialization failed");
-        util::assert_main_thread();
-
         // TODO: we should give control over the application ID to the user
         let application = GtkApplication::new(
             Some("com.github.xi-editor.druid"),


### PR DESCRIPTION
https://developer.gnome.org/gtk3/stable/GtkApplication.html#gtk-application-new

> When using GtkApplication, it is not necessary to call gtk_init() manually. It is called as soon as the application gets registered as the primary instance.

We are registering application in the same call frame, so no need to init() manually, which leads to confusion because we shouldn't tear down gtk manually - it will crash #505

We can use application as the main api point here.