### PR TITLE
Flex main axis alignment

### DIFF
--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -57,7 +57,7 @@ pub use container::Container;
 pub use controller::{Controller, ControllerHost};
 pub use either::Either;
 pub use env_scope::EnvScope;
-pub use flex::{CrossAxisAlignment, Flex};
+pub use flex::{CrossAxisAlignment, Flex, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
 pub use label::{Label, LabelText};
 pub use list::{List, ListIter};


### PR DESCRIPTION
This implements two additional options from the flutter Flex widget: the ability to set the [main axis alignment](https://api.flutter.dev/flutter/rendering/MainAxisAlignment-class.html) (which I'm calling `Justification`; not sure I like this name) as well as the ability to force the container to use all available space on the main axis, which flutter calls [`MainAxisSize`](https://api.flutter.dev/flutter/rendering/MainAxisSize-class.html).

These are implemented together because without the latter you don't have any extra space with which to use the former.

<img width="712" alt="Screen Shot 2020-03-09 at 7 49 24 PM" src="https://user-images.githubusercontent.com/3330916/76266804-14d22700-623f-11ea-9474-db3eaed9513c.png">
<img width="712" alt="Screen Shot 2020-03-09 at 7 49 33 PM" src="https://user-images.githubusercontent.com/3330916/76266814-1ac80800-623f-11ea-9000-f20c54f8497a.png">
