### PR TITLE
Update github workflow to checkout v2.

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -14,7 +14,7 @@ jobs:
         run: brew install cairo
 
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: get revisions
         id: get_revs
@@ -28,7 +28,7 @@ jobs:
         if: steps.get_revs.outputs.fetch != ''
 
       - name: checkout base
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: ${{ steps.get_revs.outputs.base }}
 
@@ -58,7 +58,7 @@ jobs:
             target/release/examples/custom_widget
 
       - name: checkout head
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           clean: false # avoid rebuilding artifacts unnecessarily
           ref: ${{ steps.get_revs.outputs.head }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: rustfmt
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -35,7 +35,7 @@ jobs:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo test stable
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install cairo
         run: brew install cairo
@@ -109,7 +109,7 @@ jobs:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo test nightly
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install cairo
         run: brew install cairo
@@ -141,7 +141,7 @@ jobs:
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install cairo
         run: brew install cairo


### PR DESCRIPTION
The github actions script we have uses checkout v1. Apparently that's broken. I ran into the issue in #712 where the tests timed out and I tried to manually re-run the jobs. However manual re-running of jobs doesn't work.

```sh
git checkout --progress --force 1b3971da947c8f67e5dcb2bbc47bd206deaae3c6
##[error]fatal: reference is not a tree: 1b3971da947c8f67e5dcb2bbc47bd206deaae3c6
Removed matchers: 'checkout-git'
##[error]Git checkout failed with exit code: 128
##[error]Exit code 1 returned from process: file name '/home/runner/runners/2.165.2/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
```

This issue is documented in [checkout#23](https://github.com/actions/checkout/issues/23). The issue was closed with a claim that checkout v2 fixes it.

This PR here updates our scripts to use checkout v2.