### PR TITLE
Add expand_width & expand_height

### DIFF
--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -69,9 +69,31 @@ impl<T> SizedBox<T> {
     }
 
     /// Expand container to fit the parent.
-    /// It is equivalent to setting width and height to Infinity.
+    ///
+    /// Only call this method if you want your widget to occupy all available
+    /// space. If you only care about expanding in one of width or height, use
+    /// [`expand_width`] or [`expand_height`] instead.
+    ///
+    /// [`expand_height`]: #method.expand_height
+    /// [`expand_width`]: #method.expand_width
     pub fn expand(mut self) -> Self {
         self.width = Some(INFINITY);
+        self.height = Some(INFINITY);
+        self
+    }
+
+    /// Expand the container on the x-axis.
+    ///
+    /// This will force the child to have maximum width.
+    pub fn expand_width(mut self) -> Self {
+        self.width = Some(INFINITY);
+        self
+    }
+
+    /// Expand the container on the y-axis.
+    ///
+    /// This will force the child to have maximum height.
+    pub fn expand_height(mut self) -> Self {
         self.height = Some(INFINITY);
         self
     }

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -88,9 +88,33 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
 
     /// Wrap this widget in a [`SizedBox`] with an infinite width and height.
     ///
+    /// Only call this method if you want your widget to occupy all available
+    /// space. If you only care about expanding in one of width or height, use
+    /// [`expand_width`] or [`expand_height`] instead.
+    ///
+    /// [`expand_height`]: #method.expand_height
+    /// [`expand_width`]: #method.expand_width
     /// [`SizedBox`]: struct.SizedBox.html
     fn expand(self) -> SizedBox<T> {
         SizedBox::new(self).expand()
+    }
+
+    /// Wrap this widget in a [`SizedBox`] with an infinite width.
+    ///
+    /// This will force the child to use all available space on the x-axis.
+    ///
+    /// [`SizedBox`]: struct.SizedBox.html
+    fn expand_width(self) -> SizedBox<T> {
+        SizedBox::new(self).expand_width()
+    }
+
+    /// Wrap this widget in a [`SizedBox`] with an infinite width.
+    ///
+    /// This will force the child to use all available space on the y-axis.
+    ///
+    /// [`SizedBox`]: struct.SizedBox.html
+    fn expand_height(self) -> SizedBox<T> {
+        SizedBox::new(self).expand_height()
     }
 
     /// Wrap this widget in a [`Container`] with the provided `background`.


### PR DESCRIPTION
This comes out of my remaining lack of satisfaction with #639. Basically I find the  `FlexParams` business still overkill in the general case, and I  want to get rid of the `loose` and  `tight` distinction. My thinking here is that `tight` is strictly representable in terms of  a child that is set to `expand`, but very often in a container if you use `expand` you will end up with an infinite size on one of the axes. This makes it easier to use `expand` on a specific axis, which will let me delete the loose/tight distinction in `FlexParams`.