### PR TITLE
Align Container and debug borders to pixels.

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
 use log;
 
 use crate::bloom::Bloom;
-use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size};
+use crate::kurbo::{Affine, Insets, Rect, Shape, Size};
 use crate::piet::RenderContext;
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
@@ -268,10 +268,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         paint_ctx.z_ops.append(&mut ctx.z_ops);
 
         if env.get(Env::DEBUG_PAINT) {
-            let rect = Rect::from_origin_size(Point::ORIGIN, ctx.size());
+            const BORDER_WIDTH: f64 = 1.0;
+            let rect = ctx.size().to_rect().inset(BORDER_WIDTH / -2.0);
             let id = self.id().to_raw();
             let color = env.get_debug_color(id);
-            ctx.stroke(rect, &color, 1.0);
+            ctx.stroke(rect, &color, BORDER_WIDTH);
         }
 
         self.state.needs_inval = false;


### PR DESCRIPTION
### How stroke works
The coordinates provided to stroke are fully respected and not rounded to an integer. Furthermore the stroke is positioned exactly on top of the provided coordinates. This means that if you draw a 1px wide line at pixel boundaries, 0.5px of the line width will be on one side pixel and  the other 0.5px on the other side. Of course the pixel is usually the smallest unit a display has, so the 1px line ends up looking like a 2px line, although usually alpha blended. The solution is to specify the midpoint of a pixel instead, i.e. if you want the line to appear on the 2nd pixel row you specify 1.5 as the point.

![stroke-point](https://user-images.githubusercontent.com/754881/76705583-d67ab300-66e9-11ea-8034-0ef8e94af369.png)

### Steps towards improving druid
This PR changes the way the `Container` widget border and the debug borders are drawn. In both cases they are drawn inwards, i.e. within the widget size, with pixel accuracy.

This PR also moves the `Container` border drawing after the background drawing so that you can have both active at the same time.

### Real life example (400% zoom)
![real-changes](https://user-images.githubusercontent.com/754881/76705799-61a87880-66eb-11ea-8aad-5cfff731c16f.png)

### Future work
* There is still more stroke usage in druid that isn't pixel perfect. These should all be addressed.
* The widget layouts themselves [should be quantized to integers](https://github.com/xi-editor/druid/pull/148#issuecomment-530441059). Otherwise even if the stroke usage is pixel-perfect, it will have a non-integer origin. This is currently affecting `Label` and probably everything that uses `Label`'s layout in calculations of its own layout, e.g. `Button`.