### PR TITLE
Git bump the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Since druid is currently in fast-evolving state, you might prefer to drink from
 the firehose:
 
 ```toml
-druid = { git = "https://github.com/xi-editor/druid.git", version = "0.4" }
+druid = { git = "https://github.com/xi-editor/druid.git", version = "0.5" }
 ```
 
 ### Platform notes


### PR DESCRIPTION
The build crashes with the error, that a version compatible with 0.4 wasn't found, but 0.5.0 was.
If we bump the version, it works perfectly.