### PR TITLE
Print HRESULT description when formatting Error::Hr

### DIFF
--- a/druid-shell/src/platform/windows/error.rs
+++ b/druid-shell/src/platform/windows/error.rs
@@ -40,6 +40,7 @@ pub enum Error {
     NullHwnd,
 }
 
+#[allow(clippy::crosspointer_transmute)]
 fn hresult_description(hr: HRESULT) -> Option<String> {
     unsafe {
         let mut message_buffer: LPWSTR = std::ptr::null_mut();

--- a/druid-shell/src/platform/windows/error.rs
+++ b/druid-shell/src/platform/windows/error.rs
@@ -17,7 +17,6 @@
 use std::fmt;
 
 use super::util::FromWide;
-use std::mem::transmute;
 use std::ptr::{null, null_mut};
 use winapi::shared::minwindef::{DWORD, HLOCAL};
 use winapi::shared::ntdef::LPWSTR;
@@ -40,7 +39,6 @@ pub enum Error {
     NullHwnd,
 }
 
-#[allow(clippy::crosspointer_transmute)]
 fn hresult_description(hr: HRESULT) -> Option<String> {
     unsafe {
         let mut message_buffer: LPWSTR = std::ptr::null_mut();
@@ -52,7 +50,7 @@ fn hresult_description(hr: HRESULT) -> Option<String> {
             null(),
             hr as DWORD,
             0,
-            transmute(&mut message_buffer as *const LPWSTR),
+            &mut message_buffer as *mut LPWSTR as LPWSTR,
             0,
             null_mut(),
         );

--- a/druid-shell/src/platform/windows/error.rs
+++ b/druid-shell/src/platform/windows/error.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use super::util::FromWide;
 use std::mem::transmute;
 use std::ptr::{null, null_mut};
-use winapi::shared::minwindef::HLOCAL;
+use winapi::shared::minwindef::{DWORD, HLOCAL};
 use winapi::shared::ntdef::LPWSTR;
 use winapi::shared::winerror::HRESULT;
 use winapi::um::winbase::{
@@ -50,7 +50,7 @@ fn hresult_description(hr: HRESULT) -> Option<String> {
                 | FORMAT_MESSAGE_IGNORE_INSERTS
                 | FORMAT_MESSAGE_MAX_WIDTH_MASK,
             null(),
-            hr as u32,
+            hr as DWORD,
             0,
             transmute(&mut message_buffer as *const LPWSTR),
             0,


### PR DESCRIPTION
When implementing error handling for #712 I thought it'd be nice to add some details to the error `HRESULT` error messages instead of just error codes. 

This change adds a short description from the [FormatMessage](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage) windows API when printing an `Error::Hr`, when one is available. 

As an example the following messages:
> failed to set window style. HRESULT 0x80070585
> failed to set window style. HRESULT 0x80070578

are now displayed as: 
> failed to set window style. HRESULT 0x80070585: Invalid index. 
> failed to set window style. HRESULT 0x80070578: Invalid window handle. 
