### PR TITLE
Alignment RadioGroup

### DIFF
--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -169,6 +169,7 @@ fn make_control_row() -> impl Widget<AppState> {
                 .with_child(Checkbox::new("Fix minor axis size").lens(Params::fix_minor_axis))
                 .with_spacer(10.)
                 .with_child(Checkbox::new("Fix major axis size").lens(Params::fix_major_axis))
+                .cross_axis_alignment(CrossAxisAlignment::Start)
                 .padding(5.0),
         )
         .border(Color::grey(0.6), 2.0)

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -16,10 +16,10 @@
 
 use crate::kurbo::{Circle, Point, Rect, Size};
 use crate::theme;
-use crate::widget::{Flex, Label, LabelText, Padding, CrossAxisAlignment};
+use crate::widget::{CrossAxisAlignment, Flex, Label, LabelText, Padding};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
-    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget, WidgetExt, WidgetPod
+    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget, WidgetExt, WidgetPod,
 };
 
 /// A group of radio buttons

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -16,10 +16,10 @@
 
 use crate::kurbo::{Circle, Point, Rect, Size};
 use crate::theme;
-use crate::widget::{Flex, Label, LabelText, Padding};
+use crate::widget::{Flex, Label, LabelText, Padding, CrossAxisAlignment};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
-    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget, WidgetExt, WidgetPod,
+    PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget, WidgetExt, WidgetPod
 };
 
 /// A group of radio buttons
@@ -30,13 +30,13 @@ impl RadioGroup {
     /// Given a vector of `(label_text, enum_variant)` tuples, create a group of Radio buttons
     pub fn new<T: Data + PartialEq>(
         variants: impl IntoIterator<Item = (impl Into<LabelText<T>> + 'static, T)>,
-    ) -> impl Widget<T> {
+    ) -> Flex<T> {
         let mut col = Flex::column();
         for (label, variant) in variants.into_iter() {
             let radio = Radio::new(label, variant);
             col.add_child(Padding::new(5.0, radio));
         }
-        col
+        col.cross_axis_alignment(CrossAxisAlignment::Start)
     }
 }
 


### PR DESCRIPTION
Hi,

During one of the last updates the default alignment for `Flex::column` changed  wich changed the alignment from `RadioGroup` too.

Currently there is no way to set the alignment inside the `RadioGroup` as the return from `RadioGroup::new()` is `impl Widget<T>` .

So I update `RadioGroup::new()` to return a `Flex<T>` to be able to change the alignment if necessary and I reset the default alignment from RadioGroup like previously as I think it make more sence in the RadioGroup case.

Let me know if it's good to you or if it's too weird to return a `Flex<T>` for `RadioGroup::new()`.