### PR TITLE
Implement overriding of lens name

### DIFF
--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -36,7 +36,7 @@ pub fn derive_data(input: TokenStream) -> TokenStream {
 ///
 /// An associated constant is defined on the struct for each field,
 /// having the same name as the field.
-#[proc_macro_derive(Lens)]
+#[proc_macro_derive(Lens, attributes(druid))]
 pub fn derive_lens(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     lens::derive_lens_impl(input)

--- a/druid/examples/lens.rs
+++ b/druid/examples/lens.rs
@@ -31,6 +31,7 @@ fn main() {
 
 #[derive(Clone, Debug, Data, Lens)]
 struct MyComplexState {
+    #[druid(lens_name = "term_lens")]
     term: String,
     scale: f64,
 }
@@ -38,7 +39,7 @@ struct MyComplexState {
 fn ui_builder() -> impl Widget<MyComplexState> {
     // `TextBox` is of type `Widget<String>`
     // via `.lens` we get it to be of type `Widget<MyComplexState>`
-    let searchbar = TextBox::new().lens(MyComplexState::term);
+    let searchbar = TextBox::new().lens(MyComplexState::term_lens);
 
     // `Slider` is of type `Widget<f64>`
     // via `.lens` we get it to be of type `Widget<MyComplexState>`


### PR DESCRIPTION
Closes issue #563 

I am not sure how to check if there is a function with a given name already. So this allows you to set a different lens_name but I don't know yet how to print a nice error message if the name for the lens is already taken by a function.