### PR TITLE
Implement EditAction for keyboard gestures

### DIFF
--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -27,4 +27,4 @@ pub mod backspace;
 pub use self::backspace::offset_for_delete_backwards;
 
 mod text_input;
-pub use self::text_input::{EditAction, SingleLineTextInput, TextInput};
+pub use self::text_input::{BufferEvent, EventDomain, SingleLineTextInput, TextInput, ViewEvent};

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -25,3 +25,6 @@ pub use self::movement::{movement, Movement};
 
 pub mod backspace;
 pub use self::backspace::offset_for_delete_backwards;
+
+mod text_input;
+pub use self::text_input::{EditAction, SingleLineTextInput, TextInput};

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -27,4 +27,4 @@ pub mod backspace;
 pub use self::backspace::offset_for_delete_backwards;
 
 mod text_input;
-pub use self::text_input::{EditAction, MouseAction, SingleLineTextInput, TextInput};
+pub use self::text_input::{BasicTextInput, EditAction, MouseAction, TextInput};

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -27,4 +27,4 @@ pub mod backspace;
 pub use self::backspace::offset_for_delete_backwards;
 
 mod text_input;
-pub use self::text_input::{EditAction, SingleLineTextInput, TextInput};
+pub use self::text_input::{EditAction, MouseAction, SingleLineTextInput, TextInput};

--- a/druid/src/text/mod.rs
+++ b/druid/src/text/mod.rs
@@ -27,4 +27,4 @@ pub mod backspace;
 pub use self::backspace::offset_for_delete_backwards;
 
 mod text_input;
-pub use self::text_input::{BufferEvent, EventDomain, SingleLineTextInput, TextInput, ViewEvent};
+pub use self::text_input::{EditAction, SingleLineTextInput, TextInput};

--- a/druid/src/text/movement.rs
+++ b/druid/src/text/movement.rs
@@ -30,7 +30,7 @@ pub enum Movement {
 }
 
 /// Compute the result of movement on a selection .
