### PR TITLE
Add set_text method to Label.

### DIFF
--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -81,6 +81,19 @@ impl<T: Data> Label<T> {
         }
     }
 
+    /// Set a new text.
+    ///
+    /// Takes an already resolved string as input.
+    ///
+    /// If you're looking for full [`LabelText`] support,
+    /// then you need to create a new [`Label`].
+    ///
+    /// [`Label`]: #method.new
+    /// [`LabelText`]: enum.LabelText.html
+    pub fn set_text(&mut self, text: impl Into<String>) {
+        self.text = LabelText::Specific(text.into());
+    }
+
     /// Set text alignment.
     #[deprecated(since = "0.5.0", note = "Use an Align widget instead")]
     pub fn text_align(self, _align: UnitPoint) -> Self {


### PR DESCRIPTION
This PR adds the `set_text` method to `Label` which allows changing the text. For changing static strings, previously the only solution was to recreate `Label` and for changing dynamic strings there's only `update`. (A bit more context in [Zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Dynamic.20label))

Unfortunately, in order to support `LabelText::Dynamic` the `set_text` method must also take in `Data` and `Env`.

As it stands right now, just recreating `Label` might be reasonable. However as `Label` might grow with all sorts of style properties, the option to just change the text and not have to recreate the whole style can be a significant win.