### PR TITLE
2 flex 2 params

### DIFF
--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -171,13 +171,13 @@ fn flex_row<T: Data>(
     w4: impl Widget<T> + 'static,
 ) -> impl Widget<T> {
     Flex::row()
-        .with_child(w1, 1.0)
+        .with_flex_child(w1, 1.0)
         .with_spacer(1.0)
-        .with_child(w2, 1.0)
+        .with_flex_child(w2, 1.0)
         .with_spacer(1.0)
-        .with_child(w3, 1.0)
+        .with_flex_child(w3, 1.0)
         .with_spacer(1.0)
-        .with_child(w4, 1.0)
+        .with_flex_child(w4, 1.0)
 }
 
 fn build_calc() -> impl Widget<CalcState> {
@@ -187,10 +187,10 @@ fn build_calc() -> impl Widget<CalcState> {
         .padding(5.0);
     Flex::column()
         .with_flex_spacer(0.2)
-        .with_child(display, 0.0)
+        .with_child(display)
         .with_flex_spacer(0.2)
         .cross_axis_alignment(CrossAxisAlignment::End)
-        .with_child(
+        .with_flex_child(
             flex_row(
                 op_button_label('c', "CE".to_string()),
                 op_button('C'),
@@ -200,7 +200,7 @@ fn build_calc() -> impl Widget<CalcState> {
             1.0,
         )
         .with_spacer(1.0)
-        .with_child(
+        .with_flex_child(
             flex_row(
                 digit_button(7),
                 digit_button(8),
@@ -210,7 +210,7 @@ fn build_calc() -> impl Widget<CalcState> {
             1.0,
         )
         .with_spacer(1.0)
-        .with_child(
+        .with_flex_child(
             flex_row(
                 digit_button(4),
                 digit_button(5),
@@ -220,7 +220,7 @@ fn build_calc() -> impl Widget<CalcState> {
             1.0,
         )
         .with_spacer(1.0)
-        .with_child(
+        .with_flex_child(
             flex_row(
                 digit_button(1),
                 digit_button(2),
@@ -230,7 +230,7 @@ fn build_calc() -> impl Widget<CalcState> {
             1.0,
         )
         .with_spacer(1.0)
-        .with_child(
+        .with_flex_child(
             flex_row(
                 op_button('±'),
                 digit_button(0),

--- a/druid/examples/either.rs
+++ b/druid/examples/either.rs
@@ -42,13 +42,12 @@ fn ui_builder() -> impl Widget<AppState> {
         Checkbox::new("Toggle slider")
             .lens(AppState::which)
             .padding(5.0),
-        0.0,
     );
     let either = Either::new(
         |data, _env| data.which,
         Slider::new().lens(AppState::value).padding(5.0),
         label.padding(5.0),
     );
-    col.add_child(either, 0.0);
+    col.add_child(either);
     col
 }

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -20,8 +20,8 @@ use druid::widget::{
 };
 use druid::{
     AppLauncher, BoxConstraints, Color, Data, Env, Event, EventCtx, LayoutCtx, Lens, LensExt,
-    LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, PlatformError, Size, UnitPoint, UpdateCtx,
-    Widget, WidgetId, WindowDesc,
+    LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, PlatformError, Size, UpdateCtx, Widget,
+    WidgetId, WindowDesc,
 };
 
 const DEFAULT_SPACER_SIZE: f64 = 8.;
@@ -126,17 +126,15 @@ fn make_control_row() -> impl Widget<AppState> {
     Flex::row()
         .with_child(
             Flex::column()
-                .with_child(Label::new("Type:").padding(5.0), 0.)
+                .with_child(Label::new("Type:").padding(5.0))
                 .with_child(
                     RadioGroup::new(vec![("Row", FlexType::Row), ("Column", FlexType::Column)])
                         .lens(Params::axis),
-                    0.,
                 ),
-            0.0,
         )
         .with_child(
             Flex::column()
-                .with_child(Label::new("CrossAxis:").padding(5.0), 0.)
+                .with_child(Label::new("CrossAxis:").padding(5.0))
                 .with_child(
                     RadioGroup::new(vec![
                         ("Start", CrossAxisAlignment::Start),
@@ -144,13 +142,11 @@ fn make_control_row() -> impl Widget<AppState> {
                         ("End", CrossAxisAlignment::End),
                     ])
                     .lens(Params::cross_alignment),
-                    0.,
                 ),
-            0.0,
         )
         .with_child(
             Flex::column()
-                .with_child(Label::new("MainAxis:").padding(5.0), 0.)
+                .with_child(Label::new("MainAxis:").padding(5.0))
                 .with_child(
                     RadioGroup::new(vec![
                         ("Start", MainAxisAlignment::Start),
@@ -161,35 +157,20 @@ fn make_control_row() -> impl Widget<AppState> {
                         ("Around", MainAxisAlignment::SpaceAround),
                     ])
                     .lens(Params::main_alignment),
-                    0.,
                 ),
-            0.0,
         )
-        .with_child(make_spacer_select(), 0.0)
+        .with_child(make_spacer_select())
         .with_child(
             Flex::column()
-                .with_child(Label::new("Misc:").padding((0., 0., 0., 10.)), 0.)
-                .with_child(
-                    Checkbox::new("Debug layout").lens(Params::debug_layout),
-                    0.0,
-                )
+                .with_child(Label::new("Misc:").padding((0., 0., 0., 10.)))
+                .with_child(Checkbox::new("Debug layout").lens(Params::debug_layout))
                 .with_spacer(10.)
-                .with_child(
-                    Checkbox::new("Fill main axis").lens(Params::fill_major_axis),
-                    0.,
-                )
+                .with_child(Checkbox::new("Fill main axis").lens(Params::fill_major_axis))
                 .with_spacer(10.)
-                .with_child(
-                    Checkbox::new("Fix minor axis size").lens(Params::fix_minor_axis),
-                    0.,
-                )
+                .with_child(Checkbox::new("Fix minor axis size").lens(Params::fix_minor_axis))
                 .with_spacer(10.)
-                .with_child(
-                    Checkbox::new("Fix major axis size").lens(Params::fix_major_axis),
-                    0.,
-                )
+                .with_child(Checkbox::new("Fix major axis size").lens(Params::fix_major_axis))
                 .padding(5.0),
-            0.0,
         )
         .border(Color::grey(0.6), 2.0)
         .rounded(5.0)
@@ -198,7 +179,7 @@ fn make_control_row() -> impl Widget<AppState> {
 
 fn make_spacer_select() -> impl Widget<Params> {
     Flex::column()
-        .with_child(Label::new("Insert Spacers:").padding(5.0), 0.)
+        .with_child(Label::new("Insert Spacers:").padding(5.0))
         .with_child(
             RadioGroup::new(vec![
                 ("None", Spacers::None),
@@ -206,7 +187,6 @@ fn make_spacer_select() -> impl Widget<Params> {
                 ("Fixed:", Spacers::Fixed),
             ])
             .lens(Params::spacers),
-            0.,
         )
         .with_child(
             Flex::row()
@@ -218,17 +198,14 @@ fn make_spacer_select() -> impl Widget<Params> {
                                 .map(|x| Some(*x), |x, y| *x = y.unwrap_or(DEFAULT_SPACER_SIZE)),
                         )
                         .fix_width(60.0),
-                    0.0,
                 )
                 .with_child(
                     Stepper::new()
                         .with_range(2.0, 50.0)
                         .with_step(2.0)
                         .lens(Params::spacer_size),
-                    0.0,
                 )
                 .padding((8.0, 5.0)),
-            0.0,
         )
 }
 
@@ -249,40 +226,35 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
     .main_axis_alignment(state.main_alignment)
     .must_fill_main_axis(state.fill_major_axis);
 
-    let mut flex = flex.with_child(TextBox::new().lens(DemoState::input_text), 0.);
+    let mut flex = flex.with_child(TextBox::new().lens(DemoState::input_text));
     space_if_needed(&mut flex, state);
 
-    flex.add_child(
-        Button::new("Clear", |_ctx, data: &mut DemoState, _env| {
-            data.input_text.clear();
-            data.enabled = false;
-            data.volume = 0.0;
-        }),
-        0.,
-    );
+    flex.add_child(Button::new("Clear", |_ctx, data: &mut DemoState, _env| {
+        data.input_text.clear();
+        data.enabled = false;
+        data.volume = 0.0;
+    }));
 
     space_if_needed(&mut flex, state);
 
-    flex.add_child(
-        Label::new(|data: &DemoState, _: &Env| data.input_text.clone()),
-        0.,
-    );
+    flex.add_child(Label::new(|data: &DemoState, _: &Env| {
+        data.input_text.clone()
+    }));
     space_if_needed(&mut flex, state);
-    flex.add_child(Checkbox::new("Demo").lens(DemoState::enabled), 0.);
+    flex.add_child(Checkbox::new("Demo").lens(DemoState::enabled));
     space_if_needed(&mut flex, state);
-    flex.add_child(Slider::new().lens(DemoState::volume), 0.);
+    flex.add_child(Slider::new().lens(DemoState::volume));
     space_if_needed(&mut flex, state);
-    flex.add_child(ProgressBar::new().lens(DemoState::volume), 0.);
+    flex.add_child(ProgressBar::new().lens(DemoState::volume));
     space_if_needed(&mut flex, state);
     flex.add_child(
         Stepper::new()
             .with_range(0.0, 1.0)
             .with_step(0.1)
             .lens(DemoState::volume),
-        0.0,
     );
     space_if_needed(&mut flex, state);
-    flex.add_child(Switch::new().lens(DemoState::enabled), 0.);
+    flex.add_child(Switch::new().lens(DemoState::enabled));
 
     let flex = flex
         .background(Color::rgba8(0, 0, 0xFF, 0x30))
@@ -312,11 +284,12 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
 
 fn make_ui() -> impl Widget<AppState> {
     Flex::column()
-        .with_child(make_control_row(), 0.0)
-        .with_spacer(20.)
-        .with_child(Rebuilder::new().align_vertical(UnitPoint::TOP_LEFT), 1.0)
         .must_fill_main_axis(true)
+        .with_child(make_control_row())
+        .with_spacer(20.)
+        .with_flex_child(Rebuilder::new(), 1.0)
         .padding(10.0)
+        .debug_paint_layout()
 }
 
 fn main() -> Result<(), PlatformError> {

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -357,7 +357,7 @@ fn blinker(top: GridPos) -> Option<[GridPos; 3]> {
 
 fn make_widget() -> impl Widget<AppData> {
     Flex::column()
-        .with_child(
+        .with_flex_child(
             GameOfLifeWidget {
                 timer_id: TimerToken::INVALID,
                 cell_size: Size {
@@ -373,7 +373,7 @@ fn make_widget() -> impl Widget<AppData> {
                 .with_child(
                     // a row with two buttons
                     Flex::row()
-                        .with_child(
+                        .with_flex_child(
                             // pause / resume button
                             Button::new(
                                 |data: &bool, _: &Env| match data {
@@ -389,7 +389,7 @@ fn make_widget() -> impl Widget<AppData> {
                             .padding((5., 5.)),
                             1.0,
                         )
-                        .with_child(
+                        .with_flex_child(
                             // clear button
                             Button::new("Clear", |ctx, data: &mut Grid, _: &Env| {
                                 data.clear();
@@ -400,21 +400,17 @@ fn make_widget() -> impl Widget<AppData> {
                             1.0,
                         )
                         .padding(8.0),
-                    0.,
                 )
                 .with_child(
                     Flex::row()
                         .with_child(
                             Label::new(|data: &AppData, _env: &_| format!("{:.2}FPS", data.fps()))
                                 .padding(3.0),
-                            0.,
                         )
-                        .with_child(Slider::new().lens(AppData::speed).padding((0., 0.)), 1.)
+                        .with_flex_child(Slider::new().expand_width().lens(AppData::speed), 1.)
                         .padding(8.0),
-                    0.,
                 )
                 .background(BG),
-            0.,
         )
 }
 

--- a/druid/examples/hello.rs
+++ b/druid/examples/hello.rs
@@ -52,9 +52,9 @@ fn build_root_widget() -> impl Widget<HelloState> {
 
     // arrange the two widgets vertically, with some padding
     let layout = Flex::column()
-        .with_child(label, 0.0)
+        .with_child(label)
         .with_spacer(VERTICAL_WIDGET_SPACING)
-        .with_child(textbox, 0.0);
+        .with_child(textbox);
 
     // center the two widgets in the available space
     Align::centered(layout)

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -30,7 +30,7 @@
 use std::time::{Duration, Instant};
 
 use druid::kurbo::RoundedRect;
-use druid::widget::{Button, Flex, WidgetExt, WidgetId};
+use druid::widget::{Button, CrossAxisAlignment, Flex, WidgetExt, WidgetId};
 use druid::{
     AppLauncher, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, LayoutCtx, Lens,
     LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size,
@@ -70,7 +70,7 @@ impl ColorWell {
         let frozen = if randomize {
             None
         } else {
-            Some(Color::rgba(0., 0., 0., 0.))
+            Some(Color::rgba(0., 0., 0., 0.2))
         };
         ColorWell {
             randomize,
@@ -162,62 +162,51 @@ fn make_ui() -> impl Widget<OurData> {
     let id_three = WidgetId::next();
 
     Flex::column()
-        .with_child(ColorWell::new(true).padding(10.0), 1.0)
-        .with_child(
+        .with_flex_child(ColorWell::new(true), 1.0)
+        .with_spacer(10.0)
+        .with_flex_child(
             Flex::row()
-                .with_child(ColorWell::new(false).padding(10.).with_id(ID_ONE), 1.0)
-                .with_child(
-                    Button::<OurData>::new("freeze", move |ctx, data, _env| {
-                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), ID_ONE)
-                    })
-                    .padding(10.0),
-                    0.5,
-                )
-                .with_child(
-                    Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
-                        ctx.submit_command(UNFREEZE_COLOR, ID_ONE)
-                    })
-                    .padding(10.0),
-                    0.5,
-                ),
+                .cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_flex_child(ColorWell::new(false).with_id(ID_ONE), 1.0)
+                .with_spacer(10.0)
+                .with_child(Button::<OurData>::new("freeze", move |ctx, data, _env| {
+                    ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), ID_ONE)
+                }))
+                .with_spacer(10.0)
+                .with_child(Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
+                    ctx.submit_command(UNFREEZE_COLOR, ID_ONE)
+                })),
             0.5,
         )
-        .with_child(
+        .with_spacer(10.0)
+        .with_flex_child(
             Flex::row()
-                .with_child(ColorWell::new(false).padding(10.).with_id(id_two), 1.)
-                .with_child(
-                    Button::<OurData>::new("freeze", move |ctx, data, _env| {
-                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_two)
-                    })
-                    .padding(10.0),
-                    0.5,
-                )
-                .with_child(
-                    Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
-                        ctx.submit_command(UNFREEZE_COLOR, id_two)
-                    })
-                    .padding(10.0),
-                    0.5,
-                ),
+                .cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_flex_child(ColorWell::new(false).with_id(id_two), 1.)
+                .with_spacer(10.0)
+                .with_child(Button::<OurData>::new("freeze", move |ctx, data, _env| {
+                    ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_two)
+                }))
+                .with_spacer(10.0)
+                .with_child(Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
+                    ctx.submit_command(UNFREEZE_COLOR, id_two)
+                })),
             0.5,
         )
-        .with_child(
+        .with_spacer(10.0)
+        .with_flex_child(
             Flex::row()
-                .with_child(ColorWell::new(false).padding(10.0).with_id(id_three), 1.)
-                .with_child(
-                    Button::<OurData>::new("freeze", move |ctx, data, _env| {
-                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_three)
-                    })
-                    .padding(10.0),
-                    0.5,
-                )
-                .with_child(
-                    Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
-                        ctx.submit_command(UNFREEZE_COLOR, id_three)
-                    })
-                    .padding(10.0),
-                    0.5,
-                ),
+                .cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_flex_child(ColorWell::new(false).with_id(id_three), 1.)
+                .with_spacer(10.0)
+                .with_child(Button::<OurData>::new("freeze", move |ctx, data, _env| {
+                    ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_three)
+                }))
+                .with_spacer(10.0)
+                .with_child(Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
+                    ctx.submit_command(UNFREEZE_COLOR, id_three)
+                })),
             0.5,
         )
+        .padding(10.)
 }

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -28,7 +28,7 @@ fn main() {
 fn main() {
     use druid::{
         widget::{FillStrat, Flex, Image, ImageData, WidgetExt},
-        AppLauncher, Widget, WindowDesc,
+        AppLauncher, Color, Widget, WindowDesc,
     };
 
     fn ui_builder() -> impl Widget<u32> {
@@ -36,7 +36,13 @@ fn main() {
 
         let mut col = Flex::column();
 
-        col.add_child(Image::new(png_data.clone()).fix_width(100.0).center(), 1.0);
+        col.add_flex_child(
+            Image::new(png_data.clone())
+                .border(Color::WHITE, 1.0)
+                .fix_width(100.0)
+                .center(),
+            1.0,
+        );
 
         /*
         // If you want to change the fill stratagy you can but you need the widget to be mut
@@ -44,8 +50,10 @@ fn main() {
         otherimage.set_fill(FillStrat::FitWidth);
         */
 
-        let otherimage = Image::new(png_data).fill_mode(FillStrat::FitWidth);
-        col.add_child(otherimage, 1.0);
+        let otherimage = Image::new(png_data)
+            .fill_mode(FillStrat::FitWidth)
+            .border(Color::WHITE, 1.0);
+        col.add_flex_child(otherimage, 1.0);
         col
     };
 

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -14,7 +14,7 @@
 
 //! This example shows how to construct a basic layout.
 
-use druid::widget::{Button, Flex, Label, SizedBox, WidgetExt};
+use druid::widget::{Button, Flex, Label, WidgetExt};
 use druid::{AppLauncher, Color, LocalizedString, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
@@ -25,28 +25,30 @@ fn build_app() -> impl Widget<u32> {
     let mut header = Flex::row();
     header.add_child(
         Label::new("One")
-            .center()
             .fix_width(60.0)
             .background(Color::rgb8(0x77, 0x77, 0))
-            .border(Color::WHITE, 3.0),
-        0.0,
+            .border(Color::WHITE, 3.0)
+            .center(),
     );
     // Spacing element that will fill all available space in between label
     // and a button. Notice that weight is non-zero.
-    header.add_child(SizedBox::empty().expand(), 1.0);
-    header.add_child(Button::new("Two", Button::noop).padding(20.), 0.0);
+    header.add_flex_spacer(1.0);
+    header.add_child(Button::new("Two", Button::noop).padding(20.));
     col.add_child(
         header
             .fix_height(100.0)
             .background(Color::rgb8(0, 0x77, 0x88)),
-        0.0,
     );
 
     for i in 0..5 {
         // Give a larger weight to one of the buttons for it to
         // occupy more space.
         let weight = if i == 2 { 3.0 } else { 1.0 };
-        col.add_child(Button::new(format!("Button #{}", i), Button::noop), weight);
+        // call `expand_height` to force the buttons to use all their provided flex
+        col.add_flex_child(
+            Button::new(format!("Button #{}", i), Button::noop).expand_height(),
+            weight,
+        );
     }
 
     col.debug_paint_layout()

--- a/druid/examples/lens.rs
+++ b/druid/examples/lens.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 use druid::widget::Slider;
-use druid::widget::{Flex, TextBox, WidgetExt};
-use druid::{AppLauncher, Data, Lens, LocalizedString, Widget, WindowDesc};
+use druid::widget::{CrossAxisAlignment, Flex, Label, TextBox, WidgetExt};
+use druid::{AppLauncher, Data, Env, Lens, LocalizedString, Widget, WindowDesc};
 
 fn main() {
     let main_window = WindowDesc::new(ui_builder)
         .title(LocalizedString::new("lens-demo-window-title").with_placeholder("Lens Demo"));
     let data = MyComplexState {
-        term: String::new(),
+        term: "hello".into(),
         scale: 0.0,
     };
 
@@ -45,7 +45,18 @@ fn ui_builder() -> impl Widget<MyComplexState> {
     // via `.lens` we get it to be of type `Widget<MyComplexState>`
     let slider = Slider::new().lens(MyComplexState::scale);
 
+    let label = Label::new(|d: &MyComplexState, _: &Env| format!("{}: {:.2}", d.term, d.scale));
+
     Flex::column()
-        .with_child(searchbar.padding(32.0), 1.0)
-        .with_child(slider.padding(32.0), 1.0)
+        .cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(label)
+        .with_spacer(8.0)
+        .with_child(
+            Flex::row()
+                .cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(searchbar)
+                .with_spacer(8.0)
+                .with_child(slider),
+        )
+        .center()
 }

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -55,7 +55,7 @@ fn ui_builder() -> impl Widget<AppData> {
             Arc::make_mut(&mut data.right).push(value as u32);
         })
         .fix_height(30.0)
-        .expand_width()
+        .expand_width(),
     );
 
     let mut lists = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use druid::lens::{self, LensExt};
-use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll, SizedBox, WidgetExt};
+use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll, WidgetExt};
 use druid::{AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
@@ -55,14 +55,13 @@ fn ui_builder() -> impl Widget<AppData> {
             Arc::make_mut(&mut data.right).push(value as u32);
         })
         .fix_height(30.0)
-        .expand_width(),
-        0.0,
+        .expand_width()
     );
 
     let mut lists = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);
 
     // Build a simple list
-    lists.add_child(
+    lists.add_flex_child(
         Scroll::new(List::new(|| {
             Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
                 .align_vertical(UnitPoint::LEFT)
@@ -77,7 +76,7 @@ fn ui_builder() -> impl Widget<AppData> {
     );
 
     // Build a list with shared data
-    lists.add_child(
+    lists.add_flex_child(
         Scroll::new(List::new(|| {
             Flex::row()
                 .with_child(
@@ -85,9 +84,8 @@ fn ui_builder() -> impl Widget<AppData> {
                         format!("List item #{}", item)
                     })
                     .align_vertical(UnitPoint::LEFT),
-                    0.0,
                 )
-                .with_child(SizedBox::empty(), 1.0)
+                .with_flex_spacer(1.0)
                 .with_child(
                     Button::new(
                         "Delete",
@@ -99,7 +97,6 @@ fn ui_builder() -> impl Widget<AppData> {
                     )
                     .fix_size(80.0, 20.0)
                     .align_vertical(UnitPoint::CENTER),
-                    0.0,
                 )
                 .padding(10.0)
                 .background(Color::rgb(0.5, 0.0, 0.5))
@@ -117,7 +114,7 @@ fn ui_builder() -> impl Widget<AppData> {
         1.0,
     );
 
-    root.add_child(lists, 1.0);
+    root.add_flex_child(lists, 1.0);
 
     // Mark the widget as needing its layout rects painted
     root.debug_paint_layout()

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -73,11 +73,11 @@ fn ui_builder() -> impl Widget<State> {
     });
 
     let mut col = Flex::column();
-    col.add_child(Align::centered(Padding::new(5.0, label)), 1.0);
+    col.add_flex_child(Align::centered(Padding::new(5.0, label)), 1.0);
     let mut row = Flex::row();
-    row.add_child(Padding::new(5.0, inc_button), 1.0);
-    row.add_child(Padding::new(5.0, dec_button), 1.0);
-    col.add_child(row, 1.0);
+    row.add_child(Padding::new(5.0, inc_button));
+    row.add_child(Padding::new(5.0, dec_button));
+    col.add_flex_child(Align::centered(row), 1.0);
     col
 }
 

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -50,16 +50,16 @@ fn build_app() -> impl Widget<()> {
     });
 
     Flex::column()
-        .with_child(
+        .with_flex_child(
             Flex::row()
-                .with_child(
+                .with_flex_child(
                     Label::new("top left")
                         .center()
                         .border(DARK_GREY, 4.0)
                         .padding(10.0),
                     1.0,
                 )
-                .with_child(
+                .with_flex_child(
                     Label::new("top right")
                         .center()
                         .background(DARK_GREY)
@@ -68,9 +68,9 @@ fn build_app() -> impl Widget<()> {
                 ),
             1.0,
         )
-        .with_child(
+        .with_flex_child(
             Flex::row()
-                .with_child(
+                .with_flex_child(
                     Label::new("bottom left")
                         .center()
                         .background(gradient)
@@ -78,7 +78,7 @@ fn build_app() -> impl Widget<()> {
                         .padding(10.0),
                     1.0,
                 )
-                .with_child(
+                .with_flex_child(
                     Label::new("bottom right")
                         .center()
                         .border(LIGHTER_GREY, 4.0)

--- a/druid/examples/parse.rs
+++ b/druid/examples/parse.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::widget::{Align, Flex, Label, Padding, Parse, TextBox};
+use druid::widget::{Align, Flex, Label, Parse, TextBox};
 use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
 
 fn main() {
@@ -33,7 +33,8 @@ fn ui_builder() -> impl Widget<Option<u32>> {
     let input = Parse::new(TextBox::new());
 
     let mut col = Flex::column();
-    col.add_child(Align::centered(Padding::new(5.0, label)), 1.0);
-    col.add_child(Padding::new(5.0, input), 1.0);
-    col
+    col.add_child(label);
+    col.add_spacer(8.0);
+    col.add_child(input);
+    Align::centered(col)
 }

--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -36,7 +36,7 @@ fn main() {
 fn build_widget() -> impl Widget<u32> {
     let mut col = Flex::column();
     for i in 0..30 {
-        col.add_child(Padding::new(3.0, OverPainter(i)), 0.0);
+        col.add_child(Padding::new(3.0, OverPainter(i)));
     }
     Scroll::new(col)
 }

--- a/druid/examples/scroll_colors.rs
+++ b/druid/examples/scroll_colors.rs
@@ -32,11 +32,10 @@ fn build_app() -> impl Widget<u32> {
             row.add_child(
                 Container::new(SizedBox::empty().width(200.0).height(200.0))
                     .background(Color::rgb(1.0 * col_progress, 1.0 * row_progress, 1.0)),
-                0.0,
             );
         }
 
-        col.add_child(row, 0.0);
+        col.add_child(row);
     }
 
     Scroll::new(col)

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -14,7 +14,7 @@
 
 //! Example of dynamic text styling
 
-use druid::widget::{Flex, Label, Painter, Parse, Stepper, TextBox, WidgetExt};
+use druid::widget::{Flex, Label, MainAxisAlignment, Painter, Parse, Stepper, TextBox, WidgetExt};
 use druid::{
     theme, AppLauncher, Color, Data, Key, Lens, LensExt, LensWrap, LocalizedString, PlatformError,
     RenderContext, Widget, WindowDesc,
@@ -89,15 +89,17 @@ fn ui_builder() -> impl Widget<AppData> {
         AppData::size.map(|x| Some(*x), |x, y| *x = y.unwrap_or(24.0)),
     );
 
-    let stepper_row = Flex::row()
-        .with_child(stepper_textbox, 0.0)
-        .with_child(stepper, 0.0);
+    let stepper_row = Flex::row().with_child(stepper_textbox).with_child(stepper);
 
     let input = TextBox::new().fix_width(200.0).lens(AppData::text);
 
     Flex::column()
-        .with_child(label.center(), 1.0)
-        .with_child(styled_label.center(), 1.0)
-        .with_child(stepper_row.center(), 1.0)
-        .with_child(input.padding(5.0).center(), 1.0)
+        .main_axis_alignment(MainAxisAlignment::Center)
+        .with_child(label)
+        .with_spacer(8.0)
+        .with_child(styled_label)
+        .with_spacer(32.0)
+        .with_child(stepper_row)
+        .with_spacer(8.0)
+        .with_child(input.padding(5.0))
 }

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -52,9 +52,9 @@ fn main() {
 
         let mut col = Flex::column();
 
-        col.add_child(Svg::new(tiger_svg.clone()).fix_width(100.0).center(), 1.0);
-        col.add_child(Svg::new(tiger_svg.clone()).fill_mode(FillStrat::Fill), 1.0);
-        col.add_child(Svg::new(tiger_svg), 1.0);
-        col
+        col.add_flex_child(Svg::new(tiger_svg.clone()).fix_width(60.0).center(), 1.0);
+        col.add_flex_child(Svg::new(tiger_svg.clone()).fill_mode(FillStrat::Fill), 1.0);
+        col.add_flex_child(Svg::new(tiger_svg), 1.0);
+        col.debug_paint_layout()
     }
 }

--- a/druid/examples/switch.rs
+++ b/druid/examples/switch.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::widget::{Flex, Label, Padding, Parse, Stepper, Switch, TextBox, WidgetExt};
+use druid::widget::{
+    Flex, Label, MainAxisAlignment, Padding, Parse, Stepper, Switch, TextBox, WidgetExt,
+};
 use druid::{AppLauncher, Data, Lens, LensExt, LensWrap, LocalizedString, Widget, WindowDesc};
 
 #[derive(Clone, Data, Lens)]
@@ -27,8 +29,8 @@ fn build_widget() -> impl Widget<DemoState> {
     let switch = LensWrap::new(Switch::new(), DemoState::value);
     let switch_label = Label::new("Setting label");
 
-    row.add_child(Padding::new(5.0, switch_label), 0.0);
-    row.add_child(Padding::new(5.0, switch), 0.0);
+    row.add_child(Padding::new(5.0, switch_label));
+    row.add_child(Padding::new(5.0, switch));
 
     let stepper = LensWrap::new(
         Stepper::new()
@@ -43,8 +45,8 @@ fn build_widget() -> impl Widget<DemoState> {
         Parse::new(TextBox::new()),
         DemoState::stepper_value.map(|x| Some(*x), |x, y| *x = y.unwrap_or(0.0)),
     );
-    textbox_row.add_child(Padding::new(5.0, textbox), 0.0);
-    textbox_row.add_child(Padding::new(5.0, stepper.center()), 0.0);
+    textbox_row.add_child(Padding::new(5.0, textbox));
+    textbox_row.add_child(Padding::new(5.0, stepper.center()));
 
     let mut label_row = Flex::row();
 
@@ -52,12 +54,13 @@ fn build_widget() -> impl Widget<DemoState> {
         format!("Stepper value: {0:.2}", data.stepper_value)
     });
 
-    label_row.add_child(Padding::new(5.0, label), 0.0);
+    label_row.add_child(Padding::new(5.0, label));
 
-    col.add_child(Padding::new(5.0, row), 1.0);
-    col.add_child(Padding::new(5.0, textbox_row), 0.0);
-    col.add_child(Padding::new(5.0, label_row), 1.0);
-    col.debug_paint_layout()
+    col.set_main_axis_alignment(MainAxisAlignment::Center);
+    col.add_child(Padding::new(5.0, row));
+    col.add_child(Padding::new(5.0, textbox_row));
+    col.add_child(Padding::new(5.0, label_row));
+    col.center()
 }
 
 fn main() {

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -40,15 +40,14 @@ fn make_ui() -> impl Widget<AppState> {
     switcher_column.add_child(
         Label::new(|data: &u32, _env: &Env| format!("Current view: {}", data))
             .lens(AppState::current_view),
-        0.0,
     );
     for i in 0..6 {
+        switcher_column.add_spacer(80.);
         switcher_column.add_child(
             Button::<u32>::new(format!("View {}", i), move |_event, data, _env| {
                 *data = i;
             })
             .lens(AppState::current_view),
-            0.0,
         );
     }
 
@@ -67,15 +66,15 @@ fn make_ui() -> impl Widget<AppState> {
             )),
             3 => Box::new(
                 Flex::column()
-                    .with_child(Label::new("Here is a label").center(), 1.0)
-                    .with_child(
+                    .with_flex_child(Label::new("Here is a label").center(), 1.0)
+                    .with_flex_child(
                         Button::new("Button", |_event, _data, _env| {
                             println!("Complex button clicked!");
                         }),
                         1.0,
                     )
-                    .with_child(TextBox::new().lens(AppState::current_text), 1.0)
-                    .with_child(
+                    .with_flex_child(TextBox::new().lens(AppState::current_text), 1.0)
+                    .with_flex_child(
                         Label::new(|data: &String, _env: &Env| format!("Value entered: {}", data))
                             .lens(AppState::current_text),
                         1.0,
@@ -93,6 +92,6 @@ fn make_ui() -> impl Widget<AppState> {
     );
 
     Flex::row()
-        .with_child(switcher_column, 0.0)
-        .with_child(view_switcher, 1.0)
+        .with_child(switcher_column)
+        .with_flex_child(view_switcher, 1.0)
 }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -662,9 +662,9 @@ mod tests {
         fn make_widgets() -> impl Widget<Option<u32>> {
             Split::vertical(
                 Flex::<Option<u32>>::row()
-                    .with_child(TextBox::new().with_id(ID_1).parse(), 1.0)
-                    .with_child(TextBox::new().with_id(ID_2).parse(), 1.0)
-                    .with_child(TextBox::new().with_id(ID_3).parse(), 1.0),
+                    .with_child(TextBox::new().with_id(ID_1).parse())
+                    .with_child(TextBox::new().with_id(ID_2).parse())
+                    .with_child(TextBox::new().with_id(ID_3).parse()),
                 Scroll::new(TextBox::new().parse()),
             )
         }

--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -42,7 +42,7 @@
 //!     // ...
 //!
 //!     // We can now use `searchbar` just like any other `Widget<MyState>`
-//!     Flex::column().with_child(searchbar, 1.0)
+//!     Flex::column().with_child(searchbar)
 //! }
 //! ```
 

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -80,9 +80,9 @@
 //!
 //!     // arrange the two widgets vertically, with some padding
 //!     let layout = Flex::column()
-//!         .with_child(label, 0.0)
+//!         .with_child(label)
 //!         .with_spacer(VERTICAL_WIDGET_SPACING)
-//!         .with_child(textbox, 0.0);
+//!         .with_child(textbox);
 //!
 //!     // center the two widgets in the available space
 //!     Align::centered(layout)

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -45,18 +45,18 @@ fn row_column() {
     let (id1, id2, id3, id4, id5, id6) = widget_id6();
     let widget = Flex::row()
         .must_fill_main_axis(true)
-        .with_child(
+        .with_flex_child(
             Flex::column()
-                .with_child(SizedBox::empty().expand().with_id(id1), 1.0)
-                .with_child(SizedBox::empty().expand().with_id(id2), 1.0),
+                .with_flex_child(SizedBox::empty().expand().with_id(id1), 1.0)
+                .with_flex_child(SizedBox::empty().expand().with_id(id2), 1.0),
             1.0,
         )
-        .with_child(
+        .with_flex_child(
             Flex::column()
-                .with_child(SizedBox::empty().expand().with_id(id3), 1.0)
-                .with_child(SizedBox::empty().expand().with_id(id4), 1.0)
-                .with_child(SizedBox::empty().expand().with_id(id5), 1.0)
-                .with_child(SizedBox::empty().expand().with_id(id6), 1.0)
+                .with_flex_child(SizedBox::empty().expand().with_id(id3), 1.0)
+                .with_flex_child(SizedBox::empty().expand().with_id(id4), 1.0)
+                .with_flex_child(SizedBox::empty().expand().with_id(id5), 1.0)
+                .with_flex_child(SizedBox::empty().expand().with_id(id6), 1.0)
                 .expand_width(),
             1.0,
         );
@@ -126,7 +126,7 @@ fn flex_paint_rect_overflow() {
     let id = WidgetId::next();
 
     let widget = Flex::row()
-        .with_child(
+        .with_flex_child(
             ModularWidget::new(())
                 .layout_fn(|_, ctx, bc, _, _| {
                     ctx.set_paint_insets(Insets::new(20., 0., 0., 0.));
@@ -135,7 +135,7 @@ fn flex_paint_rect_overflow() {
                 .expand(),
             1.0,
         )
-        .with_child(
+        .with_flex_child(
             ModularWidget::new(())
                 .layout_fn(|_, ctx, bc, _, _| {
                     ctx.set_paint_insets(Insets::new(0., 20., 0., 0.));
@@ -144,7 +144,7 @@ fn flex_paint_rect_overflow() {
                 .expand(),
             1.0,
         )
-        .with_child(
+        .with_flex_child(
             ModularWidget::new(())
                 .layout_fn(|_, ctx, bc, _, _| {
                     ctx.set_paint_insets(Insets::new(0., 0., 0., 20.));
@@ -153,7 +153,7 @@ fn flex_paint_rect_overflow() {
                 .expand(),
             1.0,
         )
-        .with_child(
+        .with_flex_child(
             ModularWidget::new(())
                 .layout_fn(|_, ctx, bc, _, _| {
                     ctx.set_paint_insets(Insets::new(0., 0., 20., 0.));

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -44,6 +44,7 @@ fn simple_layout() {
 fn row_column() {
     let (id1, id2, id3, id4, id5, id6) = widget_id6();
     let widget = Flex::row()
+        .must_fill_main_axis(true)
         .with_child(
             Flex::column()
                 .with_child(SizedBox::empty().expand().with_id(id1), 1.0)

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -230,9 +230,9 @@ fn participate_in_autofocus() {
 
     let widget = Split::vertical(
         Flex::row()
-            .with_child(TextBox::new().with_id(id_1), 1.0)
-            .with_child(TextBox::new().with_id(id_2), 1.0)
-            .with_child(TextBox::new().with_id(id_3), 1.0),
+            .with_flex_child(TextBox::new().with_id(id_1), 1.0)
+            .with_flex_child(TextBox::new().with_id(id_2), 1.0)
+            .with_flex_child(TextBox::new().with_id(id_3), 1.0),
         replacer,
     );
 

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -71,7 +71,7 @@ use crate::{
 /// let my_row = Flex::row()
 ///     .cross_axis_alignment(CrossAxisAlignment::Center)
 ///     .must_fill_main_axis(true)
-///     .with_child(Label::new("hello"), 0.0)
+///     .with_child(Label::new("hello"))
 ///     .with_spacer(8.0)
 ///     .with_flex_child(Slider::new(), 1.0);
 /// ```
@@ -84,7 +84,7 @@ use crate::{
 /// let mut my_row = Flex::row();
 /// my_row.set_must_fill_main_axis(true);
 /// my_row.set_cross_axis_alignment(CrossAxisAlignment::Center);
-/// my_row.add_child(Label::new("hello"), 0.0);
+/// my_row.add_child(Label::new("hello"));
 /// my_row.add_spacer(8.0);
 /// my_row.add_flex_child(Slider::new(), 1.0);
 /// ```
@@ -338,8 +338,8 @@ impl<T: Data> Flex<T> {
     /// Builder-style variant of `add_child`.
     ///
     /// Convenient for assembling a group of widgets in a single expression.
-    pub fn with_child(mut self, child: impl Widget<T> + 'static, flex: f64) -> Self {
-        self.add_flex_child(child, flex);
+    pub fn with_child(mut self, child: impl Widget<T> + 'static) -> Self {
+        self.add_flex_child(child, 0.0);
         self
     }
 
@@ -378,10 +378,6 @@ impl<T: Data> Flex<T> {
     }
 
     /// Builder-style method for adding a `flex` spacer to the container.
-    ///
-    /// See [`add_child`] for an overview of `flex`.
-    ///
-    /// [`add_child`]: #method.add_child
     pub fn with_flex_spacer(mut self, flex: f64) -> Self {
         self.add_flex_spacer(flex);
         self
@@ -407,20 +403,13 @@ impl<T: Data> Flex<T> {
         self.fill_major_axis = fill;
     }
 
-    /// Add a child widget.
+    /// Add a non-flex child widget.
     ///
-    /// If `flex` is zero, then the child is non-flex. It is given the same
-    /// constraints on the "minor axis" as its parent, but unconstrained on the
-    /// "major axis".
+    /// See also [`with_child`].
     ///
-    /// If `flex` is non-zero, then all the space left over after layout of
-    /// the non-flex children is divided up, in proportion to the `flex` value,
-    /// among the flex children.
-    ///
-    /// See also `with_child`.
-    //TODO: make this fn not take `flex`; I just don't want to break api yet.
-    pub fn add_child(&mut self, child: impl Widget<T> + 'static, flex: f64) {
-        self.add_flex_child(child, flex);
+    /// [`with_child`]: #method.with_child
+    pub fn add_child(&mut self, child: impl Widget<T> + 'static) {
+        self.add_flex_child(child, 0.0);
     }
 
     /// Add a flexible child widget.
@@ -461,12 +450,12 @@ impl<T: Data> Flex<T> {
     }
 
     /// Add an empty spacer widget with a specific `flex` factor.
-    ///
-    /// See [`add_child`] for an overview of `flex`.
-    ///
-    /// [`add_child`]: #method.add_child
     pub fn add_flex_spacer(&mut self, flex: f64) {
-        self.add_flex_child(SizedBox::empty(), flex);
+        let child = match self.direction {
+            Axis::Vertical => SizedBox::empty().expand_height(),
+            Axis::Horizontal => SizedBox::empty().expand_width(),
+        };
+        self.add_flex_child(child, flex);
     }
 }
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -60,7 +60,7 @@ pub use container::Container;
 pub use controller::{Controller, ControllerHost};
 pub use either::Either;
 pub use env_scope::EnvScope;
-pub use flex::{CrossAxisAlignment, Flex, MainAxisAlignment};
+pub use flex::{CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
 pub use label::{Label, LabelText};
 pub use list::{List, ListIter};

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -34,7 +34,7 @@ impl RadioGroup {
         let mut col = Flex::column();
         for (label, variant) in variants.into_iter() {
             let radio = Radio::new(label, variant);
-            col.add_child(Padding::new(5.0, radio), 0.0);
+            col.add_child(Padding::new(5.0, radio));
         }
         col
     }


### PR DESCRIPTION
This is a different way of doing flex params, described in #687. This includes changing all examples to the new api.

The tldr:
- add_child/with_child no longer takes the flex factor
- add_flex_child & with_flex_child takes `FlexParams`
- `f64` has `impl Into<FlexParams>`, so you can still just pass value
- flex is loose by default, and you need to explicitly expand to fill the space
- strictly more layouts are possible!
- there are *gasp* docs!

I'm fairly confident that this is the  correct direction, but welcome all input.


This  includes a commit from #687, supersedes #639  and closes #607.


cc @futurepaul 
