### PR TITLE
Set parse widget state in WidgetAdded

### DIFF
--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -218,7 +218,6 @@ fn make_spacer_select() -> impl Widget<Params> {
             Flex::row()
                 .with_child(
                     TextBox::new()
-                        .with_placeholder(DEFAULT_SPACER_SIZE.to_string())
                         .parse()
                         .lens(
                             Params::spacer_size

--- a/druid/src/widget/parse.rs
+++ b/druid/src/widget/parse.rs
@@ -33,9 +33,14 @@ impl<T: FromStr + Display + Data, W: Widget<String>> Widget<Option<T>> for Parse
         &mut self,
         ctx: &mut LifeCycleCtx,
         event: &LifeCycle,
-        _data: &Option<T>,
+        data: &Option<T>,
         env: &Env,
     ) {
+        if let LifeCycle::WidgetAdded = event {
+            if let Some(data) = data {
+                self.state = data.to_string();
+            }
+        }
         self.widget.lifecycle(ctx, event, &self.state, env)
     }
 


### PR DESCRIPTION
This was an oversight from the lifecycle change; the parse state
would not be set until the first update was received.