### PR TITLE
Rename Stepper builder methods

### DIFF
--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -222,9 +222,8 @@ fn make_spacer_select() -> impl Widget<Params> {
                 )
                 .with_child(
                     Stepper::new()
-                        .max(50.0)
-                        .min(2.0)
-                        .step(2.0)
+                        .with_range(2.0, 50.0)
+                        .with_step(2.0)
                         .lens(Params::spacer_size),
                     0.0,
                 )
@@ -277,9 +276,8 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
     space_if_needed(&mut flex, state);
     flex.add_child(
         Stepper::new()
-            .min(0.0)
-            .max(1.0)
-            .step(0.1)
+            .with_range(0.0, 1.0)
+            .with_step(0.1)
             .lens(DemoState::volume),
         0.0,
     );

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -64,10 +64,9 @@ fn ui_builder() -> impl Widget<AppData> {
             });
 
     let stepper = Stepper::new()
-        .max(100.0)
-        .min(0.0)
-        .step(1.0)
-        .wrap(false)
+        .with_range(0.0, 100.0)
+        .with_step(1.0)
+        .with_wrap(false)
         .lens(AppData::size);
 
     let stepper_textbox = LensWrap::new(

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -66,7 +66,7 @@ fn ui_builder() -> impl Widget<AppData> {
     let stepper = Stepper::new()
         .with_range(0.0, 100.0)
         .with_step(1.0)
-        .with_wrap(false)
+        .with_wraparound(false)
         .lens(AppData::size);
 
     let stepper_textbox = LensWrap::new(

--- a/druid/examples/switch.rs
+++ b/druid/examples/switch.rs
@@ -34,7 +34,7 @@ fn build_widget() -> impl Widget<DemoState> {
         Stepper::new()
             .with_range(0.0, 10.0)
             .with_step(0.5)
-            .with_wrap(false),
+            .with_wraparound(false),
         DemoState::stepper_value,
     );
 

--- a/druid/examples/switch.rs
+++ b/druid/examples/switch.rs
@@ -31,7 +31,10 @@ fn build_widget() -> impl Widget<DemoState> {
     row.add_child(Padding::new(5.0, switch), 0.0);
 
     let stepper = LensWrap::new(
-        Stepper::new().max(10.0).min(0.0).step(0.5).wrap(false),
+        Stepper::new()
+            .with_range(0.0, 10.0)
+            .with_step(0.5)
+            .with_wrap(false),
         DemoState::stepper_value,
     );
 

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -77,7 +77,7 @@ impl Stepper {
     /// Set whether the stepper should wrap around the minimum/maximum values.
     ///
     /// The default is no wrap
-    pub fn with_wrap(mut self, wrap: bool) -> Self {
+    pub fn with_wraparound(mut self, wrap: bool) -> Self {
         self.wrap = wrap;
         self
     }

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -57,26 +57,27 @@ impl Stepper {
         }
     }
 
-    /// Set the stepper's maximum value.
-    pub fn max(mut self, max: f64) -> Self {
+    /// Set the range covered by this slider.
+    ///
+    /// The default range is `std::f64::MIN..std::f64::MAX`.
+    pub fn with_range(mut self, min: f64, max: f64) -> Self {
+        self.min = min;
         self.max = max;
         self
     }
 
-    /// Set the stepper's minimum value.
-    pub fn min(mut self, min: f64) -> Self {
-        self.min = min;
-        self
-    }
-
     /// Set the steppers amount by which the value increases or decreases.
-    pub fn step(mut self, step: f64) -> Self {
+    ///
+    /// The default step is 1.0
+    pub fn with_step(mut self, step: f64) -> Self {
         self.step = step;
         self
     }
 
     /// Set whether the stepper should wrap around the minimum/maximum values.
-    pub fn wrap(mut self, wrap: bool) -> Self {
+    ///
+    /// The default is no wrap
+    pub fn with_wrap(mut self, wrap: bool) -> Self {
         self.wrap = wrap;
         self
     }

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -68,7 +68,7 @@ impl Stepper {
 
     /// Set the steppers amount by which the value increases or decreases.
     ///
-    /// The default step is 1.0
+    /// The default step is `1.0`.
     pub fn with_step(mut self, step: f64) -> Self {
         self.step = step;
         self
@@ -76,7 +76,7 @@ impl Stepper {
 
     /// Set whether the stepper should wrap around the minimum/maximum values.
     ///
-    /// The default is no wrap
+    /// The default is `false`.
     pub fn with_wraparound(mut self, wrap: bool) -> Self {
         self.wrap = wrap;
         self


### PR DESCRIPTION
This fuses `Stepper::min` and `Stepper::max` to `Stepper::with_range` and renames `Stepper::step` as well as `Stepper::wrap` to `Stepper::with_step` and `Stepper::with_wrap` respectively.

Closes #684 