### PR TITLE
Fix #265 PostQuitMessage when WM_DESTROY in Win

### DIFF
--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -957,6 +957,10 @@ pub(crate) unsafe extern "system" fn win_proc_dispatch(
         }
     };
 
+    if msg == WM_DESTROY {
+      PostQuitMessage(0);
+    }
+
     if msg == WM_NCDESTROY && !window_ptr.is_null() {
         SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
         mem::drop(Rc::from_raw(window_ptr));


### PR DESCRIPTION
Fix to exit the loop normally when the window is closed in Windows.
Related: #265 ( and #674, #438, #395, #362 )
