### PR TITLE
Redirect vertical scrolling as horizontal scrolling when holding shift

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -346,10 +346,18 @@ impl WindowBuilder {
                 let mut handler = state.handler.borrow_mut();
                 match scroll.get_direction() {
                     ScrollDirection::Up => {
-                        handler.wheel(Vec2::from((0.0, -120.0)), modifiers);
+                        if modifiers.shift {
+                            handler.wheel(Vec2::from((-120.0, 0.0)), modifiers);
+                        } else {
+                            handler.wheel(Vec2::from((0.0, -120.0)), modifiers);
+                        }
                     }
                     ScrollDirection::Down => {
-                        handler.wheel(Vec2::from((0.0, 120.0)), modifiers);
+                        if modifiers.shift {
+                            handler.wheel(Vec2::from((120.0, 0.0)), modifiers);
+                        } else {
+                            handler.wheel(Vec2::from((0.0, 120.0)), modifiers);
+                        }
                     }
                     ScrollDirection::Left => {
                         handler.wheel(Vec2::from((-120.0, 0.0)), modifiers);
@@ -362,6 +370,10 @@ impl WindowBuilder {
                         let (mut delta_x, mut delta_y) = scroll.get_delta();
                         delta_x *= 120.;
                         delta_y *= 120.;
+                        if modifiers.shift {
+                            delta_x += delta_y;
+                            delta_y = 0.;
+                        }
                         handler.wheel(Vec2::from((delta_x, delta_y)), modifiers)
                     }
                     e => {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -537,8 +537,12 @@ impl WndProc for MyWndProc {
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let s = s.as_mut().unwrap();
                     let delta_y = HIWORD(wparam as u32) as i16 as f64;
-                    let delta = Vec2::new(0.0, -delta_y);
                     let mods = get_mod_state();
+                    let delta = if mods.shift {
+                        Vec2::new(-delta_y, 0.)
+                    } else {
+                        Vec2::new(0., -delta_y)
+                    };
                     s.handler.wheel(delta, mods);
                 } else {
                     self.log_dropped_msg(hwnd, msg, wparam, lparam);


### PR DESCRIPTION
Because macOS is apparently a magical place where this is done at the OS level I implemented this feature in `druid-shell` for both GTK and Windows. The Windows patch is very straightforward but GTK has two codepaths for scroll events. The "smooth" scroll path receives data for both axis at once so I wrote it such that when shift is held the two axis are capable of fighting each other as that made the most sense as well as is consistent with the other codepath and Windows patch.

My understanding is that the shift key does not affect trackpad scrolling on macOS but that was not feasible to emulate here. On GTK the "smooth" events are not only used for scrolling but can in some cases be used for mousewheel input (I observed this firsthand on my laptop) and with Windows there only seems to be a single source of scroll data regardless of if it originated from a mousewheel or trackpad.