### PR TITLE
Give 'wide' widgets a shared default width

### DIFF
--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -42,6 +42,9 @@ pub const CURSOR_COLOR: Key<Color> = Key::new("cursor_color");
 pub const FONT_NAME: Key<&str> = Key::new("font_name");
 pub const TEXT_SIZE_NORMAL: Key<f64> = Key::new("text_size_normal");
 pub const BASIC_WIDGET_HEIGHT: Key<f64> = Key::new("basic_widget_height");
+
+/// The default minimum width for a 'wide' widget; a textbox, slider, progress bar, etc.
+pub const WIDE_WIDGET_WIDTH: Key<f64> = Key::new("druid.widgets.long-widget-width");
 pub const BORDERED_WIDGET_HEIGHT: Key<f64> = Key::new("bordered_widget_height");
 
 pub const TEXTBOX_BORDER_RADIUS: Key<f64> = Key::new("textbox_radius");
@@ -78,6 +81,7 @@ pub fn init() -> Env {
         .adding(CURSOR_COLOR, Color::WHITE)
         .adding(TEXT_SIZE_NORMAL, 15.0)
         .adding(BASIC_WIDGET_HEIGHT, 18.0)
+        .adding(WIDE_WIDGET_WIDTH, 100.)
         .adding(BORDERED_WIDGET_HEIGHT, 24.0)
         .adding(TEXTBOX_BORDER_RADIUS, 2.)
         .adding(SCROLL_BAR_COLOR, Color::rgb8(0xff, 0xff, 0xff))

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -49,20 +49,10 @@ impl Widget<f64> for ProgressBar {
         env: &Env,
     ) -> Size {
         bc.debug_check("ProgressBar");
-
-        let default_width = 100.0;
-
-        if bc.is_width_bounded() {
-            bc.constrain(Size::new(
-                bc.max().width,
-                env.get(theme::BASIC_WIDGET_HEIGHT),
-            ))
-        } else {
-            bc.constrain(Size::new(
-                default_width,
-                env.get(theme::BASIC_WIDGET_HEIGHT),
-            ))
-        }
+        bc.constrain(Size::new(
+            env.get(theme::WIDE_WIDGET_WIDTH),
+            env.get(theme::BASIC_WIDGET_HEIGHT),
+        ))
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &f64, env: &Env) {

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -103,20 +103,9 @@ impl Widget<f64> for Slider {
         env: &Env,
     ) -> Size {
         bc.debug_check("Slider");
-
-        let default_width = 100.0;
-
-        if bc.is_width_bounded() {
-            bc.constrain(Size::new(
-                bc.max().width,
-                env.get(theme::BASIC_WIDGET_HEIGHT),
-            ))
-        } else {
-            bc.constrain(Size::new(
-                default_width,
-                env.get(theme::BASIC_WIDGET_HEIGHT),
-            ))
-        }
+        let height = env.get(theme::BASIC_WIDGET_HEIGHT);
+        let width = env.get(theme::WIDE_WIDGET_WIDTH);
+        bc.constrain((width, height))
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &f64, env: &Env) {

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -354,15 +354,12 @@ impl Widget<String> for TextBox {
         _data: &String,
         env: &Env,
     ) -> Size {
-        let default_width = 100.0;
+        let width = env.get(theme::WIDE_WIDGET_WIDTH);
+        let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
 
-        if bc.is_width_bounded() {
-            self.width = bc.max().width;
-        } else {
-            self.width = default_width;
-        }
-
-        bc.constrain((self.width, env.get(theme::BORDERED_WIDGET_HEIGHT)))
+        let size = bc.constrain((width, height));
+        self.width = size.width;
+        size
     }
 
     fn paint(&mut self, paint_ctx: &mut PaintCtx, data: &String, env: &Env) {


### PR DESCRIPTION
This also removes the tendency for these widgets to always
explicitly fill their provided constraints when possible.

The rationale here is that if the parent wants the child to fill
the bounds, it can do this by providing tight constraints.


cc @futurepaul thoughts? I'm going through a bunch of layout stuff, and will try and write up guidelines for writing a `layout` fn, but I don't think in the general case we should just be deferring to `bc.max()`; if we want that we can wrap ourselves in a `SizedBox` with infinite bounds. 