### PR TITLE
Add rounding to the size given to BoxConstraints::constrain.

### DIFF
--- a/druid/src/box_constraints.rs
+++ b/druid/src/box_constraints.rs
@@ -65,9 +65,14 @@ impl BoxConstraints {
         }
     }
 
-    /// Clamp a given size so that fits within the constraints.
+    /// Clamp a given size so that it fits within the constraints.
+    ///
+    /// The given size is also [rounded away from zero],
+    /// so that the layout is aligned to pixels.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
     pub fn constrain(&self, size: impl Into<Size>) -> Size {
-        size.into().clamp(self.min, self.max)
+        size.into().expand().clamp(self.min, self.max)
     }
 
     /// Returns the max size of these constraints.


### PR DESCRIPTION
This PR is a continuation of the pixel grid work started in #669. Adding `Size::expand` to `BoxConstraints::constrain` seems to go a long way in solving this. It solves the issue for `Label` but also in more subtle places like `Switch` which depend on theme variables by doing things like this:
```rust
let width = env.get(theme::BORDERED_WIDGET_HEIGHT) * SWITCH_WIDTH_RATIO; // 24 * 2.75
```
Doing it in `BoxConstraints::constrain` will also help with custom widgets that users might unknowingly make fractional.

I reviewed all current widgets in druid and this change doesn't seem to have any other effects at this point.