### PR TITLE
Improve Split accuracy.

### DIFF
--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -38,7 +38,7 @@ fn build_app() -> impl Widget<u32> {
                 Align::centered(Label::new("Bottom Split")),
             )
             .split_point(0.4)
-            .splitter_size(7.0),
+            .splitter_size(3.0),
         )
         .border(Color::WHITE, 1.0),
     );
@@ -62,12 +62,14 @@ fn build_app() -> impl Widget<u32> {
             Split::horizontal(
                 Split::horizontal(fixed_vertical, fixed_horizontal)
                     .split_point(0.33)
-                    .splitter_size(5.0)
+                    .splitter_size(3.0)
+                    .min_splitter_area(3.0)
                     .draggable(true),
                 draggable_vertical,
             )
             .split_point(0.75)
             .splitter_size(5.0)
+            .min_splitter_area(11.0)
             .draggable(true),
         )
         .border(Color::WHITE, 1.0),

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -19,10 +19,10 @@ use druid::widget::{Align, Container, Label, Padding, Split};
 use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
-    let fixed_horizontal = Padding::new(
+    let fixed_cols = Padding::new(
         10.0,
         Container::new(
-            Split::horizontal(
+            Split::columns(
                 Align::centered(Label::new("Left Split")),
                 Align::centered(Label::new("Right Split")),
             )
@@ -30,10 +30,10 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    let fixed_vertical = Padding::new(
+    let fixed_rows = Padding::new(
         10.0,
         Container::new(
-            Split::vertical(
+            Split::rows(
                 Align::centered(Label::new("Top Split")),
                 Align::centered(Label::new("Bottom Split")),
             )
@@ -42,10 +42,10 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    let draggable_horizontal = Padding::new(
+    let draggable_cols = Padding::new(
         10.0,
         Container::new(
-            Split::horizontal(
+            Split::columns(
                 Align::centered(Label::new("Split A")),
                 Align::centered(Label::new("Split B")),
             )
@@ -56,16 +56,16 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    let draggable_vertical = Padding::new(
+    let draggable_rows = Padding::new(
         10.0,
         Container::new(
-            Split::vertical(
-                Split::vertical(fixed_horizontal, fixed_vertical)
+            Split::rows(
+                Split::rows(fixed_cols, fixed_rows)
                     .split_point(0.33)
                     .bar_size(3.0)
                     .min_bar_area(3.0)
                     .draggable(true),
-                draggable_horizontal,
+                draggable_cols,
             )
             .split_point(0.75)
             .bar_size(5.0)
@@ -74,7 +74,7 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    draggable_vertical
+    draggable_rows
 }
 
 fn main() {

--- a/druid/examples/split_demo.rs
+++ b/druid/examples/split_demo.rs
@@ -19,10 +19,10 @@ use druid::widget::{Align, Container, Label, Padding, Split};
 use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
 
 fn build_app() -> impl Widget<u32> {
-    let fixed_vertical = Padding::new(
+    let fixed_horizontal = Padding::new(
         10.0,
         Container::new(
-            Split::vertical(
+            Split::horizontal(
                 Align::centered(Label::new("Left Split")),
                 Align::centered(Label::new("Right Split")),
             )
@@ -30,29 +30,15 @@ fn build_app() -> impl Widget<u32> {
         )
         .border(Color::WHITE, 1.0),
     );
-    let fixed_horizontal = Padding::new(
+    let fixed_vertical = Padding::new(
         10.0,
         Container::new(
-            Split::horizontal(
+            Split::vertical(
                 Align::centered(Label::new("Top Split")),
                 Align::centered(Label::new("Bottom Split")),
             )
             .split_point(0.4)
-            .splitter_size(3.0),
-        )
-        .border(Color::WHITE, 1.0),
-    );
-    let draggable_vertical = Padding::new(
-        10.0,
-        Container::new(
-            Split::vertical(
-                Align::centered(Label::new("Split A")),
-                Align::centered(Label::new("Split B")),
-            )
-            .split_point(0.5)
-            .draggable(true)
-            .fill_splitter_handle(true)
-            .min_size(60.0),
+            .bar_size(3.0),
         )
         .border(Color::WHITE, 1.0),
     );
@@ -60,21 +46,35 @@ fn build_app() -> impl Widget<u32> {
         10.0,
         Container::new(
             Split::horizontal(
-                Split::horizontal(fixed_vertical, fixed_horizontal)
+                Align::centered(Label::new("Split A")),
+                Align::centered(Label::new("Split B")),
+            )
+            .split_point(0.5)
+            .draggable(true)
+            .solid_bar(true)
+            .min_size(60.0),
+        )
+        .border(Color::WHITE, 1.0),
+    );
+    let draggable_vertical = Padding::new(
+        10.0,
+        Container::new(
+            Split::vertical(
+                Split::vertical(fixed_horizontal, fixed_vertical)
                     .split_point(0.33)
-                    .splitter_size(3.0)
-                    .min_splitter_area(3.0)
+                    .bar_size(3.0)
+                    .min_bar_area(3.0)
                     .draggable(true),
-                draggable_vertical,
+                draggable_horizontal,
             )
             .split_point(0.75)
-            .splitter_size(5.0)
-            .min_splitter_area(11.0)
+            .bar_size(5.0)
+            .min_bar_area(11.0)
             .draggable(true),
         )
         .border(Color::WHITE, 1.0),
     );
-    draggable_horizontal
+    draggable_vertical
 }
 
 fn main() {

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -83,7 +83,7 @@ fn make_ui() -> impl Widget<AppState> {
                     ),
             ),
             4 => Box::new(
-                Split::vertical(
+                Split::horizontal(
                     Label::new("Left split").center(),
                     Label::new("Right split").center(),
                 )

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -83,7 +83,7 @@ fn make_ui() -> impl Widget<AppState> {
                     ),
             ),
             4 => Box::new(
-                Split::horizontal(
+                Split::columns(
                     Label::new("Left split").center(),
                     Label::new("Right split").center(),
                 )

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -668,7 +668,7 @@ mod tests {
     #[test]
     fn register_children() {
         fn make_widgets() -> impl Widget<Option<u32>> {
-            Split::vertical(
+            Split::horizontal(
                 Flex::<Option<u32>>::row()
                     .with_child(TextBox::new().with_id(ID_1).parse())
                     .with_child(TextBox::new().with_id(ID_2).parse())

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -668,7 +668,7 @@ mod tests {
     #[test]
     fn register_children() {
         fn make_widgets() -> impl Widget<Option<u32>> {
-            Split::horizontal(
+            Split::columns(
                 Flex::<Option<u32>>::row()
                     .with_child(TextBox::new().with_id(ID_1).parse())
                     .with_child(TextBox::new().with_id(ID_2).parse())

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -23,7 +23,7 @@ fn simple_layout() {
 
     let id_1 = WidgetId::next();
 
-    let widget = Split::horizontal(Label::new("hi"), Label::new("there"))
+    let widget = Split::columns(Label::new("hi"), Label::new("there"))
         .fix_size(BOX_WIDTH, BOX_WIDTH)
         .padding(10.0)
         .with_id(id_1)

--- a/druid/src/tests/layout_tests.rs
+++ b/druid/src/tests/layout_tests.rs
@@ -23,7 +23,7 @@ fn simple_layout() {
 
     let id_1 = WidgetId::next();
 
-    let widget = Split::vertical(Label::new("hi"), Label::new("there"))
+    let widget = Split::horizontal(Label::new("hi"), Label::new("there"))
         .fix_size(BOX_WIDTH, BOX_WIDTH)
         .padding(10.0)
         .with_id(id_1)

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -35,7 +35,7 @@ fn propogate_hot() {
     let padding_rec = Recording::default();
     let button_rec = Recording::default();
 
-    let widget = Split::vertical(
+    let widget = Split::horizontal(
         SizedBox::empty().with_id(empty),
         Button::new("hot")
             .record(&button_rec)
@@ -150,7 +150,7 @@ fn take_focus() {
 
     let left = make_focus_taker(left_focus.clone()).with_id(id_1);
     let right = make_focus_taker(right_focus.clone()).with_id(id_2);
-    let app = Split::vertical(left, right).padding(5.0);
+    let app = Split::horizontal(left, right).padding(5.0);
     let data = true;
 
     Harness::create(data, app, |harness| {
@@ -195,10 +195,10 @@ fn adding_child_lifecycle() {
     let record_new_child2 = record_new_child.clone();
 
     let replacer = ReplaceChild::new(TextBox::new(), move || {
-        Split::vertical(TextBox::new(), TextBox::new().record(&record_new_child2))
+        Split::horizontal(TextBox::new(), TextBox::new().record(&record_new_child2))
     });
 
-    let widget = Split::vertical(Label::new("hi").record(&record), replacer);
+    let widget = Split::horizontal(Label::new("hi").record(&record), replacer);
 
     Harness::create(String::new(), widget, |harness| {
         harness.send_initial_events();
@@ -225,10 +225,10 @@ fn participate_in_autofocus() {
     // this widget starts with a single child, and will replace them with a split
     // when we send it a command.
     let replacer = ReplaceChild::new(TextBox::new().with_id(id_4), move || {
-        Split::vertical(TextBox::new().with_id(id_5), TextBox::new().with_id(id_6))
+        Split::horizontal(TextBox::new().with_id(id_5), TextBox::new().with_id(id_6))
     });
 
-    let widget = Split::vertical(
+    let widget = Split::horizontal(
         Flex::row()
             .with_flex_child(TextBox::new().with_id(id_1), 1.0)
             .with_flex_child(TextBox::new().with_id(id_2), 1.0)
@@ -263,7 +263,7 @@ fn participate_in_autofocus() {
 fn child_tracking() {
     let (id_1, id_2, id_3, id_4) = widget_id4();
 
-    let widget = Split::vertical(
+    let widget = Split::horizontal(
         SizedBox::empty().with_id(id_1),
         SizedBox::empty().with_id(id_2),
     )
@@ -293,11 +293,11 @@ fn register_after_adding_child() {
     let id_7 = WidgetId::next();
 
     let replacer = ReplaceChild::new(TextBox::new().with_id(id_1), move || {
-        Split::vertical(TextBox::new().with_id(id_2), TextBox::new().with_id(id_3)).with_id(id_7)
+        Split::horizontal(TextBox::new().with_id(id_2), TextBox::new().with_id(id_3)).with_id(id_7)
     })
     .with_id(id_6);
 
-    let widget = Split::vertical(Label::new("hi").with_id(id_4), replacer).with_id(id_5);
+    let widget = Split::horizontal(Label::new("hi").with_id(id_4), replacer).with_id(id_5);
 
     Harness::create(String::new(), widget, |harness| {
         harness.send_initial_events();

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -35,7 +35,7 @@ fn propogate_hot() {
     let padding_rec = Recording::default();
     let button_rec = Recording::default();
 
-    let widget = Split::horizontal(
+    let widget = Split::columns(
         SizedBox::empty().with_id(empty),
         Button::new("hot")
             .record(&button_rec)
@@ -150,7 +150,7 @@ fn take_focus() {
 
     let left = make_focus_taker(left_focus.clone()).with_id(id_1);
     let right = make_focus_taker(right_focus.clone()).with_id(id_2);
-    let app = Split::horizontal(left, right).padding(5.0);
+    let app = Split::columns(left, right).padding(5.0);
     let data = true;
 
     Harness::create(data, app, |harness| {
@@ -195,10 +195,10 @@ fn adding_child_lifecycle() {
     let record_new_child2 = record_new_child.clone();
 
     let replacer = ReplaceChild::new(TextBox::new(), move || {
-        Split::horizontal(TextBox::new(), TextBox::new().record(&record_new_child2))
+        Split::columns(TextBox::new(), TextBox::new().record(&record_new_child2))
     });
 
-    let widget = Split::horizontal(Label::new("hi").record(&record), replacer);
+    let widget = Split::columns(Label::new("hi").record(&record), replacer);
 
     Harness::create(String::new(), widget, |harness| {
         harness.send_initial_events();
@@ -225,10 +225,10 @@ fn participate_in_autofocus() {
     // this widget starts with a single child, and will replace them with a split
     // when we send it a command.
     let replacer = ReplaceChild::new(TextBox::new().with_id(id_4), move || {
-        Split::horizontal(TextBox::new().with_id(id_5), TextBox::new().with_id(id_6))
+        Split::columns(TextBox::new().with_id(id_5), TextBox::new().with_id(id_6))
     });
 
-    let widget = Split::horizontal(
+    let widget = Split::columns(
         Flex::row()
             .with_flex_child(TextBox::new().with_id(id_1), 1.0)
             .with_flex_child(TextBox::new().with_id(id_2), 1.0)
@@ -263,7 +263,7 @@ fn participate_in_autofocus() {
 fn child_tracking() {
     let (id_1, id_2, id_3, id_4) = widget_id4();
 
-    let widget = Split::horizontal(
+    let widget = Split::columns(
         SizedBox::empty().with_id(id_1),
         SizedBox::empty().with_id(id_2),
     )
@@ -293,11 +293,11 @@ fn register_after_adding_child() {
     let id_7 = WidgetId::next();
 
     let replacer = ReplaceChild::new(TextBox::new().with_id(id_1), move || {
-        Split::horizontal(TextBox::new().with_id(id_2), TextBox::new().with_id(id_3)).with_id(id_7)
+        Split::columns(TextBox::new().with_id(id_2), TextBox::new().with_id(id_3)).with_id(id_7)
     })
     .with_id(id_6);
 
-    let widget = Split::horizontal(Label::new("hi").with_id(id_4), replacer).with_id(id_5);
+    let widget = Split::columns(Label::new("hi").with_id(id_4), replacer).with_id(id_5);
 
     Harness::create(String::new(), widget, |harness| {
         harness.send_initial_events();

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -37,6 +37,9 @@ pub struct Split<T> {
 
 impl<T> Split<T> {
     /// Create a new split panel, with the specified axis being split in two.
+    ///
+    /// Horizontal split axis means that the children are left and right.
+    /// Vertical split axis means that the children are up and down.
     fn new(
         split_axis: Axis,
         child1: impl Widget<T> + 'static,
@@ -58,13 +61,13 @@ impl<T> Split<T> {
 
     /// Create a new split panel, with the horizontal axis split in two by a vertical bar.
     /// The children are laid out left and right.
-    pub fn horizontal(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
+    pub fn columns(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
         Self::new(Axis::Horizontal, child1, child2)
     }
 
     /// Create a new split panel, with the vertical axis split in two by a horizontal bar.
     /// The children are laid out up and down.
-    pub fn vertical(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
+    pub fn rows(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
         Self::new(Axis::Vertical, child1, child2)
     }
 

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -21,166 +21,166 @@ use crate::{
     LifeCycleCtx, PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,
 };
 
-///A container containing two other widgets, splitting the area either horizontally or vertically.
+/// A container containing two other widgets, splitting the area either horizontally or vertically.
 pub struct Split<T> {
-    split_direction: Axis,
-    solid: bool,
-    draggable: bool,
-    min_size: f64,
+    split_axis: Axis,
     split_point_chosen: f64,
     split_point_effective: f64,
-    splitter_size: f64,
-    min_splitter_area: f64,
+    min_size: f64,     // Integers only
+    bar_size: f64,     // Integers only
+    min_bar_area: f64, // Integers only
+    solid: bool,
+    draggable: bool,
     child1: WidgetPod<T, Box<dyn Widget<T>>>,
     child2: WidgetPod<T, Box<dyn Widget<T>>>,
 }
 
 impl<T> Split<T> {
-    ///Create a new split panel.
+    /// Create a new split panel, with the specified axis being split in two.
     fn new(
-        split_direction: Axis,
+        split_axis: Axis,
         child1: impl Widget<T> + 'static,
         child2: impl Widget<T> + 'static,
     ) -> Self {
         Split {
-            split_direction,
-            min_size: 0.0,
-            solid: false,
+            split_axis,
             split_point_chosen: 0.5,
             split_point_effective: 0.5,
-            splitter_size: 6.0,
-            min_splitter_area: 6.0,
+            min_size: 0.0,
+            bar_size: 6.0,
+            min_bar_area: 6.0,
+            solid: false,
             draggable: false,
             child1: WidgetPod::new(child1).boxed(),
             child2: WidgetPod::new(child2).boxed(),
         }
     }
 
-    /// Create a new split panel, with a vertical splitter between two children.
-    pub fn vertical(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
-        Self::new(Axis::Vertical, child1, child2)
-    }
-
-    /// Create a new split panel, with a horizontal splitter between two children.
+    /// Create a new split panel, with the horizontal axis split in two by a vertical bar.
+    /// The children are laid out left and right.
     pub fn horizontal(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
         Self::new(Axis::Horizontal, child1, child2)
     }
 
-    /// Set container's split point as a fraction of the split dimension
-    /// The value must be between 0.0 and 1.0, exclusive
+    /// Create a new split panel, with the vertical axis split in two by a horizontal bar.
+    /// The children are laid out up and down.
+    pub fn vertical(child1: impl Widget<T> + 'static, child2: impl Widget<T> + 'static) -> Self {
+        Self::new(Axis::Vertical, child1, child2)
+    }
+
+    /// Builder-style method to set the split point as a fraction of the split axis.
+    ///
+    /// The value must be between `0.0` and `1.0`, inclusive.
+    /// The default split point is `0.5`.
     pub fn split_point(mut self, split_point: f64) -> Self {
         assert!(
-            split_point > 0.0 && split_point < 1.0,
-            "split_point must be between 0.0 and 1.0!"
+            split_point >= 0.0 && split_point <= 1.0,
+            "split_point must be in the range [0.0-1.0]!"
         );
         self.split_point_chosen = split_point;
         self
     }
 
-    /// Builder-style method to set the minimum size for both sides of the split.
+    /// Builder-style method to set the minimum size for both sides of the split axis.
     ///
     /// The value must be greater than or equal to `0.0`.
+    /// The value will be rounded up to the nearest integer.
     pub fn min_size(mut self, min_size: f64) -> Self {
         assert!(min_size >= 0.0);
-        self.min_size = min_size;
+        self.min_size = min_size.ceil();
         self
     }
 
-    /// Set the width of the splitter bar.
+    /// Builder-style method to set the size of the splitter bar.
     ///
     /// The value must be positive or zero.
-    /// The default splitter size is `6.0`.
-    pub fn splitter_size(mut self, splitter_size: f64) -> Self {
-        assert!(
-            splitter_size >= 0.0,
-            "splitter_width must be 0.0 or greater!"
-        );
-        self.splitter_size = splitter_size;
+    /// The value will be rounded up to the nearest integer.
+    /// The default splitter bar size is `6.0`.
+    pub fn bar_size(mut self, bar_size: f64) -> Self {
+        assert!(bar_size >= 0.0, "bar_size must be 0.0 or greater!");
+        self.bar_size = bar_size.ceil();
         self
     }
 
-    /// Set the minimum width of the splitter area.
+    /// Builder-style method to set the minimum size of the splitter bar area.
     ///
-    /// The minimum splitter area defines the minimum width of the area
-    /// where mouse hit detection is done for the splitter.
-    /// The final area is either this or the splitter size, whichever is greater.
+    /// The minimum splitter bar area defines the minimum size of the area
+    /// where mouse hit detection is done for the splitter bar.
+    /// The final area is either this or the splitter bar size, whichever is greater.
     ///
-    /// This can be useful when you want to use a very narrow visual splitter,
-    /// but don't want to sacrifice user experience.
+    /// This can be useful when you want to use a very narrow visual splitter bar,
+    /// but don't want to sacrifice user experience by making it hard to click on.
     ///
-    /// The default minimum splitter area is `6.0`.
-    pub fn min_splitter_area(mut self, min_splitter_area: f64) -> Self {
-        assert!(
-            min_splitter_area >= 0.0,
-            "min_splitter_area must be 0.0 or greater!"
-        );
-        self.min_splitter_area = min_splitter_area;
+    /// The value must be positive or zero.
+    /// The value will be rounded up to the nearest integer.
+    /// The default minimum splitter bar area is `6.0`.
+    pub fn min_bar_area(mut self, min_bar_area: f64) -> Self {
+        assert!(min_bar_area >= 0.0, "min_bar_area must be 0.0 or greater!");
+        self.min_bar_area = min_bar_area.ceil();
         self
     }
 
-    /// Set whether the splitter's split point can be changed by dragging.
+    /// Builder-style method to set whether the split point can be changed by dragging.
     pub fn draggable(mut self, draggable: bool) -> Self {
         self.draggable = draggable;
         self
     }
 
-    /// Builder-style method to set whether the splitter handle is drawn as a solid rectangle.
+    /// Builder-style method to set whether the splitter bar is drawn as a solid rectangle.
     ///
-    /// If this is `false` (the default), it will be drawn as two parallel lines.
-    pub fn fill_splitter_handle(mut self, solid: bool) -> Self {
+    /// If this is `false` (the default), the bar will be drawn as two parallel lines.
+    pub fn solid_bar(mut self, solid: bool) -> Self {
         self.solid = solid;
         self
     }
 
-    /// Returns the width of the area of mouse hit detection.
+    /// Returns the size of the splitter bar area.
     #[inline]
-    fn splitter_area(&self) -> f64 {
-        self.splitter_size.max(self.min_splitter_area)
+    fn bar_area(&self) -> f64 {
+        self.bar_size.max(self.min_bar_area)
     }
 
-    /// Returns the padding width added to the splitter on both sides.
+    /// Returns the padding size added to each side of the splitter bar.
     #[inline]
-    fn splitter_padding(&self) -> f64 {
-        (self.splitter_area() - self.splitter_size) / 2.0
+    fn bar_padding(&self) -> f64 {
+        (self.bar_area() - self.bar_size) / 2.0
     }
 
-    /// Returns the location of the edges of the splitter area,
+    /// Returns the location of the edges of the splitter bar area,
     /// given the specified total size.
-    fn splitter_edges(&self, size: Size) -> (f64, f64) {
-        let splitter_area = self.splitter_area();
-        match self.split_direction {
-            Axis::Vertical => {
-                let reduced_width = size.width - splitter_area;
-                let edge1 = (reduced_width * self.split_point_effective).floor();
-                let edge2 = edge1 + splitter_area;
-                (edge1, edge2)
-            }
+    fn bar_edges(&self, size: Size) -> (f64, f64) {
+        let bar_area = self.bar_area();
+        match self.split_axis {
             Axis::Horizontal => {
-                let reduced_height = size.height - splitter_area;
+                let reduced_width = size.width - bar_area;
+                let edge1 = (reduced_width * self.split_point_effective).floor();
+                let edge2 = edge1 + bar_area;
+                (edge1, edge2)
+            }
+            Axis::Vertical => {
+                let reduced_height = size.height - bar_area;
                 let edge1 = (reduced_height * self.split_point_effective).floor();
-                let edge2 = edge1 + splitter_area;
+                let edge2 = edge1 + bar_area;
                 (edge1, edge2)
             }
         }
     }
 
-    /// Returns true if the provided mouse pos is inside the splitter area.
-    fn splitter_hit_test(&self, size: Size, mouse_pos: Point) -> bool {
-        let (edge1, edge2) = self.splitter_edges(size);
-        match self.split_direction {
-            Axis::Vertical => mouse_pos.x >= edge1 && mouse_pos.x <= edge2,
-            Axis::Horizontal => mouse_pos.y >= edge1 && mouse_pos.y <= edge2,
+    /// Returns true if the provided mouse position is inside the splitter bar area.
+    fn bar_hit_test(&self, size: Size, mouse_pos: Point) -> bool {
+        let (edge1, edge2) = self.bar_edges(size);
+        match self.split_axis {
+            Axis::Horizontal => mouse_pos.x >= edge1 && mouse_pos.x <= edge2,
+            Axis::Vertical => mouse_pos.y >= edge1 && mouse_pos.y <= edge2,
         }
     }
 
-    /// Returns the min and max split coordinate of the provided size.
-    fn calculate_limits(&self, size: Size) -> (f64, f64) {
-        // Since the Axis::Direction tells us the direction of the splitter itself
-        // we need the minor axis to get the size of the split direction
-        let size_in_split_direction = self.split_direction.minor(size);
+    /// Returns the minimum and maximum split coordinate of the provided size.
+    fn split_side_limits(&self, size: Size) -> (f64, f64) {
+        let split_axis_size = self.split_axis.major(size);
 
         let mut min_limit = self.min_size;
-        let mut max_limit = (size_in_split_direction - min_limit).max(0.0);
+        let mut max_limit = (split_axis_size - min_limit).max(0.0);
 
         if min_limit > max_limit {
             min_limit = 0.5 * (min_limit + max_limit);
@@ -192,14 +192,15 @@ impl<T> Split<T> {
 
     /// Set a new chosen split point.
     fn update_split_point(&mut self, size: Size, mouse_pos: Point) {
-        let (min_limit, max_limit) = self.calculate_limits(size);
-        self.split_point_chosen = match self.split_direction {
-            Axis::Vertical => clamp(mouse_pos.x, min_limit, max_limit) / size.width,
-            Axis::Horizontal => clamp(mouse_pos.y, min_limit, max_limit) / size.height,
+        let (min_limit, max_limit) = self.split_side_limits(size);
+        self.split_point_chosen = match self.split_axis {
+            Axis::Horizontal => clamp(mouse_pos.x, min_limit, max_limit) / size.width,
+            Axis::Vertical => clamp(mouse_pos.y, min_limit, max_limit) / size.height,
         }
     }
 
-    fn get_color(&self, env: &Env) -> Color {
+    /// Returns the color of the splitter bar.
+    fn bar_color(&self, env: &Env) -> Color {
         if self.draggable {
             env.get(theme::BORDER_LIGHT)
         } else {
@@ -207,34 +208,34 @@ impl<T> Split<T> {
         }
     }
 
-    fn paint_solid(&mut self, ctx: &mut PaintCtx, env: &Env) {
+    fn paint_solid_bar(&mut self, ctx: &mut PaintCtx, env: &Env) {
         let size = ctx.size();
-        let (edge1, edge2) = self.splitter_edges(size);
-        let padding = self.splitter_padding();
-        let rect = match self.split_direction {
-            Axis::Vertical => Rect::from_points(
+        let (edge1, edge2) = self.bar_edges(size);
+        let padding = self.bar_padding();
+        let rect = match self.split_axis {
+            Axis::Horizontal => Rect::from_points(
                 Point::new(edge1 + padding.ceil(), 0.0),
                 Point::new(edge2 - padding.floor(), size.height),
             ),
-            Axis::Horizontal => Rect::from_points(
+            Axis::Vertical => Rect::from_points(
                 Point::new(0.0, edge1 + padding.ceil()),
                 Point::new(size.width, edge2 - padding.floor()),
             ),
         };
-        let splitter_color = self.get_color(env);
+        let splitter_color = self.bar_color(env);
         ctx.fill(rect, &splitter_color);
     }
 
-    fn paint_stroked(&mut self, ctx: &mut PaintCtx, env: &Env) {
+    fn paint_stroked_bar(&mut self, ctx: &mut PaintCtx, env: &Env) {
         let size = ctx.size();
-        // Set the line width to a third of the splitter size,
+        // Set the line width to a third of the splitter bar size,
         // because we'll paint two equal lines at the edges.
-        let line_width = (self.splitter_size / 3.0).floor();
+        let line_width = (self.bar_size / 3.0).floor();
         let line_midpoint = line_width / 2.0;
-        let (edge1, edge2) = self.splitter_edges(size);
-        let padding = self.splitter_padding();
-        let (line1, line2) = match self.split_direction {
-            Axis::Vertical => (
+        let (edge1, edge2) = self.bar_edges(size);
+        let padding = self.bar_padding();
+        let (line1, line2) = match self.split_axis {
+            Axis::Horizontal => (
                 Line::new(
                     Point::new(edge1 + line_midpoint + padding.ceil(), 0.0),
                     Point::new(edge1 + line_midpoint + padding.ceil(), size.height),
@@ -244,7 +245,7 @@ impl<T> Split<T> {
                     Point::new(edge2 - line_midpoint - padding.floor(), size.height),
                 ),
             ),
-            Axis::Horizontal => (
+            Axis::Vertical => (
                 Line::new(
                     Point::new(0.0, edge1 + line_midpoint + padding.ceil()),
                     Point::new(size.width, edge1 + line_midpoint + padding.ceil()),
@@ -255,11 +256,12 @@ impl<T> Split<T> {
                 ),
             ),
         };
-        let splitter_color = self.get_color(env);
+        let splitter_color = self.bar_color(env);
         ctx.stroke(line1, &splitter_color, line_width);
         ctx.stroke(line2, &splitter_color, line_width);
     }
 }
+
 impl<T: Data> Widget<T> for Split<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if self.child1.is_active() {
@@ -277,7 +279,7 @@ impl<T: Data> Widget<T> for Split<T> {
         if self.draggable {
             match event {
                 Event::MouseDown(mouse) => {
-                    if mouse.button.is_left() && self.splitter_hit_test(ctx.size(), mouse.pos) {
+                    if mouse.button.is_left() && self.bar_hit_test(ctx.size(), mouse.pos) {
                         ctx.set_active(true);
                         ctx.set_handled();
                     }
@@ -295,12 +297,10 @@ impl<T: Data> Widget<T> for Split<T> {
                         ctx.request_layout();
                     }
 
-                    if ctx.is_hot() && self.splitter_hit_test(ctx.size(), mouse.pos)
-                        || ctx.is_active()
-                    {
-                        match self.split_direction {
-                            Axis::Horizontal => ctx.set_cursor(&Cursor::ResizeUpDown),
-                            Axis::Vertical => ctx.set_cursor(&Cursor::ResizeLeftRight),
+                    if ctx.is_hot() && self.bar_hit_test(ctx.size(), mouse.pos) || ctx.is_active() {
+                        match self.split_axis {
+                            Axis::Horizontal => ctx.set_cursor(&Cursor::ResizeLeftRight),
+                            Axis::Vertical => ctx.set_cursor(&Cursor::ResizeUpDown),
                         };
                     }
                 }
@@ -328,47 +328,47 @@ impl<T: Data> Widget<T> for Split<T> {
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Split");
 
-        let mut my_size = bc.max();
-
-        // Update our effective split point to respect our constraints
-        let (min_limit, max_limit) = self.calculate_limits(my_size);
-        self.split_point_effective = match self.split_direction {
-            Axis::Vertical => {
-                if my_size.width <= std::f64::EPSILON {
-                    0.5
-                } else {
-                    clamp(
-                        self.split_point_chosen,
-                        min_limit / my_size.width,
-                        max_limit / my_size.width,
-                    )
-                }
-            }
+        match self.split_axis {
             Axis::Horizontal => {
-                if my_size.height <= std::f64::EPSILON {
-                    0.5
-                } else {
-                    clamp(
-                        self.split_point_chosen,
-                        min_limit / my_size.height,
-                        max_limit / my_size.height,
-                    )
-                }
-            }
-        };
-
-        let splitter_area = self.splitter_area();
-        let reduced_width = my_size.width - splitter_area;
-        let reduced_height = my_size.height - splitter_area;
-        let (child1_bc, child2_bc) = match self.split_direction {
-            Axis::Vertical => {
                 if !bc.is_width_bounded() {
                     log::warn!("A Split widget was given an unbounded width to split.")
                 }
-                let child1_width = (reduced_width * self.split_point_effective)
+            }
+            Axis::Vertical => {
+                if !bc.is_height_bounded() {
+                    log::warn!("A Split widget was given an unbounded height to split.")
+                }
+            }
+        }
+
+        let mut my_size = bc.max();
+        let bar_area = self.bar_area();
+        let reduced_size = Size::new(
+            (my_size.width - bar_area).max(0.),
+            (my_size.height - bar_area).max(0.),
+        );
+
+        // Update our effective split point to respect our constraints
+        self.split_point_effective = {
+            let (min_limit, max_limit) = self.split_side_limits(reduced_size);
+            let reduced_axis_size = self.split_axis.major(reduced_size);
+            if reduced_axis_size.is_infinite() || reduced_axis_size <= std::f64::EPSILON {
+                0.5
+            } else {
+                clamp(
+                    self.split_point_chosen,
+                    min_limit / reduced_axis_size,
+                    max_limit / reduced_axis_size,
+                )
+            }
+        };
+
+        let (child1_bc, child2_bc) = match self.split_axis {
+            Axis::Horizontal => {
+                let child1_width = (reduced_size.width * self.split_point_effective)
                     .floor()
                     .max(0.0);
-                let child2_width = (reduced_width - child1_width).max(0.0);
+                let child2_width = (reduced_size.width - child1_width).max(0.0);
                 (
                     BoxConstraints::new(
                         Size::new(child1_width, bc.min().height),
@@ -380,14 +380,11 @@ impl<T: Data> Widget<T> for Split<T> {
                     ),
                 )
             }
-            Axis::Horizontal => {
-                if !bc.is_width_bounded() {
-                    log::warn!("A Split widget was given an unbounded height to split.")
-                }
-                let child1_height = (reduced_height * self.split_point_effective)
+            Axis::Vertical => {
+                let child1_height = (reduced_size.height * self.split_point_effective)
                     .floor()
                     .max(0.0);
-                let child2_height = (reduced_height - child1_height).max(0.0);
+                let child2_height = (reduced_size.height - child1_height).max(0.0);
                 (
                     BoxConstraints::new(
                         Size::new(bc.min().width, child1_height),
@@ -403,25 +400,25 @@ impl<T: Data> Widget<T> for Split<T> {
         let child1_size = self.child1.layout(ctx, &child1_bc, &data, env);
         let child2_size = self.child2.layout(ctx, &child2_bc, &data, env);
 
-        //Top-left align for both children, out of laziness.
-        //Reduce our unsplit direction to the larger of the two widgets
-        let (child1_rect, child2_rect) = match self.split_direction {
-            Axis::Vertical => {
+        // Top-left align for both children, out of laziness.
+        // Reduce our unsplit direction to the larger of the two widgets
+        let (child1_rect, child2_rect) = match self.split_axis {
+            Axis::Horizontal => {
                 my_size.height = child1_size.height.max(child2_size.height);
                 (
                     Rect::from_origin_size(Point::ORIGIN, child1_size),
                     Rect::from_origin_size(
-                        Point::new(child1_size.width + splitter_area, 0.0),
+                        Point::new(child1_size.width + bar_area, 0.0),
                         child2_size,
                     ),
                 )
             }
-            Axis::Horizontal => {
+            Axis::Vertical => {
                 my_size.width = child1_size.width.max(child2_size.width);
                 (
                     Rect::from_origin_size(Point::ORIGIN, child1_size),
                     Rect::from_origin_size(
-                        Point::new(0.0, child1_size.height + splitter_area),
+                        Point::new(0.0, child1_size.height + bar_area),
                         child2_size,
                     ),
                 )
@@ -439,9 +436,9 @@ impl<T: Data> Widget<T> for Split<T> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         if self.solid {
-            self.paint_solid(ctx, env);
+            self.paint_solid_bar(ctx, env);
         } else {
-            self.paint_stroked(ctx, env);
+            self.paint_stroked_bar(ctx, env);
         }
         self.child1.paint_with_offset(ctx, &data, env);
         self.child2.paint_with_offset(ctx, &data, env);


### PR DESCRIPTION
This PR includes a slew of changes to the `Split` widget.

* All layout and drawing is now quantized to integers as a continuation of work in #669. This means that single pixel lines never bleed out to side pixels. This applies to both the inner children and the split bar.
* Adds `min_splitter_area(f64)` method which basically acts as padding around the split bar. This padding still reacts to mouse events. As a result it is possible to use extremely narrow split bars while still having a reasonable area for the user to click on. Fixes #641.
* No longer forgets the `split_point` chosen by the user. The widget still modifies the split point when the size constraints require it (e.g. when resizing the window to extremely small) however now the user chosen split point is restored as soon as the constraints allow it.
* The meaning of `splitter_size` has slightly changed, to a less surprising interpretation.
    * Previously a splitter size of 10 with a solid fill meant:
     4px wide solid fill with 3px padding on each side.
    With the fill width formula being: size - 2*((size/3).floor())
    Now a 10 with a solid fill means a 10px wide solid fill.
    The new `min_splitter_area` can be used to add padding.
    * Previously a splitter size of 10 with a line style meant:
    2px pad | ~2px line | 2px pad | ~2px line | 2px pad
    With 1px lines being centered (size/3).floor() pixels away from edges.
    Now a 10 with a line style means: 3px line | 4px pad | 3px line
    Padding at edges can be added optionally with `min_splitter_area`.
* Renamed a few internal functions and added a few lines of documentation for better readability.

Generally speaking the `Split` widget still has issues, which were there before and aren't addressed here, e.g. children still being drawn when they have zero sized layout. I'll probably tackle this at least partially in a future PR.