### PR TITLE
Scrollbar min size

### DIFF
--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -30,11 +30,8 @@ fn build_app() -> impl Widget<u32> {
             let row_progress = j as f64 / rows as f64;
 
             row.add_child(
-                Container::new(SizedBox::empty().width(50.0).height(50.0)).background(Color::rgb(
-                    1.0 * col_progress,
-                    1.0 * row_progress,
-                    1.0,
-                )),
+                Container::new(SizedBox::empty().width(200.0).height(200.0))
+                    .background(Color::rgb(1.0 * col_progress, 1.0 * row_progress, 1.0)),
                 0.0,
             );
         }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -25,6 +25,8 @@ use crate::{
     RenderContext, TimerToken, UpdateCtx, Widget, WidgetPod,
 };
 
+const SCROLLBAR_MIN_SIZE: f64 = 45.0;
+
 #[derive(Debug, Clone)]
 enum ScrollDirection {
     Horizontal,
@@ -186,16 +188,25 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         let bar_width = env.get(theme::SCROLL_BAR_WIDTH);
         let bar_pad = env.get(theme::SCROLL_BAR_PAD);
 
-        let scale_y = viewport.height() / self.child_size.height;
+        let percent_visible = viewport.height() / self.child_size.height;
+        let percent_scrolled = self.scroll_offset.y / (self.child_size.height - viewport.height());
 
-        let top_y_offset = (scale_y * self.scroll_offset.y).ceil();
-        let bottom_y_offset = (scale_y * viewport.height()).ceil() + top_y_offset;
+        let mut length = (percent_visible * viewport.height()).ceil();
+        if length < SCROLLBAR_MIN_SIZE {
+            length = SCROLLBAR_MIN_SIZE;
+        }
+
+        let vertical_padding = bar_pad + bar_pad + bar_width;
+
+        let top_y_offset =
+            ((viewport.height() - length - vertical_padding) * percent_scrolled).ceil();
+        let bottom_y_offset = top_y_offset + length;
 
         let x0 = self.scroll_offset.x + viewport.width() - bar_width - bar_pad;
         let y0 = self.scroll_offset.y + top_y_offset + bar_pad;
 
         let x1 = self.scroll_offset.x + viewport.width() - bar_pad;
-        let y1 = self.scroll_offset.y + bottom_y_offset - (bar_pad * 2.) - bar_width;
+        let y1 = self.scroll_offset.y + bottom_y_offset;
 
         Rect::new(x0, y0, x1, y1)
     }
@@ -204,15 +215,24 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         let bar_width = env.get(theme::SCROLL_BAR_WIDTH);
         let bar_pad = env.get(theme::SCROLL_BAR_PAD);
 
-        let scale_x = viewport.width() / self.child_size.width;
+        let percent_visible = viewport.width() / self.child_size.width;
+        let percent_scrolled = self.scroll_offset.x / (self.child_size.width - viewport.width());
 
-        let left_x_offset = (scale_x * self.scroll_offset.x).ceil();
-        let right_x_offset = (scale_x * viewport.width()).ceil() + left_x_offset;
+        let mut length = (percent_visible * viewport.width()).ceil();
+        if length < SCROLLBAR_MIN_SIZE {
+            length = SCROLLBAR_MIN_SIZE;
+        }
+
+        let horizontal_padding = bar_pad + bar_pad + bar_width;
+
+        let left_x_offset =
+            ((viewport.width() - length - horizontal_padding) * percent_scrolled).ceil();
+        let right_x_offset = left_x_offset + length;
 
         let x0 = self.scroll_offset.x + left_x_offset + bar_pad;
         let y0 = self.scroll_offset.y + viewport.height() - bar_width - bar_pad;
 
-        let x1 = self.scroll_offset.x + right_x_offset - (bar_pad * 2.) - bar_width;
+        let x1 = self.scroll_offset.x + right_x_offset;
         let y1 = self.scroll_offset.y + viewport.height() - bar_pad;
 
         Rect::new(x0, y0, x1, y1)

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -191,10 +191,8 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         let percent_visible = viewport.height() / self.child_size.height;
         let percent_scrolled = self.scroll_offset.y / (self.child_size.height - viewport.height());
 
-        let mut length = (percent_visible * viewport.height()).ceil();
-        if length < SCROLLBAR_MIN_SIZE {
-            length = SCROLLBAR_MIN_SIZE;
-        }
+        let length = (percent_visible * viewport.height()).ceil();
+        let length = length.max(SCROLLBAR_MIN_SIZE);
 
         let vertical_padding = bar_pad + bar_pad + bar_width;
 
@@ -218,10 +216,8 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         let percent_visible = viewport.width() / self.child_size.width;
         let percent_scrolled = self.scroll_offset.x / (self.child_size.width - viewport.width());
 
-        let mut length = (percent_visible * viewport.width()).ceil();
-        if length < SCROLLBAR_MIN_SIZE {
-            length = SCROLLBAR_MIN_SIZE;
-        }
+        let length = (percent_visible * viewport.width()).ceil();
+        let length = length.max(SCROLLBAR_MIN_SIZE);
 
         let horizontal_padding = bar_pad + bar_pad + bar_width;
 


### PR DESCRIPTION
There were a few things I wanted to get done before working on inlay scrollbars. This is one of them. It gracefully handles situations where the scrollbar would otherwise be too small for a hit test to ever succeed. After fighting with it for a while I believe that the scrollbar bounds calculation is actually clearer now than before which surprised me.

I do have two concerns:
1. I don't ever like using absolute pixel values. I was originally going to multiply the min value by the DPI normalized but now I'm thinking that it might be useful to instead define the min length in terms of percentage of the display's resolution on that axis however that is very out of the box and odd. Either way I feel that is something that can be determined at a later date.
2. I'm worried that the dependency on `rand` makes `scroll_big` too heavy for an example. Any input on how to achieve a similar result without the `rand` dependency is welcome.