### PR TITLE
[Do not merge] prototype Container::background as a KeyOrValue

### DIFF
--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -15,10 +15,8 @@
 //! A widget that provides simple visual styling options to a child.
 
 use crate::shell::kurbo::{Point, Rect, RoundedRect, Size};
-use crate::{
-    BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintBrush,
-    PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,
-};
+use crate::{BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintBrush, PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod, KeyOrValue};
+use crate::env::Brush;
 
 struct BorderStyle {
     width: f64,
@@ -27,7 +25,7 @@ struct BorderStyle {
 
 /// A widget that provides simple visual styling options to a child.
 pub struct Container<T> {
-    background: Option<PaintBrush>,
+    background: Option<KeyOrValue<Brush>>,
     border: Option<BorderStyle>,
     corner_radius: f64,
 
@@ -46,7 +44,7 @@ impl<T: Data> Container<T> {
     }
 
     /// Paint background with a color or a gradient.
-    pub fn background(mut self, brush: impl Into<PaintBrush>) -> Self {
+    pub fn background(mut self, brush: impl Into<KeyOrValue<Brush>>) -> Self {
         self.background = Some(brush.into());
         self
     }
@@ -126,7 +124,10 @@ impl<T: Data> Widget<T> for Container<T> {
         };
 
         if let Some(background) = &self.background {
-            paint_ctx.fill(panel, background);
+            match background.resolve(env) {
+                Brush::Color(c) => paint_ctx.fill(panel, &c),
+                Brush::LinearGradient(g) => paint_ctx.fill(panel, g.as_ref()),
+            };
         };
 
         self.inner.paint(paint_ctx, data, env);

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -21,7 +21,8 @@ use super::{
     Align, Container, Controller, ControllerHost, EnvScope, IdentityWrapper, Padding, Parse,
     SizedBox, WidgetId,
 };
-use crate::{Data, Env, Lens, LensWrap, Widget};
+use crate::{Data, Env, Lens, LensWrap, Widget, KeyOrValue};
+use crate::env::Brush;
 
 /// A trait that provides extra methods for combining `Widget`s.
 pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
@@ -103,7 +104,7 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     ///
     /// [`Container`]: struct.Container.html
     /// [`PaintBrush`]: https://docs.rs/piet/0.0.7/piet/enum.PaintBrush.html
-    fn background(self, brush: impl Into<PaintBrush>) -> Container<T> {
+    fn background(self, brush: impl Into<KeyOrValue<Brush>>) -> Container<T> {
         Container::new(self).background(brush)
     }
 


### PR DESCRIPTION
This is a prototype of how `Container::background` could work with a `KeyOrValue<Brush>` rather than a `PaintBrush`.

The PR is mainly created for making discussions easier at this stage.

I only implemented one case of Gradient (Linear) to prototype the idea, the rest of them (Radix and Fixed) could be implemented later on following the same idea.