### PR TITLE
Add UnitWrap for easier use of Widget<()>.

### DIFF
--- a/druid/src/lens.rs
+++ b/druid/src/lens.rs
@@ -293,6 +293,75 @@ where
     }
 }
 
+/// A wrapper for widgets that don't use data, i.e. `Widget<()>`.
+///
+/// You can think of it like a [`LensWrap`] with a [`Lens`] that
+/// always focuses to `()` for every source type.
+///
+/// Wrapping such dataless widgets in `UnitWrap` will allow you
+/// to conveniently use them in [`Flex`] layouts for example.
+///
+/// Keep in mind that because the data will always be `()`,
+/// the [`update`] method of the wrapped widget will never be called.
+///
+/// [`LensWrap`]: struct.LensWrap.html
+/// [`Lens`]: trait.Lens.html
+/// [`Flex`]: ../widget/struct.Flex.html
+/// [`update`]: ../widget/trait.Widget.html#tymethod.update
+pub struct UnitWrap<W>
+where
+    W: Widget<()>,
+{
+    inner: W,
+}
+
+impl<W> UnitWrap<W>
+where
+    W: Widget<()>,
+{
+    /// Wrap a `Widget<()>` with a `UnitWrap` for use in cases
+    /// where `Widget<T: Data>` for any value of `T` can be used.
+    pub fn new(inner: W) -> UnitWrap<W> {
+        UnitWrap { inner }
+    }
+}
+
+impl<T, W> Widget<T> for UnitWrap<W>
+where
+    T: Data,
+    W: Widget<()>,
+{
+    #[inline]
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, env: &Env) {
+        self.inner.event(ctx, event, &mut (), env);
+    }
+
+    #[inline]
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &T, env: &Env) {
+        self.inner.lifecycle(ctx, event, &(), env);
+    }
+
+    #[inline]
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &T, _data: &T, _env: &Env) {
+        // The inner Widget data is always `()` and will never change.
+    }
+
+    #[inline]
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
+        self.inner.layout(ctx, bc, &(), env)
+    }
+
+    #[inline]
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
+        self.inner.paint(ctx, &(), env);
+    }
+
+    #[inline]
+    fn id(&self) -> Option<WidgetId> {
+        self.inner.id()
+    }
+}
+
 /// Lens accessing a member of some type using accessor functions
 ///
 /// See also the `lens` macro.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -150,7 +150,7 @@ pub use data::Data;
 pub use env::{Env, Key, KeyOrValue, Value, ValueType};
 pub use event::{Event, LifeCycle, WheelEvent};
 pub use ext_event::{ExtEventError, ExtEventSink};
-pub use lens::{Lens, LensExt, LensWrap};
+pub use lens::{Lens, LensExt, LensWrap, UnitWrap};
 pub use localization::LocalizedString;
 pub use menu::{sys as platform_menus, ContextMenu, MenuDesc, MenuItem};
 pub use mouse::MouseEvent;

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -18,7 +18,7 @@ use super::{
     Align, BackgroundBrush, Container, Controller, ControllerHost, EnvScope, IdentityWrapper,
     Padding, Parse, SizedBox, WidgetId,
 };
-use crate::{Color, Data, Env, Insets, KeyOrValue, Lens, LensWrap, UnitPoint, Widget};
+use crate::{Color, Data, Env, Insets, KeyOrValue, Lens, LensWrap, UnitPoint, UnitWrap, Widget};
 
 /// A trait that provides extra methods for combining `Widget`s.
 pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
@@ -178,10 +178,20 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// Wrap this widget in a [`LensWrap`] widget for the provided [`Lens`].
     ///
     ///
-    /// [`LensWrap`]: ../struct.LensWrap.html
-    /// [`Lens`]: ../trait.Lens.html
+    /// [`LensWrap`]: ../lens/struct.LensWrap.html
+    /// [`Lens`]: ../lens/trait.Lens.html
     fn lens<S: Data, L: Lens<S, T>>(self, lens: L) -> LensWrap<T, L, Self> {
         LensWrap::new(self, lens)
+    }
+
+    /// Wrap a `Widget<()>` in a [`UnitWrap`] widget.
+    ///
+    /// [`UnitWrap`]: ../lens/struct.UnitWrap.html
+    fn unit(self) -> UnitWrap<Self>
+    where
+        Self: Widget<()>,
+    {
+        UnitWrap::new(self)
     }
 
     /// Parse a `Widget<String>`'s contents


### PR DESCRIPTION
A discussion came up [in zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Lens.20to.20unit.20type) about what the best way to use a `Widget<()>` in a `Flex` layout is. Some [ad hoc solutions](https://gist.github.com/emigr2k1/a687b49e35c95079fb0df3395fa4f121) were tried.

Perhaps there's already an efficient and simple way to do this? If so, then this PR might not be useful but we would like to know how.

Otherwise I cooked up this PR here which adds a new `UnitWrap` type and a corresponding `WidgetExt::unit` method. This makes it easy to use these dataless `Widget<()>` widgets in a `Flex` layout.