### PR TITLE
Allow setting minimum window size

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -86,6 +86,7 @@ pub struct WindowBuilder {
     title: String,
     menu: Option<Menu>,
     size: Size,
+    min_size: Option<Size>,
     resizable: bool,
     show_titlebar: bool,
 }
@@ -116,6 +117,7 @@ impl WindowBuilder {
             title: String::new(),
             menu: None,
             size: Size::new(500.0, 400.0),
+            min_size: None,
             resizable: true,
             show_titlebar: true,
         }
@@ -127,6 +129,10 @@ impl WindowBuilder {
 
     pub fn set_size(&mut self, size: Size) {
         self.size = size;
+    }
+
+    pub fn set_min_size(&mut self, size: Size) {
+        self.min_size = Some(size);
     }
 
     pub fn resizable(&mut self, resizable: bool) {
@@ -168,6 +174,13 @@ impl WindowBuilder {
             (self.size.width * dpi_scale) as i32,
             (self.size.height * dpi_scale) as i32,
         );
+
+        if let Some(min_size) = self.min_size {
+            window.set_size_request(
+                (min_size.width * dpi_scale) as i32,
+                (min_size.height * dpi_scale) as i32,
+            );
+        }
 
         let accel_group = AccelGroup::new();
         window.add_accel_group(&accel_group);

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -175,13 +175,6 @@ impl WindowBuilder {
             (self.size.height * dpi_scale) as i32,
         );
 
-        if let Some(min_size) = self.min_size {
-            window.set_size_request(
-                (min_size.width * dpi_scale) as i32,
-                (min_size.height * dpi_scale) as i32,
-            );
-        }
-
         let accel_group = AccelGroup::new();
         window.add_accel_group(&accel_group);
 
@@ -236,6 +229,13 @@ impl WindowBuilder {
 
             Inhibit(true)
         });
+
+        if let Some(min_size) = self.min_size {
+            drawing_area.set_size_request(
+                (min_size.width * dpi_scale) as i32,
+                (min_size.height * dpi_scale) as i32,
+            );
+        }
 
         let last_size = Cell::new((0, 0));
 

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -76,6 +76,7 @@ pub(crate) struct WindowBuilder {
     title: String,
     menu: Option<Menu>,
     size: Size,
+    min_size: Option<Size>,
     resizable: bool,
     show_titlebar: bool,
 }
@@ -107,6 +108,7 @@ impl WindowBuilder {
             title: String::new(),
             menu: None,
             size: Size::new(500.0, 400.0),
+            min_size: None,
             resizable: true,
             show_titlebar: true,
         }
@@ -118,6 +120,11 @@ impl WindowBuilder {
 
     pub fn set_size(&mut self, size: Size) {
         self.size = size;
+    }
+
+    pub fn set_min_size(&mut self, size: Size) {
+        // TODO: Use this in `self.build`
+        self.min_size = Some(size);
     }
 
     pub fn resizable(&mut self, resizable: bool) {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -75,6 +75,7 @@ pub struct WindowBuilder {
     resizable: bool,
     show_titlebar: bool,
     size: Size,
+    min_size: Option<Size>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -706,6 +707,7 @@ impl WindowBuilder {
             show_titlebar: true,
             present_strategy: Default::default(),
             size: Size::new(500.0, 400.0),
+            min_size: None,
         }
     }
 
@@ -716,6 +718,11 @@ impl WindowBuilder {
 
     pub fn set_size(&mut self, size: Size) {
         self.size = size;
+    }
+
+    pub fn set_min_size(&mut self, size: Size) {
+        // TODO: Use this in `self.build`
+        self.min_size = Some(size);
     }
 
     pub fn resizable(&mut self, resizable: bool) {

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -223,6 +223,11 @@ impl WindowBuilder {
         self.0.set_size(size)
     }
 
+    /// Set the window's initial size.
+    pub fn set_min_size(&mut self, size: Size) {
+        self.0.set_min_size(size)
+    }
+
     /// Set whether the window should be resizable
     pub fn resizable(&mut self, resizable: bool) {
         self.0.resizable(resizable)

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -200,9 +200,9 @@ fn build_calc() -> impl Widget<CalcState> {
 }
 
 fn main() {
-    let window = WindowDesc::new(build_calc)
-        .title(LocalizedString::new("calc-demo-window-title").with_placeholder("Simple Calculator"))
-        .with_min_size((250.0, 350.0));
+    let window = WindowDesc::new(build_calc).title(
+        LocalizedString::new("calc-demo-window-title").with_placeholder("Simple Calculator"),
+    );
     let calc_state = CalcState {
         value: "0".to_string(),
         operand: 0.0,

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -200,9 +200,9 @@ fn build_calc() -> impl Widget<CalcState> {
 }
 
 fn main() {
-    let window = WindowDesc::new(build_calc).title(
-        LocalizedString::new("calc-demo-window-title").with_placeholder("Simple Calculator"),
-    );
+    let window = WindowDesc::new(build_calc)
+        .title(LocalizedString::new("calc-demo-window-title").with_placeholder("Simple Calculator"))
+        .with_min_size((250.0, 350.0));
     let calc_state = CalcState {
         value: "0".to_string(),
         operand: 0.0,

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -323,7 +323,8 @@ fn make_ui() -> impl Widget<AppState> {
 
 fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(make_ui)
-        .window_size((600., 600.00))
+        .window_size((620., 265.00))
+        .with_min_size((620., 265.00))
         .title(LocalizedString::new("Flex Container Options"));
 
     let demo_state = DemoState {

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -323,7 +323,7 @@ fn make_ui() -> impl Widget<AppState> {
 
 fn main() -> Result<(), PlatformError> {
     let main_window = WindowDesc::new(make_ui)
-        .window_size((620., 265.00))
+        .window_size((620., 600.00))
         .with_min_size((620., 265.00))
         .title(LocalizedString::new("Flex Container Options"));
 

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -41,6 +41,7 @@ pub struct WindowDesc<T> {
     pub(crate) root: Box<dyn Widget<T>>,
     pub(crate) title: LocalizedString<T>,
     pub(crate) size: Option<Size>,
+    pub(crate) min_size: Option<Size>,
     pub(crate) menu: Option<MenuDesc<T>>,
     pub(crate) resizable: bool,
     pub(crate) show_titlebar: bool,
@@ -145,6 +146,7 @@ impl<T: Data> WindowDesc<T> {
             root: root().boxed(),
             title: LocalizedString::new("app-name"),
             size: None,
+            min_size: None,
             menu: MenuDesc::platform_default(),
             resizable: true,
             show_titlebar: true,
@@ -179,6 +181,14 @@ impl<T: Data> WindowDesc<T> {
         self
     }
 
+    /// Set the minimal window size, similar to [`window_size`]
+    ///
+    /// [`window_size`]: struct.WindowDesc.html#method.window_size
+    pub fn with_min_size(mut self, size: impl Into<Size>) -> Self {
+        self.min_size = Some(size.into());
+        self
+    }
+
     pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
         self
@@ -210,6 +220,9 @@ impl<T: Data> WindowDesc<T> {
         builder.set_handler(Box::new(handler));
         if let Some(size) = self.size {
             builder.set_size(size);
+        }
+        if let Some(min_size) = self.min_size {
+            builder.set_min_size(min_size);
         }
 
         builder.set_title(self.title.localized_str());

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -181,7 +181,9 @@ impl<T: Data> WindowDesc<T> {
         self
     }
 
-    /// Set the minimal window size, similar to [`window_size`]
+    /// Set the minimum window size.
+    ///
+    /// To  set the initial window size, see [`window_size`].
     ///
     /// [`window_size`]: struct.WindowDesc.html#method.window_size
     pub fn with_min_size(mut self, size: impl Into<Size>) -> Self {


### PR DESCRIPTION
This implements setting the minimum window size (#632) **for Linux**.
The minimum size is also passed to the Mac and Windows WindowBuilder but they are not being utilized.

I've added this to the `calc` example and `TODO` tags to the implementation missing places as it was done in #587.