### PR TITLE
Interpolation options and better Alpha

### DIFF
--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -55,7 +55,7 @@ impl<T: Data> Image<T> {
     }
 
     /// Modify the widget's `FillStrat`.
-    pub fn set_fill(&mut self, newfil: FillStrat) {
+    pub fn set_fill_mode(&mut self, newfil: FillStrat) {
         self.fill = newfil;
     }
 }

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -72,7 +72,7 @@ impl<T: Data> Svg<T> {
     }
 
     /// Modify the widget's `FillStrat`.
-    pub fn set_fill(&mut self, newfil: FillStrat) {
+    pub fn set_fill_mode(&mut self, newfil: FillStrat) {
         self.fill = newfil;
     }
 }


### PR DESCRIPTION
Complete tec debt identified in #578 

This MR allows the user of the image widget to determine the interpolation used for plotting.

And only stores the alpha channel if it is used.