### PR TITLE
Add PaintCtx::with_save

### DIFF
--- a/druid/examples/custom_widget.rs
+++ b/druid/examples/custom_widget.rs
@@ -95,13 +95,11 @@ impl Widget<String> for CustomWidget {
         let layout = ctx.text().new_text_layout(&font, data).build().unwrap();
 
         // Let's rotate our text slightly. First we save our current (default) context:
-        ctx.with_save(|rc| {
+        ctx.with_save(|ctx| {
             // Now we can rotate the context (or set a clip path, for instance):
-            rc.transform(Affine::rotate(0.1));
-            rc.draw_text(&layout, (80.0, 40.0), &fill_color);
-            Ok(())
-        })
-        .unwrap();
+            ctx.transform(Affine::rotate(0.1));
+            ctx.draw_text(&layout, (80.0, 40.0), &fill_color);
+        });
         // When we exit with_save, the original context's rotation is restored
 
         // Let's burn some CPU to make a (partially transparent) image buffer

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -305,21 +305,12 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             return;
         }
 
-        if let Err(e) = ctx.save() {
-            log::error!("saving render context failed: {:?}", e);
-            return;
-        }
-
-        let layout_origin = self.state.layout_rect.origin().to_vec2();
-        ctx.transform(Affine::translate(layout_origin));
-
-        let visible = ctx.region().to_rect() - layout_origin;
-
-        ctx.with_child_ctx(visible, |ctx| self.paint(ctx, data, &env));
-
-        if let Err(e) = ctx.restore() {
-            log::error!("restoring render context failed: {:?}", e);
-        }
+        ctx.with_save(|ctx| {
+            let layout_origin = self.state.layout_rect.origin().to_vec2();
+            ctx.transform(Affine::translate(layout_origin));
+            let visible = ctx.region().to_rect() - layout_origin;
+            ctx.with_child_ctx(visible, |ctx| self.paint(ctx, data, &env));
+        });
     }
 
     /// Compute layout of a widget.

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -150,16 +150,9 @@ impl<T: Data> Widget<T> for Button<T> {
 
         let label_offset = (size.to_vec2() - self.label_size.to_vec2()) / 2.0;
 
-        if let Err(e) = ctx.save() {
-            log::error!("saving render context failed: {:?}", e);
-            return;
-        }
-
-        ctx.transform(Affine::translate(label_offset));
-        self.label.paint(ctx, data, env);
-
-        if let Err(e) = ctx.restore() {
-            log::error!("restoring render context failed: {:?}", e);
-        }
+        ctx.with_save(|ctx| {
+            ctx.transform(Affine::translate(label_offset));
+            self.label.paint(ctx, data, env);
+        });
     }
 }

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -136,20 +136,13 @@ impl<T: Data> Widget<T> for Container<T> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         if let Some(background) = self.background.as_mut() {
-            if let Err(e) = ctx.save() {
-                log::error!("{}", e);
-                return;
-            }
+            let panel = ctx.size().to_rounded_rect(self.corner_radius);
 
-            let bg_rect = ctx.size().to_rounded_rect(self.corner_radius);
-            ctx.clip(bg_rect);
-            background.paint(ctx, data, env);
-
-            if let Err(e) = ctx.restore() {
-                log::error!("{}", e);
-                return;
-            }
-        };
+            ctx.with_save(|ctx| {
+                ctx.clip(panel);
+                background.paint(ctx, data, env);
+            });
+        }
 
         if let Some(border) = &self.border {
             let border_width = border.width.resolve(env);

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -192,22 +192,17 @@ impl ImageData {
     fn to_piet(&self, offset_matrix: Affine, ctx: &mut PaintCtx, interpolation: InterpolationMode) {
         ctx.with_save(|ctx| {
             ctx.transform(offset_matrix);
-
+            let size = self.get_size();
             let im = ctx
                 .make_image(
-                    self.x_pixels as usize,
-                    self.y_pixels as usize,
+                    size.width as usize,
+                    size.height as usize,
                     &self.pixels,
                     self.format,
                 )
                 .unwrap();
-            let rec =
-                Rect::from_origin_size((0.0, 0.0), (self.x_pixels as f64, self.y_pixels as f64));
-            ctx.draw_image(&im, rec, interpolation);
-
-            Ok(())
+            ctx.draw_image(&im, size.to_rect(), interpolation);
         })
-        .unwrap();
     }
 }
 

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -14,7 +14,6 @@
 
 //! A container that scrolls its contents.
 
-use log::error;
 use std::f64::INFINITY;
 use std::time::{Duration, Instant};
 
@@ -429,21 +428,15 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        if let Err(e) = ctx.save() {
-            error!("saving render context failed: {:?}", e);
-            return;
-        }
-        let viewport = Rect::from_origin_size(Point::ORIGIN, ctx.size());
-        ctx.clip(viewport);
-        ctx.transform(Affine::translate(-self.scroll_offset));
+        let viewport = ctx.size().to_rect();
+        ctx.with_save(|ctx| {
+            ctx.clip(viewport);
+            ctx.transform(Affine::translate(-self.scroll_offset));
 
-        let visible = viewport.with_origin(self.scroll_offset.to_point());
-        ctx.with_child_ctx(visible, |ctx| self.child.paint(ctx, data, env));
+            let visible = viewport.with_origin(self.scroll_offset.to_point());
+            ctx.with_child_ctx(visible, |ctx| self.child.paint(ctx, data, env));
 
-        self.draw_bars(ctx, viewport, env);
-
-        if let Err(e) = ctx.restore() {
-            error!("restoring render context failed: {:?}", e);
-        }
+            self.draw_bars(ctx, viewport, env);
+        });
     }
 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -443,9 +443,7 @@ impl Widget<String> for TextBox {
 
                 rc.stroke(line, &cursor_color, 1.);
             }
-            Ok(())
-        })
-        .unwrap();
+        });
 
         // Paint the border
         ctx.stroke(clip_rect, &border_color, BORDER_WIDTH);

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -299,17 +299,10 @@ impl<T: Data> Window<T> {
 
         for z_op in z_ops.into_iter() {
             ctx.with_child_ctx(visible, |ctx| {
-                if let Err(e) = ctx.render_ctx.save() {
-                    log::error!("saving render context failed: {:?}", e);
-                    return;
-                }
-
-                ctx.render_ctx.transform(z_op.transform);
-                (z_op.paint_func)(ctx);
-
-                if let Err(e) = ctx.render_ctx.restore() {
-                    log::error!("restoring render context failed: {:?}", e);
-                }
+                ctx.with_save(|ctx| {
+                    ctx.render_ctx.transform(z_op.transform);
+                    (z_op.paint_func)(ctx);
+                });
             });
         }
     }


### PR DESCRIPTION
This reduces boilerplate when you need to clip or transform briefly
during painting.

- closes #646