### PR TITLE
Add Label::dynamic constructor

### DIFF
--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -81,6 +81,31 @@ impl<T: Data> Label<T> {
         }
     }
 
+    /// Construct a new dynamic label.
+    ///
+    /// The contents of this label are generated from the data using a closure.
+    ///
+    /// This is provided as a convenience; a closure can also be passed to [`new`],
+    /// but due to limitations of the implementation of that method, the types in
+    /// the closure need to be annotated, which is not true for this method.
+    ///
+    /// # Examples
+    ///
+    /// The following are equivalent.
+    ///
+    /// ```
+    /// use druid::Env;
+    /// use druid::widget::Label;
+    /// let button1: Label<u32> = Label::new(|data: &u32, _: &Env| format!("total is {}", data));
+    /// let button2: Label<u32> = Label::dynamic(|data, _| format!("total is {}", data));
+    /// ```
+    ///
+    /// [`new`]: #method.new
+    pub fn dynamic(text: impl Fn(&T, &Env) -> String + 'static) -> Self {
+        let text: LabelText<T> = text.into();
+        Label::new(text)
+    }
+
     /// Set a new text.
     ///
     /// Takes an already resolved string as input.


### PR DESCRIPTION
This is just a convenience; because of how type resolution works
with the `Into<LabelText>` paramater, you are forced to always
provide explicit types when creating a label with dynamic text.

This is a papercut, and is particularly annoying when trying to
write sample code.