### PR TITLE
Automatically capture mouse on windows on mouse down

### DIFF
--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -275,7 +275,12 @@ impl WndState {
         self.captured_mouse_buttons &= !(1 << (button as u32));
         if self.captured_mouse_buttons == 0 {
             unsafe {
-                ReleaseCapture();
+                if ReleaseCapture() == FALSE {
+                    warn!(
+                        "failed to release mouse capture: {}",
+                        Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                    );
+                }
             }
         }
     }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -695,8 +695,6 @@ impl WndProc for MyWndProc {
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let s = s.as_mut().unwrap();
                     s.captured_mouse_buttons = 0;
-                } else {
-                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                 }
                 Some(0)
             }


### PR DESCRIPTION
This pull requests adds functionality on windows to automatically capture mouse when the first mouse button down event is received, and holds the capture until the last mouse button is released, as proposed by @raphlinus  in #457. This seemed like the best solution, since the standard behavior on Cocoa is to capture all mouse buttons.

Note that there is one windows specific edge case that still needs to be handled by the app, which is dealing with another app stealing mouse capture. Ideally we should expose this event outside of druid-shell to allow the app to do similar processing to mouse up, for example releasing the scroll bar.