-pub fn movement(m: Movement, s: Selection, text: &impl EditableText, modify: bool) -> Selection {
+pub fn movement(m: &Movement, s: Selection, text: &impl EditableText, modify: bool) -> Selection {
     let offset = match m {
         Movement::Left => {
             if s.is_caret() || modify {

--- a/druid/src/text/movement.rs
+++ b/druid/src/text/movement.rs
@@ -30,7 +30,7 @@ pub enum Movement {
 }
 
 /// Compute the result of movement on a selection .
-pub fn movement(m: &Movement, s: Selection, text: &impl EditableText, modify: bool) -> Selection {
+pub fn movement(m: Movement, s: Selection, text: &impl EditableText, modify: bool) -> Selection {
     let offset = match m {
         Movement::Left => {
             if s.is_caret() || modify {

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -1,0 +1,91 @@
+use crate::{HotKey, KeyCode, SysMods};
+use druid_shell::KeyEvent;
+
+// This enumeration is heavily inspired by xi-editors edit notification
+// https://github.com/xi-editor/xi-editor/blob/066523b2a57f719cd93cc9ac0dda7687194badd4/rust/core-lib/src/rpc.rs#L374
+// This is done with the goal of eventually being able to easily switch
+// to a xi-based implementation of our EditActions.
+#[derive(Clone, Debug)]
+pub enum EditAction {
+    Insert { chars: String },
+    DeleteForward,
+    DeleteBackward,
+
+    MoveLeft,
+    MoveLeftAndModifySelection,
+    MoveRight,
+    MoveRightAndModifySelection,
+
+    MoveToLeftEndOfLine,
+    MoveToRightEndOfLine,
+
+    SelectAll,
+}
+
+pub trait TextInput {
+    /// Handle a key event and return an edit action to be executed
+    /// for the key event
+    fn handle_event(&self, event: &KeyEvent) -> Option<EditAction>;
+}
+
+/// Handles key events and returns actions that are applicable to
+/// single line textboxes
+pub struct SingleLineTextInput {}
+
+impl SingleLineTextInput {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TextInput for SingleLineTextInput {
+    fn handle_event(&self, event: &KeyEvent) -> Option<EditAction> {
+        let action = match event {
+            // Select all (Ctrl+A || Cmd+A)
+            k_e if (HotKey::new(SysMods::Cmd, "a")).matches(k_e) => EditAction::SelectAll,
+            // Jump left (Ctrl+ArrowLeft || Cmd+ArrowLeft)
+            k_e if (HotKey::new(SysMods::Cmd, KeyCode::ArrowLeft)).matches(k_e)
+                || HotKey::new(None, KeyCode::Home).matches(k_e) =>
+            {
+                EditAction::MoveToLeftEndOfLine
+            }
+            // Jump right (Ctrl+ArrowRight || Cmd+ArrowRight)
+            k_e if (HotKey::new(SysMods::Cmd, KeyCode::ArrowRight)).matches(k_e)
+                || HotKey::new(None, KeyCode::End).matches(k_e) =>
+            {
+                EditAction::MoveToRightEndOfLine
+            }
+            // Select left (Shift+ArrowLeft)
+            k_e if (HotKey::new(SysMods::Shift, KeyCode::ArrowLeft)).matches(k_e) => {
+                EditAction::MoveLeftAndModifySelection
+            }
+            // Select right (Shift+ArrowRight)
+            k_e if (HotKey::new(SysMods::Shift, KeyCode::ArrowRight)).matches(k_e) => {
+                EditAction::MoveRightAndModifySelection
+            }
+            // Move left (ArrowLeft)
+            k_e if (HotKey::new(None, KeyCode::ArrowLeft)).matches(k_e) => EditAction::MoveLeft,
+            // Move right (ArrowRight)
+            k_e if (HotKey::new(None, KeyCode::ArrowRight)).matches(k_e) => EditAction::MoveRight,
+            // Backspace
+            k_e if (HotKey::new(None, KeyCode::Backspace)).matches(k_e) => {
+                EditAction::DeleteBackward
+            }
+            // Delete
+            k_e if (HotKey::new(None, KeyCode::Delete)).matches(k_e) => EditAction::DeleteForward,
+            // Actual typing
+            k_e if k_e.key_code.is_printable() => {
+                if let Some(chars) = k_e.text() {
+                    EditAction::Insert {
+                        chars: chars.to_owned(),
+                    }
+                } else {
+                    return None;
+                }
+            }
+            _ => return None,
+        };
+
+        Some(action)
+    }
+}

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -21,18 +21,6 @@ pub enum EditAction {
     Paste(String),
 }
 
-impl EditAction {
-    // Returns whether executing the edit action mutates the underlying data storage
-    pub fn is_mutation(&self) -> bool {
-        match self {
-            Self::Delete => true,
-            Self::Backspace => true,
-            Self::Insert(_) | Self::Paste(_) => true,
-            _ => false,
-        }
-    }
-}
-
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MouseAction {
     pub column: usize,

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -13,11 +13,17 @@ pub enum EditAction {
     Move(Movement),
     ModifySelection(Movement),
     SelectAll,
-    // Click(MouseAction),
-    // Drag(MouseAction),
+    Click(MouseAction),
+    Drag(MouseAction),
     Delete, // { movement: Movement, kill: bool },
     Backspace,
     Insert(String),
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct MouseAction {
+    pub column: usize,
+    pub shift: bool,
 }
 
 pub trait TextInput {

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -1,31 +1,40 @@
+use super::Movement;
 use crate::{HotKey, KeyCode, SysMods};
 use druid_shell::KeyEvent;
 
-// This enumeration is heavily inspired by xi-editors edit notification
-// https://github.com/xi-editor/xi-editor/blob/066523b2a57f719cd93cc9ac0dda7687194badd4/rust/core-lib/src/rpc.rs#L374
+// This following enumerations are heavily inspired by xi-editors enumerations found at
+// https://github.com/xi-editor/xi-editor/blob/e2589974fc4050beb33af82481aa71b258358e48/rust/core-lib/src/edit_types.rs
 // This is done with the goal of eventually being able to easily switch
-// to a xi-based implementation of our EditActions.
-#[derive(Clone, Debug)]
-pub enum EditAction {
-    Insert { chars: String },
-    DeleteForward,
-    DeleteBackward,
+// to a xi-based implementation of our Events.
 
-    MoveLeft,
-    MoveLeftAndModifySelection,
-    MoveRight,
-    MoveRightAndModifySelection,
-
-    MoveToLeftEndOfLine,
-    MoveToRightEndOfLine,
-
+/// Events that only modify view state
+#[derive(Debug, PartialEq, Clone)]
+pub enum ViewEvent {
+    Move(Movement),
+    ModifySelection(Movement),
     SelectAll,
+    // Click(MouseAction),
+    // Drag(MouseAction),
+}
+
+/// Events that modify the buffer
+#[derive(Debug, PartialEq, Clone)]
+pub enum BufferEvent {
+    Delete, // { movement: Movement, kill: bool },
+    Backspace,
+    Insert(String),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum EventDomain {
+    View(ViewEvent),
+    Buffer(BufferEvent),
 }
 
 pub trait TextInput {
     /// Handle a key event and return an edit action to be executed
     /// for the key event
-    fn handle_event(&self, event: &KeyEvent) -> Option<EditAction>;
+    fn handle_event(&self, event: &KeyEvent) -> Option<EventDomain>;
 }
 
 /// Handles key events and returns actions that are applicable to
@@ -39,46 +48,52 @@ impl SingleLineTextInput {
 }
 
 impl TextInput for SingleLineTextInput {
-    fn handle_event(&self, event: &KeyEvent) -> Option<EditAction> {
+    fn handle_event(&self, event: &KeyEvent) -> Option<EventDomain> {
         let action = match event {
             // Select all (Ctrl+A || Cmd+A)
-            k_e if (HotKey::new(SysMods::Cmd, "a")).matches(k_e) => EditAction::SelectAll,
+            k_e if (HotKey::new(SysMods::Cmd, "a")).matches(k_e) => {
+                EventDomain::View(ViewEvent::SelectAll)
+            }
             // Jump left (Ctrl+ArrowLeft || Cmd+ArrowLeft)
             k_e if (HotKey::new(SysMods::Cmd, KeyCode::ArrowLeft)).matches(k_e)
                 || HotKey::new(None, KeyCode::Home).matches(k_e) =>
             {
-                EditAction::MoveToLeftEndOfLine
+                EventDomain::View(ViewEvent::Move(Movement::LeftOfLine))
             }
             // Jump right (Ctrl+ArrowRight || Cmd+ArrowRight)
             k_e if (HotKey::new(SysMods::Cmd, KeyCode::ArrowRight)).matches(k_e)
                 || HotKey::new(None, KeyCode::End).matches(k_e) =>
             {
-                EditAction::MoveToRightEndOfLine
+                EventDomain::View(ViewEvent::Move(Movement::RightOfLine))
             }
             // Select left (Shift+ArrowLeft)
             k_e if (HotKey::new(SysMods::Shift, KeyCode::ArrowLeft)).matches(k_e) => {
-                EditAction::MoveLeftAndModifySelection
+                EventDomain::View(ViewEvent::ModifySelection(Movement::Left))
             }
             // Select right (Shift+ArrowRight)
             k_e if (HotKey::new(SysMods::Shift, KeyCode::ArrowRight)).matches(k_e) => {
-                EditAction::MoveRightAndModifySelection
+                EventDomain::View(ViewEvent::ModifySelection(Movement::Right))
             }
             // Move left (ArrowLeft)
-            k_e if (HotKey::new(None, KeyCode::ArrowLeft)).matches(k_e) => EditAction::MoveLeft,
+            k_e if (HotKey::new(None, KeyCode::ArrowLeft)).matches(k_e) => {
+                EventDomain::View(ViewEvent::Move(Movement::Left))
+            }
             // Move right (ArrowRight)
-            k_e if (HotKey::new(None, KeyCode::ArrowRight)).matches(k_e) => EditAction::MoveRight,
+            k_e if (HotKey::new(None, KeyCode::ArrowRight)).matches(k_e) => {
+                EventDomain::View(ViewEvent::Move(Movement::Right))
+            }
             // Backspace
             k_e if (HotKey::new(None, KeyCode::Backspace)).matches(k_e) => {
-                EditAction::DeleteBackward
+                EventDomain::Buffer(BufferEvent::Backspace)
             }
             // Delete
-            k_e if (HotKey::new(None, KeyCode::Delete)).matches(k_e) => EditAction::DeleteForward,
+            k_e if (HotKey::new(None, KeyCode::Delete)).matches(k_e) => {
+                EventDomain::Buffer(BufferEvent::Delete)
+            }
             // Actual typing
             k_e if k_e.key_code.is_printable() => {
                 if let Some(chars) = k_e.text() {
-                    EditAction::Insert {
-                        chars: chars.to_owned(),
-                    }
+                    EventDomain::Buffer(BufferEvent::Insert(chars.to_owned()))
                 } else {
                     return None;
                 }

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -9,32 +9,21 @@ use druid_shell::KeyEvent;
 
 /// Events that only modify view state
 #[derive(Debug, PartialEq, Clone)]
-pub enum ViewEvent {
+pub enum EditAction {
     Move(Movement),
     ModifySelection(Movement),
     SelectAll,
     // Click(MouseAction),
     // Drag(MouseAction),
-}
-
-/// Events that modify the buffer
-#[derive(Debug, PartialEq, Clone)]
-pub enum BufferEvent {
     Delete, // { movement: Movement, kill: bool },
     Backspace,
     Insert(String),
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub enum EventDomain {
-    View(ViewEvent),
-    Buffer(BufferEvent),
-}
-
 pub trait TextInput {
     /// Handle a key event and return an edit action to be executed
     /// for the key event
-    fn handle_event(&self, event: &KeyEvent) -> Option<EventDomain>;
+    fn handle_event(&self, event: &KeyEvent) -> Option<EditAction>;
 }
 
 /// Handles key events and returns actions that are applicable to
@@ -48,52 +37,46 @@ impl SingleLineTextInput {
 }
 
 impl TextInput for SingleLineTextInput {
-    fn handle_event(&self, event: &KeyEvent) -> Option<EventDomain> {
+    fn handle_event(&self, event: &KeyEvent) -> Option<EditAction> {
         let action = match event {
             // Select all (Ctrl+A || Cmd+A)
-            k_e if (HotKey::new(SysMods::Cmd, "a")).matches(k_e) => {
-                EventDomain::View(ViewEvent::SelectAll)
-            }
+            k_e if (HotKey::new(SysMods::Cmd, "a")).matches(k_e) => EditAction::SelectAll,
             // Jump left (Ctrl+ArrowLeft || Cmd+ArrowLeft)
             k_e if (HotKey::new(SysMods::Cmd, KeyCode::ArrowLeft)).matches(k_e)
                 || HotKey::new(None, KeyCode::Home).matches(k_e) =>
             {
-                EventDomain::View(ViewEvent::Move(Movement::LeftOfLine))
+                EditAction::Move(Movement::LeftOfLine)
             }
             // Jump right (Ctrl+ArrowRight || Cmd+ArrowRight)
             k_e if (HotKey::new(SysMods::Cmd, KeyCode::ArrowRight)).matches(k_e)
                 || HotKey::new(None, KeyCode::End).matches(k_e) =>
             {
-                EventDomain::View(ViewEvent::Move(Movement::RightOfLine))
+                EditAction::Move(Movement::RightOfLine)
             }
             // Select left (Shift+ArrowLeft)
             k_e if (HotKey::new(SysMods::Shift, KeyCode::ArrowLeft)).matches(k_e) => {
-                EventDomain::View(ViewEvent::ModifySelection(Movement::Left))
+                EditAction::ModifySelection(Movement::Left)
             }
             // Select right (Shift+ArrowRight)
             k_e if (HotKey::new(SysMods::Shift, KeyCode::ArrowRight)).matches(k_e) => {
-                EventDomain::View(ViewEvent::ModifySelection(Movement::Right))
+                EditAction::ModifySelection(Movement::Right)
             }
             // Move left (ArrowLeft)
             k_e if (HotKey::new(None, KeyCode::ArrowLeft)).matches(k_e) => {
-                EventDomain::View(ViewEvent::Move(Movement::Left))
+                EditAction::Move(Movement::Left)
             }
             // Move right (ArrowRight)
             k_e if (HotKey::new(None, KeyCode::ArrowRight)).matches(k_e) => {
-                EventDomain::View(ViewEvent::Move(Movement::Right))
+                EditAction::Move(Movement::Right)
             }
             // Backspace
-            k_e if (HotKey::new(None, KeyCode::Backspace)).matches(k_e) => {
-                EventDomain::Buffer(BufferEvent::Backspace)
-            }
+            k_e if (HotKey::new(None, KeyCode::Backspace)).matches(k_e) => EditAction::Backspace,
             // Delete
-            k_e if (HotKey::new(None, KeyCode::Delete)).matches(k_e) => {
-                EventDomain::Buffer(BufferEvent::Delete)
-            }
+            k_e if (HotKey::new(None, KeyCode::Delete)).matches(k_e) => EditAction::Delete,
             // Actual typing
             k_e if k_e.key_code.is_printable() => {
                 if let Some(chars) = k_e.text() {
-                    EventDomain::Buffer(BufferEvent::Insert(chars.to_owned()))
+                    EditAction::Insert(chars.to_owned())
                 } else {
                     return None;
                 }

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -18,6 +18,19 @@ pub enum EditAction {
     Delete, // { movement: Movement, kill: bool },
     Backspace,
     Insert(String),
+    Paste(String),
+}
+
+impl EditAction {
+    // Returns whether executing the edit action mutates the underlying data storage
+    pub fn is_mutation(&self) -> bool {
+        match self {
+            Self::Delete => true,
+            Self::Backspace => true,
+            Self::Insert(_) | Self::Paste(_) => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -1,13 +1,29 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Map input to `EditAction`s
+
 use super::Movement;
 use crate::{HotKey, KeyCode, SysMods};
-use druid_shell::KeyEvent;
+use druid_shell::{KeyEvent, KeyModifiers};
 
 // This following enumerations are heavily inspired by xi-editors enumerations found at
 // https://github.com/xi-editor/xi-editor/blob/e2589974fc4050beb33af82481aa71b258358e48/rust/core-lib/src/edit_types.rs
 // This is done with the goal of eventually being able to easily switch
 // to a xi-based implementation of our Events.
 
-/// Events that only modify view state
+/// An enum that represents actions in a text buffer.
 #[derive(Debug, PartialEq, Clone)]
 pub enum EditAction {
     Move(Movement),
@@ -15,16 +31,18 @@ pub enum EditAction {
     SelectAll,
     Click(MouseAction),
     Drag(MouseAction),
-    Delete, // { movement: Movement, kill: bool },
+    Delete,
     Backspace,
     Insert(String),
     Paste(String),
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+/// Extra information related to mouse actions
+#[derive(PartialEq, Debug, Clone)]
 pub struct MouseAction {
+    pub row: usize,
     pub column: usize,
-    pub shift: bool,
+    pub mods: KeyModifiers,
 }
 
 pub trait TextInput {
@@ -35,15 +53,15 @@ pub trait TextInput {
 
 /// Handles key events and returns actions that are applicable to
 /// single line textboxes
-pub struct SingleLineTextInput {}
+pub struct BasicTextInput {}
 
-impl SingleLineTextInput {
+impl BasicTextInput {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl TextInput for SingleLineTextInput {
+impl TextInput for BasicTextInput {
     fn handle_event(&self, event: &KeyEvent) -> Option<EditAction> {
         let action = match event {
             // Select all (Ctrl+A || Cmd+A)

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -120,7 +120,7 @@ impl TextBox {
         self.selection.end
     }
 
-    fn do_edit_action(&mut self, edit_action: &EditAction, text: &mut String) {
+    fn do_edit_action(&mut self, edit_action: EditAction, text: &mut String) {
         match edit_action {
             EditAction::Insert(chars) | EditAction::Paste(chars) => self.insert(text, &chars),
             EditAction::Backspace => self.delete_backward(text),
@@ -140,7 +140,7 @@ impl TextBox {
     }
 
     /// Edit a selection using a `Movement`.
-    fn move_selection(&mut self, mvmnt: &Movement, text: &mut String, modify: bool) {
+    fn move_selection(&mut self, mvmnt: Movement, text: &mut String, modify: bool) {
         // This movement function should ensure all movements are legit.
         // If they aren't, that's a problem with the movement function.
         self.selection = movement(mvmnt, self.selection, text, modify);
@@ -164,7 +164,7 @@ impl TextBox {
         if self.selection.is_caret() {
             // Never touch the characters before the cursor.
             if text.next_grapheme_offset(self.cursor()).is_some() {
-                self.move_selection(&Movement::Right, text, false);
+                self.move_selection(Movement::Right, text, false);
                 self.delete_backward(text);
             }
         } else {
@@ -317,14 +317,14 @@ impl Widget<String> for TextBox {
         }
 
         if let Some(edit_action) = edit_action {
-            self.do_edit_action(&edit_action, data);
-            self.reset_cursor_blink(ctx);
-
             let is_select_all = if let EditAction::SelectAll = &edit_action {
                 true
             } else {
                 false
             };
+
+            self.do_edit_action(edit_action, data);
+            self.reset_cursor_blink(ctx);
 
             if !is_select_all {
                 text_layout = self.get_layout(&mut ctx.text(), &data, env);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -28,8 +28,8 @@ use crate::piet::{
 use crate::theme;
 
 use crate::text::{
-    movement, offset_for_delete_backwards, EditAction, EditableText, Movement, Selection,
-    SingleLineTextInput, TextInput,
+    movement, offset_for_delete_backwards, BufferEvent, EditableText, EventDomain, Movement,
+    Selection, SingleLineTextInput, TextInput, ViewEvent,
 };
 
 const BORDER_WIDTH: f64 = 1.;
@@ -120,26 +120,18 @@ impl TextBox {
         self.selection.end
     }
 
-    fn do_edit_action(&mut self, edit_action: EditAction, text: &mut String) {
+    fn do_edit_action(&mut self, edit_action: EventDomain, text: &mut String) {
         match edit_action {
-            EditAction::Insert { chars } => self.insert(text, &chars),
-            EditAction::DeleteBackward => self.delete_backward(text),
-            EditAction::DeleteForward => self.delete_forward(text),
-            EditAction::MoveLeft => self.move_selection(Movement::Left, text, false),
-            EditAction::MoveLeftAndModifySelection => {
-                self.move_selection(Movement::Left, text, true)
+            EventDomain::Buffer(BufferEvent::Insert(chars)) => self.insert(text, &chars),
+            EventDomain::Buffer(BufferEvent::Backspace) => self.delete_backward(text),
+            EventDomain::Buffer(BufferEvent::Delete) => self.delete_forward(text),
+            EventDomain::View(ViewEvent::Move(movement)) => {
+                self.move_selection(movement, text, false)
             }
-            EditAction::MoveRight => self.move_selection(Movement::Right, text, false),
-            EditAction::MoveRightAndModifySelection => {
-                self.move_selection(Movement::Right, text, true)
+            EventDomain::View(ViewEvent::ModifySelection(movement)) => {
+                self.move_selection(movement, text, true)
             }
-            EditAction::MoveToLeftEndOfLine => {
-                self.move_selection(Movement::LeftOfLine, text, false)
-            }
-            EditAction::MoveToRightEndOfLine => {
-                self.move_selection(Movement::RightOfLine, text, false)
-            }
-            EditAction::SelectAll => self.selection.all(text),
+            EventDomain::View(ViewEvent::SelectAll) => self.selection.all(text),
         }
     }
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -28,8 +28,8 @@ use crate::piet::{
 use crate::theme;
 
 use crate::text::{
-    movement, offset_for_delete_backwards, EditAction, EditableText, MouseAction, Movement,
-    Selection, SingleLineTextInput, TextInput,
+    movement, offset_for_delete_backwards, BasicTextInput, EditAction, EditableText, MouseAction,
+    Movement, Selection, TextInput,
 };
 
 const BORDER_WIDTH: f64 = 1.;
@@ -129,7 +129,7 @@ impl TextBox {
             EditAction::ModifySelection(movement) => self.move_selection(movement, text, true),
             EditAction::SelectAll => self.selection.all(text),
             EditAction::Click(action) => {
-                if action.shift {
+                if action.mods.shift {
                     self.selection.end = action.column;
                 } else {
                     self.caret_to(text, action.column);
@@ -242,8 +242,9 @@ impl Widget<String> for TextBox {
 
                 let cursor_offset = self.offset_for_point(mouse.pos, &text_layout);
                 edit_action = Some(EditAction::Click(MouseAction {
+                    row: 0,
                     column: cursor_offset,
-                    shift: mouse.mods.shift,
+                    mods: mouse.mods,
                 }));
 
                 ctx.request_paint();
@@ -253,8 +254,9 @@ impl Widget<String> for TextBox {
                 if ctx.is_active() {
                     let cursor_offset = self.offset_for_point(mouse.pos, &text_layout);
                     edit_action = Some(EditAction::Drag(MouseAction {
+                        row: 0,
                         column: cursor_offset,
-                        shift: mouse.mods.shift,
+                        mods: mouse.mods,
                     }));
                     ctx.request_paint();
                 }
@@ -308,7 +310,7 @@ impl Widget<String> for TextBox {
                 };
 
                 if !event_handled {
-                    edit_action = SingleLineTextInput::new().handle_event(key_event);
+                    edit_action = BasicTextInput::new().handle_event(key_event);
                 }
 
                 ctx.request_paint();

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -28,8 +28,8 @@ use crate::piet::{
 use crate::theme;
 
 use crate::text::{
-    movement, offset_for_delete_backwards, BufferEvent, EditableText, EventDomain, Movement,
-    Selection, SingleLineTextInput, TextInput, ViewEvent,
+    movement, offset_for_delete_backwards, EditAction, EditableText, Movement, Selection,
+    SingleLineTextInput, TextInput,
 };
 
 const BORDER_WIDTH: f64 = 1.;
@@ -120,18 +120,14 @@ impl TextBox {
         self.selection.end
     }
 
-    fn do_edit_action(&mut self, edit_action: EventDomain, text: &mut String) {
+    fn do_edit_action(&mut self, edit_action: EditAction, text: &mut String) {
         match edit_action {
-            EventDomain::Buffer(BufferEvent::Insert(chars)) => self.insert(text, &chars),
-            EventDomain::Buffer(BufferEvent::Backspace) => self.delete_backward(text),
-            EventDomain::Buffer(BufferEvent::Delete) => self.delete_forward(text),
-            EventDomain::View(ViewEvent::Move(movement)) => {
-                self.move_selection(movement, text, false)
-            }
-            EventDomain::View(ViewEvent::ModifySelection(movement)) => {
-                self.move_selection(movement, text, true)
-            }
-            EventDomain::View(ViewEvent::SelectAll) => self.selection.all(text),
+            EditAction::Insert(chars) => self.insert(text, &chars),
+            EditAction::Backspace => self.delete_backward(text),
+            EditAction::Delete => self.delete_forward(text),
+            EditAction::Move(movement) => self.move_selection(movement, text, false),
+            EditAction::ModifySelection(movement) => self.move_selection(movement, text, true),
+            EditAction::SelectAll => self.selection.all(text),
         }
     }
 


### PR DESCRIPTION
This moves our textbox actions into an `EditAction` enum with the goal of eventually moving to a xi-based implementation for our textbox.

This is a step in solving issue #615 