### PR TITLE
Derive Eq for WidgetId

### DIFF
--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -118,7 +118,7 @@ use crate::{
 /// [`WidgetExt::with_id`]: ../trait.WidgetExt.html#tymethod.with_id
 /// [`IdentityWrapper`]: struct.IdentityWrapper.html
 // this is NonZeroU64 because we regularly store Option<WidgetId>
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct WidgetId(NonZeroU64);
 
 /// The trait implemented by all widgets.


### PR DESCRIPTION
This allows WidgetId to be used as a key for HashMap, for example.

Because WidgetId is basically a NonZeroU64, there's no obvious reason
on why WidgetId should not implement Eq.