### PR TITLE
Add a color hierarchy

### DIFF
--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -57,7 +57,7 @@ fn ui_builder() -> impl Widget<AppData> {
     // text_size gets a custom key which we set with the env_scope wrapper.
     let styled_label =
         Label::new(|data: &AppData, _env: &_| format!("Size {:.1}: {}", data.size, data.text))
-            .text_color(theme::PRIMARY_LIGHT)
+            .text_color(theme::COLOR_PRIMARY_LIGHT)
             .text_size(MY_CUSTOM_TEXT_SIZE)
             .env_scope(|env: &mut druid::Env, data: &AppData| {
                 env.set(MY_CUSTOM_TEXT_SIZE, data.size)

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), PlatformError> {
 
 fn ui_builder() -> impl Widget<AppData> {
     // This is druid's default text style.
-    // It's set by theme::LABEL_COLOR and theme::TEXT_SIZE_NORMAL
+    // It's set by theme::COLOR_BASE_LIGHTEST and theme::TEXT_SIZE_NORMAL
     let label =
         Label::new(|data: &String, _env: &_| format!("Default: {}", data)).lens(AppData::text);
 

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -27,7 +27,7 @@ fn main() {
             env.set(theme::COLOR_BASE_DARKEST, Color::WHITE);
             env.set(theme::COLOR_BASE_LIGHTEST, Color::BLACK);
             env.set(theme::CURSOR_COLOR, Color::BLACK);
-            env.set(theme::BACKGROUND_LIGHT, Color::rgb8(230, 230, 230));
+            env.set(theme::COLOR_BASE_DARK, Color::rgb8(230, 230, 230));
         })
         .use_simple_logger()
         .launch("typing is fun!".to_string())
@@ -38,7 +38,7 @@ fn build_widget() -> impl Widget<String> {
     let textbox = TextBox::new();
     let textbox_2 = EnvScope::new(
         |env, _| {
-            env.set(theme::BACKGROUND_LIGHT, Color::rgb8(50, 50, 50));
+            env.set(theme::COLOR_BASE_DARK, Color::rgb8(50, 50, 50));
             env.set(theme::COLOR_BASE_LIGHTEST, Color::WHITE);
             env.set(theme::CURSOR_COLOR, Color::WHITE);
             env.set(theme::SELECTION_COLOR, Color::rgb8(100, 100, 100));

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -25,7 +25,7 @@ fn main() {
         .configure_env(|env, _| {
             env.set(theme::SELECTION_COLOR, Color::rgb8(0xA6, 0xCC, 0xFF));
             env.set(theme::COLOR_BASE_DARKEST, Color::WHITE);
-            env.set(theme::LABEL_COLOR, Color::BLACK);
+            env.set(theme::COLOR_BASE_LIGHTEST, Color::BLACK);
             env.set(theme::CURSOR_COLOR, Color::BLACK);
             env.set(theme::BACKGROUND_LIGHT, Color::rgb8(230, 230, 230));
         })
@@ -39,7 +39,7 @@ fn build_widget() -> impl Widget<String> {
     let textbox_2 = EnvScope::new(
         |env, _| {
             env.set(theme::BACKGROUND_LIGHT, Color::rgb8(50, 50, 50));
-            env.set(theme::LABEL_COLOR, Color::WHITE);
+            env.set(theme::COLOR_BASE_LIGHTEST, Color::WHITE);
             env.set(theme::CURSOR_COLOR, Color::WHITE);
             env.set(theme::SELECTION_COLOR, Color::rgb8(100, 100, 100));
         },

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -24,7 +24,7 @@ fn main() {
     AppLauncher::with_window(window)
         .configure_env(|env, _| {
             env.set(theme::SELECTION_COLOR, Color::rgb8(0xA6, 0xCC, 0xFF));
-            env.set(theme::WINDOW_BACKGROUND_COLOR, Color::WHITE);
+            env.set(theme::COLOR_BASE_DARKEST, Color::WHITE);
             env.set(theme::LABEL_COLOR, Color::BLACK);
             env.set(theme::CURSOR_COLOR, Color::BLACK);
             env.set(theme::BACKGROUND_LIGHT, Color::rgb8(230, 230, 230));

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -23,7 +23,7 @@ fn main() {
     );
     AppLauncher::with_window(window)
         .configure_env(|env, _| {
-            env.set(theme::SELECTION_COLOR, Color::rgb8(0xA6, 0xCC, 0xFF));
+            env.set(theme::COLOR_SECONDARY, Color::rgb8(0xA6, 0xCC, 0xFF));
             env.set(theme::COLOR_BASE_DARKEST, Color::WHITE);
             env.set(theme::COLOR_BASE_LIGHTEST, Color::BLACK);
             env.set(theme::CURSOR_COLOR, Color::BLACK);
@@ -41,7 +41,7 @@ fn build_widget() -> impl Widget<String> {
             env.set(theme::COLOR_BASE_DARK, Color::rgb8(50, 50, 50));
             env.set(theme::COLOR_BASE_LIGHTEST, Color::WHITE);
             env.set(theme::CURSOR_COLOR, Color::WHITE);
-            env.set(theme::SELECTION_COLOR, Color::rgb8(100, 100, 100));
+            env.set(theme::COLOR_SECONDARY, Color::rgb8(100, 100, 100));
         },
         TextBox::new().with_placeholder("placeholder"),
     );

--- a/druid/examples/textbox.rs
+++ b/druid/examples/textbox.rs
@@ -26,7 +26,7 @@ fn main() {
             env.set(theme::COLOR_SECONDARY, Color::rgb8(0xA6, 0xCC, 0xFF));
             env.set(theme::COLOR_BASE_DARKEST, Color::WHITE);
             env.set(theme::COLOR_BASE_LIGHTEST, Color::BLACK);
-            env.set(theme::CURSOR_COLOR, Color::BLACK);
+            env.set(theme::COLOR_INK_INVERTED, Color::BLACK);
             env.set(theme::COLOR_BASE_DARK, Color::rgb8(230, 230, 230));
         })
         .use_simple_logger()
@@ -40,7 +40,7 @@ fn build_widget() -> impl Widget<String> {
         |env, _| {
             env.set(theme::COLOR_BASE_DARK, Color::rgb8(50, 50, 50));
             env.set(theme::COLOR_BASE_LIGHTEST, Color::WHITE);
-            env.set(theme::CURSOR_COLOR, Color::WHITE);
+            env.set(theme::COLOR_INK_INVERTED, Color::WHITE);
             env.set(theme::COLOR_SECONDARY, Color::rgb8(100, 100, 100));
         },
         TextBox::new().with_placeholder("placeholder"),

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -29,8 +29,6 @@ pub const COLOR_BASE_DARK: Key<Color> = Key::new("color_base_dark");
 pub const COLOR_BASE_DARKER: Key<Color> = Key::new("color_base_darker");
 pub const COLOR_BASE_DARKEST: Key<Color> = Key::new("color_base_darkest");
 
-pub const WINDOW_BACKGROUND_COLOR: Key<Color> = Key::new("window_background_color");
-
 pub const LABEL_COLOR: Key<Color> = Key::new("label_color");
 pub const PLACEHOLDER_COLOR: Key<Color> = Key::new("placeholder_color");
 
@@ -79,8 +77,7 @@ pub fn init() -> Env {
         .adding(COLOR_BASE, Color::rgb8(0x77, 0x77, 0x77))
         .adding(COLOR_BASE_DARK, Color::rgb8(0x56, 0x56, 0x56))
         .adding(COLOR_BASE_DARKER, Color::rgb8(0x3d, 0x3d, 0x3d))
-        .adding(COLOR_BASE_DARKER, Color::rgb8(0x21, 0x21, 0x21))
-        .adding(WINDOW_BACKGROUND_COLOR, Color::rgb8(0x29, 0x29, 0x29))
+        .adding(COLOR_BASE_DARKEST, Color::rgb8(0x29, 0x29, 0x29))
         .adding(LABEL_COLOR, Color::rgb8(0xf0, 0xf0, 0xea))
         .adding(PLACEHOLDER_COLOR, Color::rgb8(0x80, 0x80, 0x80))
         .adding(PROGRESS_BAR_RADIUS, 4.)

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -18,13 +18,14 @@ use crate::piet::Color;
 
 use crate::{Env, Key};
 
+pub const COLOR_PRIMARY_LIGHT: Key<Color> = Key::new("color_primary_light");
+pub const COLOR_PRIMARY: Key<Color> = Key::new("color_primary");
+
 pub const WINDOW_BACKGROUND_COLOR: Key<Color> = Key::new("window_background_color");
 
 pub const LABEL_COLOR: Key<Color> = Key::new("label_color");
 pub const PLACEHOLDER_COLOR: Key<Color> = Key::new("placeholder_color");
 
-pub const PRIMARY_LIGHT: Key<Color> = Key::new("primary_light");
-pub const PRIMARY_DARK: Key<Color> = Key::new("primary_dark");
 pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
 pub const BACKGROUND_LIGHT: Key<Color> = Key::new("background_light");
 pub const BACKGROUND_DARK: Key<Color> = Key::new("background_dark");
@@ -62,11 +63,11 @@ pub const SCROLL_BAR_EDGE_WIDTH: Key<f64> = Key::new("scroll_bar_edge_width");
 /// An initial theme.
 pub fn init() -> Env {
     let mut env = Env::default()
+        .adding(COLOR_PRIMARY_LIGHT, Color::rgb8(0x5c, 0xc4, 0xff))
+        .adding(COLOR_PRIMARY, Color::rgb8(0x00, 0x8d, 0xdd))
         .adding(WINDOW_BACKGROUND_COLOR, Color::rgb8(0x29, 0x29, 0x29))
         .adding(LABEL_COLOR, Color::rgb8(0xf0, 0xf0, 0xea))
         .adding(PLACEHOLDER_COLOR, Color::rgb8(0x80, 0x80, 0x80))
-        .adding(PRIMARY_LIGHT, Color::rgb8(0x5c, 0xc4, 0xff))
-        .adding(PRIMARY_DARK, Color::rgb8(0x00, 0x8d, 0xdd))
         .adding(PROGRESS_BAR_RADIUS, 4.)
         .adding(BACKGROUND_LIGHT, Color::rgb8(0x3a, 0x3a, 0x3a))
         .adding(BACKGROUND_DARK, Color::rgb8(0x31, 0x31, 0x31))

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -30,8 +30,6 @@ pub const COLOR_BASE_DARKER: Key<Color> = Key::new("color_base_darker");
 pub const COLOR_BASE_DARKEST: Key<Color> = Key::new("color_base_darkest");
 
 pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
-pub const BACKGROUND_LIGHT: Key<Color> = Key::new("background_light");
-pub const BACKGROUND_DARK: Key<Color> = Key::new("background_dark");
 pub const FOREGROUND_LIGHT: Key<Color> = Key::new("foreground_light");
 pub const FOREGROUND_DARK: Key<Color> = Key::new("foreground_dark");
 pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
@@ -76,8 +74,6 @@ pub fn init() -> Env {
         .adding(COLOR_BASE_DARKER, Color::rgb8(0x3d, 0x3d, 0x3d))
         .adding(COLOR_BASE_DARKEST, Color::rgb8(0x29, 0x29, 0x29))
         .adding(PROGRESS_BAR_RADIUS, 4.)
-        .adding(BACKGROUND_LIGHT, Color::rgb8(0x3a, 0x3a, 0x3a))
-        .adding(BACKGROUND_DARK, Color::rgb8(0x31, 0x31, 0x31))
         .adding(FOREGROUND_LIGHT, Color::rgb8(0xf9, 0xf9, 0xf9))
         .adding(FOREGROUND_DARK, Color::rgb8(0xbf, 0xbf, 0xbf))
         .adding(BUTTON_DARK, Color::BLACK)

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -35,8 +35,6 @@ pub const COLOR_INK: Key<Color> = Key::new("color_ink");
 pub const COLOR_INK_INVERTED: Key<Color> = Key::new("color_ink_inverted");
 
 pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
-pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
-pub const BUTTON_LIGHT: Key<Color> = Key::new("button_light");
 pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("button_radius");
 pub const BUTTON_BORDER_WIDTH: Key<f64> = Key::new("button_border_width");
 
@@ -74,8 +72,6 @@ pub fn init() -> Env {
         .adding(COLOR_INK, Color::rgb8(0x00, 0x00, 0x00))
         .adding(COLOR_INK_INVERTED, Color::rgb8(0xff, 0xff, 0xff))
         .adding(PROGRESS_BAR_RADIUS, 4.)
-        .adding(BUTTON_DARK, Color::BLACK)
-        .adding(BUTTON_LIGHT, Color::rgb8(0x21, 0x21, 0x21))
         .adding(BUTTON_BORDER_RADIUS, 4.)
         .adding(BUTTON_BORDER_WIDTH, 2.)
         .adding(TEXT_SIZE_NORMAL, 15.0)

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -21,6 +21,14 @@ use crate::{Env, Key};
 pub const COLOR_PRIMARY_LIGHT: Key<Color> = Key::new("color_primary_light");
 pub const COLOR_PRIMARY: Key<Color> = Key::new("color_primary");
 
+pub const COLOR_BASE_LIGHTEST: Key<Color> = Key::new("color_base_lightest");
+pub const COLOR_BASE_LIGHTER: Key<Color> = Key::new("color_base_lighter");
+pub const COLOR_BASE_LIGHT: Key<Color> = Key::new("color_base_light");
+pub const COLOR_BASE: Key<Color> = Key::new("color_base");
+pub const COLOR_BASE_DARK: Key<Color> = Key::new("color_base_dark");
+pub const COLOR_BASE_DARKER: Key<Color> = Key::new("color_base_darker");
+pub const COLOR_BASE_DARKEST: Key<Color> = Key::new("color_base_darkest");
+
 pub const WINDOW_BACKGROUND_COLOR: Key<Color> = Key::new("window_background_color");
 
 pub const LABEL_COLOR: Key<Color> = Key::new("label_color");
@@ -65,6 +73,13 @@ pub fn init() -> Env {
     let mut env = Env::default()
         .adding(COLOR_PRIMARY_LIGHT, Color::rgb8(0x5c, 0xc4, 0xff))
         .adding(COLOR_PRIMARY, Color::rgb8(0x00, 0x8d, 0xdd))
+        .adding(COLOR_BASE_LIGHTEST, Color::rgb8(0xe0, 0xe0, 0xe0))
+        .adding(COLOR_BASE_LIGHTER, Color::rgb8(0xcf, 0xcf, 0xcf))
+        .adding(COLOR_BASE_LIGHT, Color::rgb8(0xa9, 0xa9, 0xa9))
+        .adding(COLOR_BASE, Color::rgb8(0x77, 0x77, 0x77))
+        .adding(COLOR_BASE_DARK, Color::rgb8(0x56, 0x56, 0x56))
+        .adding(COLOR_BASE_DARKER, Color::rgb8(0x3d, 0x3d, 0x3d))
+        .adding(COLOR_BASE_DARKER, Color::rgb8(0x21, 0x21, 0x21))
         .adding(WINDOW_BACKGROUND_COLOR, Color::rgb8(0x29, 0x29, 0x29))
         .adding(LABEL_COLOR, Color::rgb8(0xf0, 0xf0, 0xea))
         .adding(PLACEHOLDER_COLOR, Color::rgb8(0x80, 0x80, 0x80))

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -34,8 +34,6 @@ pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
 pub const BUTTON_LIGHT: Key<Color> = Key::new("button_light");
 pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("button_radius");
 pub const BUTTON_BORDER_WIDTH: Key<f64> = Key::new("button_border_width");
-pub const BORDER_DARK: Key<Color> = Key::new("border");
-pub const BORDER_LIGHT: Key<Color> = Key::new("border_light");
 pub const SELECTION_COLOR: Key<Color> = Key::new("selection_color");
 pub const CURSOR_COLOR: Key<Color> = Key::new("cursor_color");
 
@@ -76,8 +74,6 @@ pub fn init() -> Env {
         .adding(BUTTON_LIGHT, Color::rgb8(0x21, 0x21, 0x21))
         .adding(BUTTON_BORDER_RADIUS, 4.)
         .adding(BUTTON_BORDER_WIDTH, 2.)
-        .adding(BORDER_DARK, Color::rgb8(0x3a, 0x3a, 0x3a))
-        .adding(BORDER_LIGHT, Color::rgb8(0xa1, 0xa1, 0xa1))
         .adding(SELECTION_COLOR, Color::rgb8(0xf3, 0x00, 0x21))
         .adding(CURSOR_COLOR, Color::WHITE)
         .adding(TEXT_SIZE_NORMAL, 15.0)

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -39,7 +39,6 @@ pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
 pub const BUTTON_LIGHT: Key<Color> = Key::new("button_light");
 pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("button_radius");
 pub const BUTTON_BORDER_WIDTH: Key<f64> = Key::new("button_border_width");
-pub const CURSOR_COLOR: Key<Color> = Key::new("cursor_color");
 
 pub const FONT_NAME: Key<&str> = Key::new("font_name");
 pub const TEXT_SIZE_NORMAL: Key<f64> = Key::new("text_size_normal");
@@ -79,7 +78,6 @@ pub fn init() -> Env {
         .adding(BUTTON_LIGHT, Color::rgb8(0x21, 0x21, 0x21))
         .adding(BUTTON_BORDER_RADIUS, 4.)
         .adding(BUTTON_BORDER_WIDTH, 2.)
-        .adding(CURSOR_COLOR, Color::WHITE)
         .adding(TEXT_SIZE_NORMAL, 15.0)
         .adding(TEXT_SIZE_LARGE, 24.0)
         .adding(BASIC_WIDGET_HEIGHT, 18.0)

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -30,8 +30,6 @@ pub const COLOR_BASE_DARKER: Key<Color> = Key::new("color_base_darker");
 pub const COLOR_BASE_DARKEST: Key<Color> = Key::new("color_base_darkest");
 
 pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
-pub const FOREGROUND_LIGHT: Key<Color> = Key::new("foreground_light");
-pub const FOREGROUND_DARK: Key<Color> = Key::new("foreground_dark");
 pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
 pub const BUTTON_LIGHT: Key<Color> = Key::new("button_light");
 pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("button_radius");
@@ -74,8 +72,6 @@ pub fn init() -> Env {
         .adding(COLOR_BASE_DARKER, Color::rgb8(0x3d, 0x3d, 0x3d))
         .adding(COLOR_BASE_DARKEST, Color::rgb8(0x29, 0x29, 0x29))
         .adding(PROGRESS_BAR_RADIUS, 4.)
-        .adding(FOREGROUND_LIGHT, Color::rgb8(0xf9, 0xf9, 0xf9))
-        .adding(FOREGROUND_DARK, Color::rgb8(0xbf, 0xbf, 0xbf))
         .adding(BUTTON_DARK, Color::BLACK)
         .adding(BUTTON_LIGHT, Color::rgb8(0x21, 0x21, 0x21))
         .adding(BUTTON_BORDER_RADIUS, 4.)

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -31,6 +31,9 @@ pub const COLOR_BASE_DARK: Key<Color> = Key::new("color_base_dark");
 pub const COLOR_BASE_DARKER: Key<Color> = Key::new("color_base_darker");
 pub const COLOR_BASE_DARKEST: Key<Color> = Key::new("color_base_darkest");
 
+pub const COLOR_INK: Key<Color> = Key::new("color_ink");
+pub const COLOR_INK_INVERTED: Key<Color> = Key::new("color_ink_inverted");
+
 pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
 pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
 pub const BUTTON_LIGHT: Key<Color> = Key::new("button_light");
@@ -49,8 +52,6 @@ pub const BORDERED_WIDGET_HEIGHT: Key<f64> = Key::new("bordered_widget_height");
 
 pub const TEXTBOX_BORDER_RADIUS: Key<f64> = Key::new("textbox_radius");
 
-pub const SCROLL_BAR_COLOR: Key<Color> = Key::new("scroll_bar_color");
-pub const SCROLL_BAR_BORDER_COLOR: Key<Color> = Key::new("scroll_bar_border_color");
 pub const SCROLL_BAR_MAX_OPACITY: Key<f64> = Key::new("scroll_bar_max_opacity");
 pub const SCROLL_BAR_FADE_DELAY: Key<u64> = Key::new("scroll_bar_fade_time");
 pub const SCROLL_BAR_WIDTH: Key<f64> = Key::new("scroll_bar_width");
@@ -71,6 +72,8 @@ pub fn init() -> Env {
         .adding(COLOR_BASE_DARK, Color::rgb8(0x56, 0x56, 0x56))
         .adding(COLOR_BASE_DARKER, Color::rgb8(0x3d, 0x3d, 0x3d))
         .adding(COLOR_BASE_DARKEST, Color::rgb8(0x29, 0x29, 0x29))
+        .adding(COLOR_INK, Color::rgb8(0x00, 0x00, 0x00))
+        .adding(COLOR_INK_INVERTED, Color::rgb8(0xff, 0xff, 0xff))
         .adding(PROGRESS_BAR_RADIUS, 4.)
         .adding(BUTTON_DARK, Color::BLACK)
         .adding(BUTTON_LIGHT, Color::rgb8(0x21, 0x21, 0x21))
@@ -83,8 +86,6 @@ pub fn init() -> Env {
         .adding(WIDE_WIDGET_WIDTH, 100.)
         .adding(BORDERED_WIDGET_HEIGHT, 24.0)
         .adding(TEXTBOX_BORDER_RADIUS, 2.)
-        .adding(SCROLL_BAR_COLOR, Color::rgb8(0xff, 0xff, 0xff))
-        .adding(SCROLL_BAR_BORDER_COLOR, Color::rgb8(0x77, 0x77, 0x77))
         .adding(SCROLL_BAR_MAX_OPACITY, 0.7)
         .adding(SCROLL_BAR_FADE_DELAY, 1500u64)
         .adding(SCROLL_BAR_WIDTH, 8.)

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -29,8 +29,6 @@ pub const COLOR_BASE_DARK: Key<Color> = Key::new("color_base_dark");
 pub const COLOR_BASE_DARKER: Key<Color> = Key::new("color_base_darker");
 pub const COLOR_BASE_DARKEST: Key<Color> = Key::new("color_base_darkest");
 
-pub const PLACEHOLDER_COLOR: Key<Color> = Key::new("placeholder_color");
-
 pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
 pub const BACKGROUND_LIGHT: Key<Color> = Key::new("background_light");
 pub const BACKGROUND_DARK: Key<Color> = Key::new("background_dark");
@@ -77,7 +75,6 @@ pub fn init() -> Env {
         .adding(COLOR_BASE_DARK, Color::rgb8(0x56, 0x56, 0x56))
         .adding(COLOR_BASE_DARKER, Color::rgb8(0x3d, 0x3d, 0x3d))
         .adding(COLOR_BASE_DARKEST, Color::rgb8(0x29, 0x29, 0x29))
-        .adding(PLACEHOLDER_COLOR, Color::rgb8(0x80, 0x80, 0x80))
         .adding(PROGRESS_BAR_RADIUS, 4.)
         .adding(BACKGROUND_LIGHT, Color::rgb8(0x3a, 0x3a, 0x3a))
         .adding(BACKGROUND_DARK, Color::rgb8(0x31, 0x31, 0x31))

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -29,7 +29,6 @@ pub const COLOR_BASE_DARK: Key<Color> = Key::new("color_base_dark");
 pub const COLOR_BASE_DARKER: Key<Color> = Key::new("color_base_darker");
 pub const COLOR_BASE_DARKEST: Key<Color> = Key::new("color_base_darkest");
 
-pub const LABEL_COLOR: Key<Color> = Key::new("label_color");
 pub const PLACEHOLDER_COLOR: Key<Color> = Key::new("placeholder_color");
 
 pub const PROGRESS_BAR_RADIUS: Key<f64> = Key::new("progress_bar_radius");
@@ -78,7 +77,6 @@ pub fn init() -> Env {
         .adding(COLOR_BASE_DARK, Color::rgb8(0x56, 0x56, 0x56))
         .adding(COLOR_BASE_DARKER, Color::rgb8(0x3d, 0x3d, 0x3d))
         .adding(COLOR_BASE_DARKEST, Color::rgb8(0x29, 0x29, 0x29))
-        .adding(LABEL_COLOR, Color::rgb8(0xf0, 0xf0, 0xea))
         .adding(PLACEHOLDER_COLOR, Color::rgb8(0x80, 0x80, 0x80))
         .adding(PROGRESS_BAR_RADIUS, 4.)
         .adding(BACKGROUND_LIGHT, Color::rgb8(0x3a, 0x3a, 0x3a))

--- a/druid/src/theme.rs
+++ b/druid/src/theme.rs
@@ -21,6 +21,8 @@ use crate::{Env, Key};
 pub const COLOR_PRIMARY_LIGHT: Key<Color> = Key::new("color_primary_light");
 pub const COLOR_PRIMARY: Key<Color> = Key::new("color_primary");
 
+pub const COLOR_SECONDARY: Key<Color> = Key::new("color_secondary");
+
 pub const COLOR_BASE_LIGHTEST: Key<Color> = Key::new("color_base_lightest");
 pub const COLOR_BASE_LIGHTER: Key<Color> = Key::new("color_base_lighter");
 pub const COLOR_BASE_LIGHT: Key<Color> = Key::new("color_base_light");
@@ -34,7 +36,6 @@ pub const BUTTON_DARK: Key<Color> = Key::new("button_dark");
 pub const BUTTON_LIGHT: Key<Color> = Key::new("button_light");
 pub const BUTTON_BORDER_RADIUS: Key<f64> = Key::new("button_radius");
 pub const BUTTON_BORDER_WIDTH: Key<f64> = Key::new("button_border_width");
-pub const SELECTION_COLOR: Key<Color> = Key::new("selection_color");
 pub const CURSOR_COLOR: Key<Color> = Key::new("cursor_color");
 
 pub const FONT_NAME: Key<&str> = Key::new("font_name");
@@ -62,6 +63,7 @@ pub fn init() -> Env {
     let mut env = Env::default()
         .adding(COLOR_PRIMARY_LIGHT, Color::rgb8(0x5c, 0xc4, 0xff))
         .adding(COLOR_PRIMARY, Color::rgb8(0x00, 0x8d, 0xdd))
+        .adding(COLOR_SECONDARY, Color::rgb8(0xf3, 0x00, 0x21))
         .adding(COLOR_BASE_LIGHTEST, Color::rgb8(0xe0, 0xe0, 0xe0))
         .adding(COLOR_BASE_LIGHTER, Color::rgb8(0xcf, 0xcf, 0xcf))
         .adding(COLOR_BASE_LIGHT, Color::rgb8(0xa9, 0xa9, 0xa9))
@@ -74,7 +76,6 @@ pub fn init() -> Env {
         .adding(BUTTON_LIGHT, Color::rgb8(0x21, 0x21, 0x21))
         .adding(BUTTON_BORDER_RADIUS, 4.)
         .adding(BUTTON_BORDER_WIDTH, 2.)
-        .adding(SELECTION_COLOR, Color::rgb8(0xf3, 0x00, 0x21))
         .adding(CURSOR_COLOR, Color::WHITE)
         .adding(TEXT_SIZE_NORMAL, 15.0)
         .adding(TEXT_SIZE_LARGE, 24.0)

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -124,13 +124,13 @@ impl<T: Data> Widget<T> for Button<T> {
             LinearGradient::new(
                 UnitPoint::TOP,
                 UnitPoint::BOTTOM,
-                (env.get(theme::BUTTON_LIGHT), env.get(theme::BUTTON_DARK)),
+                (env.get(theme::COLOR_BASE_DARKEST), env.get(theme::COLOR_INK)),
             )
         } else {
             LinearGradient::new(
                 UnitPoint::TOP,
                 UnitPoint::BOTTOM,
-                (env.get(theme::BUTTON_DARK), env.get(theme::BUTTON_LIGHT)),
+                (env.get(theme::COLOR_INK), env.get(theme::COLOR_BASE_DARKEST)),
             )
         };
 

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -135,9 +135,9 @@ impl<T: Data> Widget<T> for Button<T> {
         };
 
         let border_color = if is_hot {
-            env.get(theme::BORDER_LIGHT)
+            env.get(theme::COLOR_BASE_LIGHT)
         } else {
-            env.get(theme::BORDER_DARK)
+            env.get(theme::COLOR_BASE_DARKER)
         };
 
         paint_ctx.stroke(

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -118,7 +118,7 @@ impl Widget<bool> for Checkbox {
             style.set_line_cap(LineCap::Round);
             style.set_line_join(LineJoin::Round);
 
-            paint_ctx.stroke_styled(path, &env.get(theme::LABEL_COLOR), 2., &style);
+            paint_ctx.stroke_styled(path, &env.get(theme::COLOR_BASE_LIGHTEST), 2., &style);
         }
     }
 }

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -93,8 +93,8 @@ impl Widget<bool> for Checkbox {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::BACKGROUND_LIGHT),
-                env.get(theme::BACKGROUND_DARK),
+                env.get(theme::COLOR_BASE_DARK),
+                env.get(theme::COLOR_BASE_DARKER),
             ),
         );
 

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -101,9 +101,9 @@ impl Widget<bool> for Checkbox {
         paint_ctx.fill(rect, &background_gradient);
 
         let border_color = if paint_ctx.is_hot() {
-            env.get(theme::BORDER_LIGHT)
+            env.get(theme::COLOR_BASE_LIGHT)
         } else {
-            env.get(theme::BORDER_DARK)
+            env.get(theme::COLOR_BASE_DARKER)
         };
 
         paint_ctx.stroke(rect, &border_color, 1.);

--- a/druid/src/widget/env_scope.rs
+++ b/druid/src/widget/env_scope.rs
@@ -41,7 +41,7 @@ impl<T, W> EnvScope<T, W> {
     ///
     /// EnvScope::new(
     ///     |env, data| {
-    ///         env.set(theme::LABEL_COLOR, Color::WHITE);
+    ///         env.set(theme::COLOR_BASE_LIGHTEST, Color::WHITE);
     ///     },
     ///     Label::new("White text!")
     /// )

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -76,7 +76,7 @@ impl<T: Data> Label<T> {
         let text = text.into();
         Self {
             text,
-            color: theme::LABEL_COLOR.into(),
+            color: theme::COLOR_BASE_LIGHTEST.into(),
             size: theme::TEXT_SIZE_NORMAL.into(),
         }
     }

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -78,8 +78,8 @@ impl Widget<f64> for ProgressBar {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::BACKGROUND_LIGHT),
-                env.get(theme::BACKGROUND_DARK),
+                env.get(theme::COLOR_BASE_DARK),
+                env.get(theme::COLOR_BASE_DARKER),
             ),
         );
         paint_ctx.fill(rounded_rect, &background_gradient);

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -98,7 +98,7 @@ impl Widget<f64> for ProgressBar {
         let bar_gradient = LinearGradient::new(
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
-            (env.get(theme::PRIMARY_LIGHT), env.get(theme::PRIMARY_DARK)),
+            (env.get(theme::COLOR_PRIMARY_LIGHT), env.get(theme::COLOR_PRIMARY)),
         );
         paint_ctx.fill(rounded_rect, &bar_gradient);
     }

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -71,7 +71,7 @@ impl Widget<f64> for ProgressBar {
         );
 
         //Paint the border
-        paint_ctx.stroke(rounded_rect, &env.get(theme::BORDER_DARK), 2.0);
+        paint_ctx.stroke(rounded_rect, &env.get(theme::COLOR_BASE_DARKER), 2.0);
 
         //Paint the background
         let background_gradient = LinearGradient::new(

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -127,9 +127,9 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         paint_ctx.fill(circle, &background_gradient);
 
         let border_color = if paint_ctx.is_hot() {
-            env.get(theme::BORDER_LIGHT)
+            env.get(theme::COLOR_BASE_LIGHT)
         } else {
-            env.get(theme::BORDER_DARK)
+            env.get(theme::COLOR_BASE_DARKER)
         };
 
         paint_ctx.stroke(circle, &border_color, 1.);

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -119,8 +119,8 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::BACKGROUND_LIGHT),
-                env.get(theme::BACKGROUND_DARK),
+                env.get(theme::COLOR_BASE_DARK),
+                env.get(theme::COLOR_BASE_DARKER),
             ),
         );
 

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -138,7 +138,7 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         if *data == self.variant {
             let inner_circle = Circle::new((size / 2., size / 2.), 2.);
 
-            paint_ctx.fill(inner_circle, &env.get(theme::LABEL_COLOR));
+            paint_ctx.fill(inner_circle, &env.get(theme::COLOR_BASE_LIGHTEST));
         }
 
         // Paint the text label

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -225,11 +225,11 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         }
 
         let brush = paint_ctx.render_ctx.solid_brush(
-            env.get(theme::SCROLL_BAR_COLOR)
+            env.get(theme::COLOR_INK_INVERTED)
                 .with_alpha(self.scroll_bars.opacity),
         );
         let border_brush = paint_ctx.render_ctx.solid_brush(
-            env.get(theme::SCROLL_BAR_BORDER_COLOR)
+            env.get(theme::COLOR_BASE)
                 .with_alpha(self.scroll_bars.opacity),
         );
 

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -128,8 +128,8 @@ impl Widget<f64> for Slider {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::BACKGROUND_LIGHT),
-                env.get(theme::BACKGROUND_DARK),
+                env.get(theme::COLOR_BASE_DARK),
+                env.get(theme::COLOR_BASE_DARKER),
             ),
         );
 

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -149,16 +149,16 @@ impl Widget<f64> for Slider {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::FOREGROUND_LIGHT),
-                env.get(theme::FOREGROUND_DARK),
+                env.get(theme::COLOR_BASE_LIGHTEST),
+                env.get(theme::COLOR_BASE_LIGHT),
             ),
         );
         let flipped_knob_gradient = LinearGradient::new(
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::FOREGROUND_DARK),
-                env.get(theme::FOREGROUND_LIGHT),
+                env.get(theme::COLOR_BASE_LIGHT),
+                env.get(theme::COLOR_BASE_LIGHTEST),
             ),
         );
 
@@ -170,9 +170,9 @@ impl Widget<f64> for Slider {
 
         //Paint the border
         let border_color = if is_hovered || is_active {
-            env.get(theme::FOREGROUND_LIGHT)
+            env.get(theme::COLOR_BASE_LIGHTEST)
         } else {
-            env.get(theme::FOREGROUND_DARK)
+            env.get(theme::COLOR_BASE_LIGHT)
         };
 
         paint_ctx.stroke(knob_circle, &border_color, 2.);

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -133,7 +133,7 @@ impl Widget<f64> for Slider {
             ),
         );
 
-        paint_ctx.stroke(background_rect, &env.get(theme::BORDER_DARK), 2.0);
+        paint_ctx.stroke(background_rect, &env.get(theme::COLOR_BASE_DARKER), 2.0);
 
         paint_ctx.fill(background_rect, &background_gradient);
 

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -344,9 +344,9 @@ impl<T: Data> Widget<T> for Split<T> {
             }
         };
         let line_color = if self.draggable {
-            env.get(theme::BORDER_LIGHT)
+            env.get(theme::COLOR_BASE_LIGHT)
         } else {
-            env.get(theme::BORDER_DARK)
+            env.get(theme::COLOR_BASE_DARKER)
         };
         paint_ctx.stroke(line1, &line_color, 1.0);
         paint_ctx.stroke(line2, &line_color, 1.0);

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -118,7 +118,7 @@ impl Widget<f64> for Stepper {
         let width = env.get(theme::BASIC_WIDGET_HEIGHT);
         let button_size = Size::new(width, height / 2.);
 
-        paint_ctx.stroke(rounded_rect, &env.get(theme::BORDER_DARK), 2.0);
+        paint_ctx.stroke(rounded_rect, &env.get(theme::COLOR_BASE_DARKER), 2.0);
         paint_ctx.clip(rounded_rect);
 
         // draw buttons for increase/decrease

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -166,7 +166,7 @@ impl Widget<f64> for Stepper {
         arrows.line_to(Point::new(width / 2., height - 4.));
         arrows.close_path();
 
-        paint_ctx.fill(arrows, &env.get(theme::LABEL_COLOR));
+        paint_ctx.fill(arrows, &env.get(theme::COLOR_BASE_LIGHTEST));
     }
 
     fn layout(

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -138,7 +138,7 @@ impl Widget<f64> for Stepper {
         let inactive_gradient = LinearGradient::new(
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
-            (env.get(theme::BUTTON_DARK), env.get(theme::BUTTON_LIGHT)),
+            (env.get(theme::COLOR_INK), env.get(theme::COLOR_BASE_DARKEST)),
         );
 
         // draw buttons that are currently triggered as active

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -132,7 +132,7 @@ impl Widget<f64> for Stepper {
         let active_gradient = LinearGradient::new(
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
-            (env.get(theme::PRIMARY_LIGHT), env.get(theme::PRIMARY_DARK)),
+            (env.get(theme::COLOR_PRIMARY_LIGHT), env.get(theme::COLOR_PRIMARY)),
         );
 
         let inactive_gradient = LinearGradient::new(

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -229,8 +229,8 @@ impl Widget<bool> for Switch {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::PRIMARY_LIGHT).with_alpha(opacity),
-                env.get(theme::PRIMARY_DARK).with_alpha(opacity),
+                env.get(theme::COLOR_PRIMARY_LIGHT).with_alpha(opacity),
+                env.get(theme::COLOR_PRIMARY).with_alpha(opacity),
             ),
         );
         let background_gradient_off_state = LinearGradient::new(

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -255,16 +255,16 @@ impl Widget<bool> for Switch {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::FOREGROUND_LIGHT),
-                env.get(theme::FOREGROUND_DARK),
+                env.get(theme::COLOR_BASE_LIGHTEST),
+                env.get(theme::COLOR_BASE_LIGHT),
             ),
         );
         let flipped_knob_gradient = LinearGradient::new(
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::FOREGROUND_DARK),
-                env.get(theme::FOREGROUND_LIGHT),
+                env.get(theme::COLOR_BASE_LIGHT),
+                env.get(theme::COLOR_BASE_LIGHTEST),
             ),
         );
 
@@ -276,9 +276,9 @@ impl Widget<bool> for Switch {
 
         // paint the border
         let border_color = if is_hovered || is_active {
-            env.get(theme::FOREGROUND_LIGHT)
+            env.get(theme::COLOR_BASE_LIGHTEST)
         } else {
-            env.get(theme::FOREGROUND_DARK)
+            env.get(theme::COLOR_BASE_LIGHT)
         };
 
         paint_ctx.stroke(knob_circle, &border_color, 2.);

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -103,12 +103,12 @@ impl Switch {
         paint_ctx.draw_text(
             &on_label_layout,
             on_label_origin,
-            &env.get(theme::LABEL_COLOR),
+            &env.get(theme::COLOR_BASE_LIGHTEST),
         );
         paint_ctx.draw_text(
             &off_label_layout,
             off_label_origin,
-            &env.get(theme::LABEL_COLOR),
+            &env.get(theme::COLOR_BASE_LIGHTEST),
         );
     }
 }

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -237,8 +237,8 @@ impl Widget<bool> for Switch {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
             (
-                env.get(theme::BACKGROUND_LIGHT).with_alpha(1. - opacity),
-                env.get(theme::BACKGROUND_DARK).with_alpha(1. - opacity),
+                env.get(theme::COLOR_BASE_DARK).with_alpha(1. - opacity),
+                env.get(theme::COLOR_BASE_DARKER).with_alpha(1. - opacity),
             ),
         );
 

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -242,7 +242,7 @@ impl Widget<bool> for Switch {
             ),
         );
 
-        paint_ctx.stroke(background_rect, &env.get(theme::BORDER_DARK), 2.0);
+        paint_ctx.stroke(background_rect, &env.get(theme::COLOR_BASE_DARKER), 2.0);
         paint_ctx.fill(background_rect, &background_gradient_on_state);
         paint_ctx.fill(background_rect, &background_gradient_off_state);
         paint_ctx.clip(background_rect);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -373,7 +373,7 @@ impl Widget<String> for TextBox {
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
         let background_color = env.get(theme::COLOR_BASE_DARK);
-        let selection_color = env.get(theme::SELECTION_COLOR);
+        let selection_color = env.get(theme::COLOR_SECONDARY);
         let text_color = env.get(theme::COLOR_BASE_LIGHTEST);
         let placeholder_color = env.get(theme::COLOR_BASE);
         let cursor_color = env.get(theme::CURSOR_COLOR);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -376,7 +376,7 @@ impl Widget<String> for TextBox {
         let selection_color = env.get(theme::COLOR_SECONDARY);
         let text_color = env.get(theme::COLOR_BASE_LIGHTEST);
         let placeholder_color = env.get(theme::COLOR_BASE);
-        let cursor_color = env.get(theme::CURSOR_COLOR);
+        let cursor_color = env.get(theme::COLOR_INK_INVERTED);
 
         let has_focus = paint_ctx.has_focus();
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -381,7 +381,7 @@ impl Widget<String> for TextBox {
         let has_focus = paint_ctx.has_focus();
 
         let border_color = if has_focus {
-            env.get(theme::PRIMARY_LIGHT)
+            env.get(theme::COLOR_PRIMARY_LIGHT)
         } else {
             env.get(theme::BORDER_DARK)
         };

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -375,7 +375,7 @@ impl Widget<String> for TextBox {
         let background_color = env.get(theme::BACKGROUND_LIGHT);
         let selection_color = env.get(theme::SELECTION_COLOR);
         let text_color = env.get(theme::COLOR_BASE_LIGHTEST);
-        let placeholder_color = env.get(theme::PLACEHOLDER_COLOR);
+        let placeholder_color = env.get(theme::COLOR_BASE);
         let cursor_color = env.get(theme::CURSOR_COLOR);
 
         let has_focus = paint_ctx.has_focus();

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -372,7 +372,7 @@ impl Widget<String> for TextBox {
 
         let font_size = env.get(theme::TEXT_SIZE_NORMAL);
         let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
-        let background_color = env.get(theme::BACKGROUND_LIGHT);
+        let background_color = env.get(theme::COLOR_BASE_DARK);
         let selection_color = env.get(theme::SELECTION_COLOR);
         let text_color = env.get(theme::COLOR_BASE_LIGHTEST);
         let placeholder_color = env.get(theme::COLOR_BASE);

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -374,7 +374,7 @@ impl Widget<String> for TextBox {
         let height = env.get(theme::BORDERED_WIDGET_HEIGHT);
         let background_color = env.get(theme::BACKGROUND_LIGHT);
         let selection_color = env.get(theme::SELECTION_COLOR);
-        let text_color = env.get(theme::LABEL_COLOR);
+        let text_color = env.get(theme::COLOR_BASE_LIGHTEST);
         let placeholder_color = env.get(theme::PLACEHOLDER_COLOR);
         let cursor_color = env.get(theme::CURSOR_COLOR);
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -383,7 +383,7 @@ impl Widget<String> for TextBox {
         let border_color = if has_focus {
             env.get(theme::COLOR_PRIMARY_LIGHT)
         } else {
-            env.get(theme::BORDER_DARK)
+            env.get(theme::COLOR_BASE_DARKER)
         };
 
         // Paint the background

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -249,7 +249,7 @@ impl<T: Data> Window<T> {
             self.layout(piet, data, env);
         }
 
-        piet.clear(env.get(crate::theme::WINDOW_BACKGROUND_COLOR));
+        piet.clear(env.get(crate::theme::COLOR_BASE_DARKEST));
         self.paint(piet, data, env);
 
         // If commands were submitted during anim frame, ask the handler


### PR DESCRIPTION
This PR is one step towards the design-token-based approach to basic UI units and measures as discussed in #420.

I'm going to break the work in #420 up into two or three smaller PRs. In this first PR, I'm looking for feedback on what the community thinks of this design. I've used this successfully on the Web, but does it make sense at all in the context of Druid?

In this PR, I took all the different colors used in `theme.rs` and put them in a color hierarchy, from lightest to darkest. You can visually see the colors I used in [this CodePen](https://codepen.io/s3thi/pen/KKpQaVo). After creating the hierarchy, I replaced all uses of color across the codebase with colors from the hierarchy. This resulted in minor changes to the appearances of some widgets because I had to eliminate the use of some colors, but the differences are not striking.

As new widgets are written, they should try to work with the colors within this hierarchy before defining their own colors. This will prevent an overcrowding of the theme with widget-specific variables such as `SCROLL_BAR_BORDER_COLOR` or `BUTTON_LIGHT`. It will also allow easy customization, because now you only have to change a couple of variables to affect the appearance of your entire app.

My next step is to do this same exercise for border radiuses, text sizes, opacities, margins & paddings, and widget sizes. Before that, though, I'd love to know if this is even worthwhile.