### PR TITLE
Add FlexChild type

### DIFF
--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -57,7 +57,7 @@ pub use container::Container;
 pub use controller::{Controller, ControllerHost};
 pub use either::Either;
 pub use env_scope::EnvScope;
-pub use flex::{CrossAxisAlignment, Flex, MainAxisAlignment};
+pub use flex::{CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
 pub use label::{Label, LabelText};
 pub use list::{List, ListIter};


### PR DESCRIPTION
This is the last major bit of work on flex? maybe? But it enables
an important property of flex  children, which is that they can
be either 'loose' or 'tight'; that is, they can be *allowed* or
*required* to use the space they are provided during layout.

This also includes a big overhaul of flex-related docs


my intention is that at some point I will change `add_child` to not take a flex factor, but this will break everyones code so I want to hold off til at least I have the rest of the API nailed down.

This also currently has a bizarre test failure, in a case that does not, as far as  I can see,  touch anything that I've done here. I'll go for a walk and talk a closer look. 

closes #607
