### PR TITLE
Label and button alignment

### DIFF
--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -34,5 +34,5 @@ fn ui_builder() -> impl Widget<u32> {
 
     Flex::column()
         .with_child(Align::centered(Padding::new(5.0, label)), 1.0)
-        .with_child(Padding::new(5.0, button), 1.0)
+        .with_child(Align::centered(Padding::new(5.0, button)), 1.0)
 }

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use druid::lens::{self, LensExt};
-use druid::widget::{Button, Flex, Label, List, Scroll, WidgetExt};
+use druid::widget::{Button, Flex, Label, List, Scroll, SizedBox, WidgetExt};
 use druid::{AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
@@ -64,6 +64,7 @@ fn ui_builder() -> impl Widget<AppData> {
     lists.add_child(
         Scroll::new(List::new(|| {
             Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
+                .align_vertical(UnitPoint::LEFT)
                 .padding(10.0)
                 .expand()
                 .height(50.0)
@@ -81,9 +82,11 @@ fn ui_builder() -> impl Widget<AppData> {
                 .with_child(
                     Label::new(|(_, item): &(Arc<Vec<u32>>, u32), _env: &_| {
                         format!("List item #{}", item)
-                    }),
-                    1.0,
+                    })
+                    .align_vertical(UnitPoint::LEFT),
+                    0.0,
                 )
+                .with_child(SizedBox::empty(), 1.0)
                 .with_child(
                     Button::new(
                         "Delete",

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -33,12 +33,14 @@ fn build_app() -> impl Widget<()> {
             Flex::row()
                 .with_child(
                     Label::new("top left")
+                        .center()
                         .border(gradient.clone(), 4.0)
                         .padding(10.0),
                     1.0,
                 )
                 .with_child(
                     Label::new("top right")
+                        .center()
                         .background(solid.clone())
                         .padding(10.0),
                     1.0,
@@ -49,6 +51,7 @@ fn build_app() -> impl Widget<()> {
             Flex::row()
                 .with_child(
                     Label::new("bottom left")
+                        .center()
                         .background(gradient.clone())
                         .rounded(10.0)
                         .padding(10.0),
@@ -56,6 +59,7 @@ fn build_app() -> impl Widget<()> {
                 )
                 .with_child(
                     Label::new("bottom right")
+                        .center()
                         .border(solid.clone(), 4.0)
                         .rounded(10.0)
                         .padding(10.0),

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -37,7 +37,7 @@ impl<T: Data> Button<T> {
         action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static,
     ) -> Button<T> {
         Button {
-            label: Label::new(text).text_align(UnitPoint::CENTER),
+            label: Label::new(text),
             action: Box::new(action),
         }
     }


### PR DESCRIPTION
This changes the behaviour of the Label widget to match the behaviour of flutter's Text widget,  which draws its contents in the top left corner.

It should still be possible to achieve other layouts by using an `Align` widget.

In addition, this changes how the button calculates its own bounds; previously it would just pass these down to the label; now it takes the label's layout size, adds some padding, and lays itself out in that.

This means that buttons now have a reasonable default size:

before:
<img width="149" alt="Screen Shot 2020-03-10 at 3 42 37 PM" src="https://user-images.githubusercontent.com/3330916/76352649-c75cc500-62e5-11ea-94bf-70fec56cf16f.png">
after:
<img width="182" alt="Screen Shot 2020-03-10 at 3 42 15 PM" src="https://user-images.githubusercontent.com/3330916/76352615-bb710300-62e5-11ea-9a8d-a2992a0a37c5.png">

