### PR TITLE
Adding a reference to the data to the child_builder of a ViewSwitcher

### DIFF
--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -54,7 +54,7 @@ fn make_ui() -> impl Widget<AppState> {
 
     let view_switcher = ViewSwitcher::new(
         |data: &AppState, _env| data.current_view,
-        |selector, _env| match selector {
+        |selector, _data, _env| match selector {
             0 => Box::new(Label::new("Simple Label").center()),
             1 => Box::new(Button::new("Simple Button", |_event, _data, _env| {
                 println!("Simple button clicked!");

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -22,9 +22,12 @@ use crate::{
 /// A widget that can switch dynamically between one of many views depending
 /// on application state.
 
+type ChildPicker<T, U> = dyn Fn(&T, &Env) -> U;
+type ChildBuilder<T, U> = dyn Fn(&U, &T, &Env) -> Box<dyn Widget<T>>;
+
 pub struct ViewSwitcher<T, U> {
-    child_picker: Box<dyn Fn(&T, &Env) -> U>,
-    child_builder: Box<dyn Fn(&U, &T, &Env) -> Box<dyn Widget<T>>>,
+    child_picker: Box<ChildPicker<T, U>>,
+    child_builder: Box<ChildBuilder<T, U>>,
     active_child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
     active_child_id: Option<U>,
 }

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -24,7 +24,7 @@ use crate::{
 
 pub struct ViewSwitcher<T, U> {
     child_picker: Box<dyn Fn(&T, &Env) -> U>,
-    child_builder: Box<dyn Fn(&U, &Env) -> Box<dyn Widget<T>>>,
+    child_builder: Box<dyn Fn(&U, &T, &Env) -> Box<dyn Widget<T>>>,
     active_child: Option<WidgetPod<T, Box<dyn Widget<T>>>>,
     active_child_id: Option<U>,
 }
@@ -41,7 +41,7 @@ impl<T: Data, U: PartialEq> ViewSwitcher<T, U> {
     /// the value passed to it.
     pub fn new(
         child_picker: impl Fn(&T, &Env) -> U + 'static,
-        child_builder: impl Fn(&U, &Env) -> Box<dyn Widget<T>> + 'static,
+        child_builder: impl Fn(&U, &T, &Env) -> Box<dyn Widget<T>> + 'static,
     ) -> Self {
         Self {
             child_picker: Box::new(child_picker),
@@ -62,7 +62,7 @@ impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::WidgetAdded = event {
             let child_id = (self.child_picker)(data, env);
-            self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, env)));
+            self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, data, env)));
             self.active_child_id = Some(child_id);
         }
         if let Some(child) = self.active_child.as_mut() {
@@ -73,7 +73,7 @@ impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
     fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &T, data: &T, env: &Env) {
         let child_id = (self.child_picker)(data, env);
         if Some(&child_id) != self.active_child_id.as_ref() {
-            self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, env)));
+            self.active_child = Some(WidgetPod::new((self.child_builder)(&child_id, data, env)));
             self.active_child_id = Some(child_id);
             ctx.children_changed();
         }


### PR DESCRIPTION
My model contains some fields that are only necessary while building the view. The current `child_builder` signature does not include a reference to the data, which forces me to clone the whole data and transfer the ownership to the closure.

For an example of what I mean you can have a look to this code:

- The clone happens [here](https://github.com/chris-zen/kiro-synth/blob/druid-tabs/kiro-synth-host/src/ui/view.rs#L103)
- The building happens [here](https://github.com/chris-zen/kiro-synth/blob/druid-tabs/kiro-synth-host/src/ui/view.rs#L108)

In that example I store in [the data model](https://github.com/chris-zen/kiro-synth/blob/druid-tabs/kiro-synth-host/src/ui/model.rs#L39) two kind of things (for convenience):

- data that never changes from the user interaction like origin, min, max, step.
- data that changes on user interaction like the value and the modulation.

So I need to pass the data model across the view building functions, as well as the regular Widget data (which can be adapted using lenses).