### PR TITLE
Fix stepper wraparound

### DIFF
--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -278,6 +278,7 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
         Stepper::new()
             .with_range(0.0, 1.0)
             .with_step(0.1)
+            .with_wraparound(true)
             .lens(DemoState::volume),
         0.0,
     );

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -197,11 +197,6 @@ impl Widget<f64> for Stepper {
             Event::MouseDown(mouse) => {
                 ctx.set_active(true);
 
-                // ignore double clicks
-                if mouse.count > 1 {
-                    return;
-                }
-
                 if mouse.pos.y > height / 2. {
                     self.decrease_active = true;
                     self.decrement(data);


### PR DESCRIPTION
- Fixes the stepper wraparound behavior
- Adds wraparound to `flex` example

This is the same as #713 which was reverted with #716 but without the apparently GTK specific double click fix. The behavior will still be broken on GTK but work as expected on Mac and most likely Windows.

The behavior when wrapping is now the same as in QT