### PR TITLE
Infinite size warnings

### DIFF
--- a/druid/src/box_constraints.rs
+++ b/druid/src/box_constraints.rs
@@ -102,6 +102,14 @@ impl BoxConstraints {
             log::warn!("Bad BoxConstraints passed to {}:", name);
             log::warn!("{:?}", self);
         }
+
+        if self.min.width.is_infinite() {
+            log::warn!("Infinite minimum width constraint passed to {}:", name);
+        }
+
+        if self.min.height.is_infinite() {
+            log::warn!("Infinite minimum height constraint passed to {}:", name);
+        }
     }
 
     /// Shrink min and max constraints by size

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -328,6 +328,15 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     ) -> Size {
         layout_ctx.paint_insets = Insets::ZERO;
         let size = self.inner.layout(layout_ctx, bc, data, &env);
+
+        if size.width.is_infinite() {
+            log::warn!("A widget has an infinite width.");
+        }
+
+        if size.height.is_infinite() {
+            log::warn!("A widget has an infinite height.");
+        }
+
         self.state.paint_insets = layout_ctx.paint_insets;
         self.state.needs_layout = false;
         size

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -330,11 +330,13 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let size = self.inner.layout(layout_ctx, bc, data, &env);
 
         if size.width.is_infinite() {
-            log::warn!("A widget has an infinite width.");
+            let name = self.widget().type_name();
+            log::warn!("Widget `{}` has an infinite width.", name);
         }
 
         if size.height.is_infinite() {
-            log::warn!("A widget has an infinite height.");
+            let name = self.widget().type_name();
+            log::warn!("Widget `{}` has an infinite height.", name);
         }
 
         self.state.paint_insets = layout_ctx.paint_insets;

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -552,6 +552,15 @@ impl<T: Data> Widget<T> for Flex<T> {
                     .direction
                     .constraints(&loosened_bc, 0., std::f64::INFINITY);
                 let child_size = child.widget.layout(layout_ctx, &child_bc, data, env);
+
+                if child_size.width.is_infinite() {
+                    log::warn!("A non-Flex child has an infinite width.");
+                }
+
+                if child_size.height.is_infinite() {
+                    log::warn!("A non-Flex child has an infinite height.");
+                }
+
                 minor = minor.max(self.direction.minor(child_size));
                 total_non_flex += self.direction.major(child_size);
                 // Stash size.
@@ -573,6 +582,7 @@ impl<T: Data> Widget<T> for Flex<T> {
 
                 let child_bc = self.direction.constraints(&loosened_bc, min_major, major);
                 let child_size = child.widget.layout(layout_ctx, &child_bc, data, env);
+
                 flex_used += self.direction.major(child_size);
                 minor = minor.max(self.direction.minor(child_size));
                 // Stash size.

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -252,6 +252,11 @@ pub trait Widget<T> {
     fn id(&self) -> Option<WidgetId> {
         None
     }
+
+    /// Get the (verbose) type name of the widget for debugging purposes.
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
 }
 
 impl WidgetId {

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -253,7 +253,9 @@ pub trait Widget<T> {
         None
     }
 
+    #[doc(hidden)]
     /// Get the (verbose) type name of the widget for debugging purposes.
+    /// You should not override this method.
     fn type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
     }

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -318,4 +318,8 @@ impl<T> Widget<T> for Box<dyn Widget<T>> {
     fn id(&self) -> Option<WidgetId> {
         self.deref().id()
     }
+
+    fn type_name(&self) -> &'static str {
+        self.deref().type_name()
+    }
 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -435,6 +435,15 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
         let child_bc = BoxConstraints::new(Size::ZERO, self.direction.max_size(bc));
         let size = self.child.layout(ctx, &child_bc, data, env);
+
+        if size.width.is_infinite() {
+            log::warn!("Scroll widget's child has an infinite width.");
+        }
+
+        if size.height.is_infinite() {
+            log::warn!("Scroll widget's child has an infinite height.");
+        }
+
         self.child_size = size;
         self.child
             .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));

--- a/druid/src/widget/sized_box.rs
+++ b/druid/src/widget/sized_box.rs
@@ -152,10 +152,20 @@ impl<T: Data> Widget<T> for SizedBox<T> {
         bc.debug_check("SizedBox");
 
         let child_bc = self.child_constraints(bc);
-        match self.inner.as_mut() {
+        let size = match self.inner.as_mut() {
             Some(inner) => inner.layout(ctx, &child_bc, data, env),
             None => bc.constrain((self.width.unwrap_or(0.0), self.height.unwrap_or(0.0))),
+        };
+
+        if size.width.is_infinite() {
+            log::warn!("SizedBox is returning an infinite width.");
         }
+
+        if size.height.is_infinite() {
+            log::warn!("SizedBox is returning an infinite height.");
+        }
+
+        size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {


### PR DESCRIPTION
Seems like warning when a widget is attempting to return an infinite size fixes most of #685. This is not a systematic fix-up, but just what I've thought of so far.

These specific fixes are motivated by a layout issue I was having:

```rust
Flex::row().with_child(
  Label::new(|data: &ListItem, _env: &Env| data.file_name.clone())
      .expand_width()
      .on_click(|_, data, _| {
          println!("hey");
      }),
)
```

Flex gives SizedBox an infinite max constraint, SizedBox passes an infinite minimum constraint to Label (this is where we go wrong I believe), and Label measures itself and then "constrains" itself within the infinite BoxConstraints.

When I switched to `width_flex_child` I get my desired result.