### PR TITLE
Fix Stepper wraparound and double step

### DIFF
--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -278,6 +278,7 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
         Stepper::new()
             .with_range(0.0, 1.0)
             .with_step(0.1)
+            .with_wraparound(true)
             .lens(DemoState::volume),
         0.0,
     );


### PR DESCRIPTION
- Fixes the stepper wraparound behavior
- Adds wraparound to `flex` example
- Prevents counting double clicks as additional increments

The behavior when wrapping is now the same as in QT