### PR TITLE
Loosen incoming constraints in Flex

### DIFF
--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -16,7 +16,7 @@
 
 use druid::{AppLauncher, Data, Lens, LensWrap, LocalizedString, Widget, WindowDesc};
 
-use druid::widget::{Button, Flex, Label, Padding};
+use druid::widget::{Button, Flex, Label, WidgetExt};
 
 #[derive(Clone, Data, Lens)]
 struct CalcState {
@@ -112,15 +112,10 @@ impl CalcState {
     }
 }
 
-fn pad<T: Data>(inner: impl Widget<T> + 'static) -> impl Widget<T> {
-    Padding::new(5.0, inner)
-}
-
 fn op_button_label(op: char, label: String) -> impl Widget<CalcState> {
-    pad(Button::new(
-        label,
-        move |_ctx, data: &mut CalcState, _env| data.op(op),
-    ))
+    Button::new(label, move |_ctx, data: &mut CalcState, _env| data.op(op))
+        .expand()
+        .padding(5.0)
 }
 
 fn op_button(op: char) -> impl Widget<CalcState> {
@@ -128,10 +123,12 @@ fn op_button(op: char) -> impl Widget<CalcState> {
 }
 
 fn digit_button(digit: u8) -> impl Widget<CalcState> {
-    pad(Button::new(
+    Button::new(
         format!("{}", digit),
         move |_ctx, data: &mut CalcState, _env| data.digit(digit),
-    ))
+    )
+    .expand()
+    .padding(5.0)
 }
 
 fn flex_row<T: Data>(
@@ -151,9 +148,10 @@ fn build_calc() -> impl Widget<CalcState> {
     let display = LensWrap::new(
         Label::new(|data: &String, _env: &_| data.clone()),
         CalcState::value,
-    );
+    )
+    .padding(5.0);
     Flex::column()
-        .with_child(pad(display), 0.0)
+        .with_child(display, 0.0)
         .with_child(
             flex_row(
                 op_button_label('c', "CE".to_string()),

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -42,6 +42,7 @@ pub(crate) const DEFAULT_SIZE: Size = Size::new(400., 400.);
 pub struct Harness<'a, T> {
     piet: Piet<'a>,
     inner: Inner<T>,
+    window_size: Size,
 }
 
 /// All of the state except for the `Piet` (render context). We need to pass
@@ -80,8 +81,18 @@ impl<T: Data> Harness<'_, T> {
             cmds: Default::default(),
         };
 
-        let mut harness = Harness { piet, inner };
+        let mut harness = Harness {
+            piet,
+            inner,
+            window_size: DEFAULT_SIZE,
+        };
         f(&mut harness);
+    }
+
+    /// Set the size without sending a resize event; intended to be used
+    /// before calling `send_initial_events`
+    pub fn set_initial_size(&mut self, size: Size) {
+        self.window_size = size;
     }
 
     pub fn window(&self) -> &Window<T> {
@@ -133,7 +144,7 @@ impl<T: Data> Harness<'_, T> {
     // should we do this automatically? Also these will change regularly?
     pub fn send_initial_events(&mut self) {
         self.event(Event::WindowConnected);
-        self.event(Event::Size(DEFAULT_SIZE));
+        self.event(Event::Size(self.window_size));
     }
 
     /// Send an event to the widget.

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -125,31 +125,39 @@ fn flex_paint_rect_overflow() {
 
     let widget = Flex::row()
         .with_child(
-            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
-                ctx.set_paint_insets(Insets::new(20., 0., 0., 0.));
-                bc.constrain(Size::new(10., 10.))
-            }),
+            ModularWidget::new(())
+                .layout_fn(|_, ctx, bc, _, _| {
+                    ctx.set_paint_insets(Insets::new(20., 0., 0., 0.));
+                    bc.constrain(Size::new(10., 10.))
+                })
+                .expand(),
             1.0,
         )
         .with_child(
-            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
-                ctx.set_paint_insets(Insets::new(0., 20., 0., 0.));
-                bc.constrain(Size::new(10., 10.))
-            }),
+            ModularWidget::new(())
+                .layout_fn(|_, ctx, bc, _, _| {
+                    ctx.set_paint_insets(Insets::new(0., 20., 0., 0.));
+                    bc.constrain(Size::new(10., 10.))
+                })
+                .expand(),
             1.0,
         )
         .with_child(
-            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
-                ctx.set_paint_insets(Insets::new(0., 0., 0., 20.));
-                bc.constrain(Size::new(10., 10.))
-            }),
+            ModularWidget::new(())
+                .layout_fn(|_, ctx, bc, _, _| {
+                    ctx.set_paint_insets(Insets::new(0., 0., 0., 20.));
+                    bc.constrain(Size::new(10., 10.))
+                })
+                .expand(),
             1.0,
         )
         .with_child(
-            ModularWidget::new(()).layout_fn(|_, ctx, bc, _, _| {
-                ctx.set_paint_insets(Insets::new(0., 0., 20., 0.));
-                bc.constrain(Size::new(10., 10.))
-            }),
+            ModularWidget::new(())
+                .layout_fn(|_, ctx, bc, _, _| {
+                    ctx.set_paint_insets(Insets::new(0., 0., 20., 0.));
+                    bc.constrain(Size::new(10., 10.))
+                })
+                .expand(),
             1.0,
         )
         .with_id(id)
@@ -158,6 +166,7 @@ fn flex_paint_rect_overflow() {
         .center();
 
     Harness::create((), widget, |harness| {
+        harness.set_initial_size(Size::new(300., 300.));
         harness.send_initial_events();
         harness.just_layout();
 


### PR DESCRIPTION
The flex widget should not force its children to match its
own minimum size, particularly on the minor axis; the container
is allowed to be larger than the sum of its children, and many
of the configurable options on the flex widget expect this to be
the case.

If the user wants a specific widget to fill its available space,
this can be achieved with an expanded SizedBox or possibly with a
(not yet implemented) 'stretch' alignment.

before:
<img width="662" alt="Screen Shot 2020-03-09 at 10 02 02 PM" src="https://user-images.githubusercontent.com/3330916/76272359-9cc12c80-6251-11ea-8b48-0f8cf028cda4.png">
after:
<img width="609" alt="Screen Shot 2020-03-10 at 11 03 50 AM" src="https://user-images.githubusercontent.com/3330916/76326307-d419f280-62be-11ea-8a20-66fea661d0aa.png">

progress on #607 