### PR TITLE
Update kurbo to 0.5.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "glib-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtk 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtk-sys 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1034,7 +1035,7 @@ name = "piet"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kurbo 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1493,7 +1494,7 @@ dependencies = [
  "data-url 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "harfbuzz_rs 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kurbo 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rctree 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1722,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum intl_pluralrules 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "752ecba25a0554836d7921e383ba5c78ffea6e4825cc70dac75e2ab8e43af1be"
 "checksum jpeg-decoder 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0256f0aec7352539102a9efbcb75543227b7ab1117e0f95450023af730128451"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
-"checksum kurbo 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbc14ddfabdbe7279fb1bd715dcba997e7d44d5d3a2e064096e06f3bc53b04d"
+"checksum kurbo 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd59c4aa881500a0d58f4e46237d98b19da67b75b1549c3115ecea7a632e381"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.8"
 lazy_static = "1.0"
 time = "0.2.7"
 cfg-if = "0.1.10"
+kurbo = "0.5.9"
 
 cairo-rs = {  version = "0.8.0", default_features = false, optional = true }
 gio = { version = "0.8.0", optional = true }

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -21,8 +21,8 @@
 #![deny(intra_doc_link_resolution_failure)]
 #![allow(clippy::new_without_default)]
 
+pub use kurbo;
 pub use piet_common as piet;
-pub use piet_common::kurbo;
 
 #[cfg(target_os = "windows")]
 #[macro_use]


### PR DESCRIPTION
I really want `Size::to_rect` in druid. 🤷‍♂ 