### PR TITLE
fancier calc

### DIFF
--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -25,7 +25,7 @@ use druid::{
 };
 use druid::{
     widget::{CrossAxisAlignment, Flex, Label, MainAxisAlignment, Padding, Painter},
-    UnitPoint,
+    Insets, UnitPoint,
 };
 
 #[derive(Clone, Data, Lens)]
@@ -179,10 +179,11 @@ fn flex_row3<T: Data>(
     w2: impl Widget<T> + 'static,
     w3: impl Widget<T> + 'static,
 ) -> impl Widget<T> {
+    let insets = Insets::new(1., 1., 0., 0.);
     Flex::row()
-        .with_flex_child(Padding::new(1., w1), 2.0)
-        .with_flex_child(Padding::new(1., w2), 1.0)
-        .with_flex_child(Padding::new(1., w3), 1.0)
+        .with_flex_child(Padding::new(insets.clone(), w1), 2.0)
+        .with_flex_child(Padding::new(insets.clone(), w2), 1.0)
+        .with_flex_child(Padding::new(insets, w3), 1.0)
 }
 
 fn flex_row4<T: Data>(
@@ -191,11 +192,12 @@ fn flex_row4<T: Data>(
     w3: impl Widget<T> + 'static,
     w4: impl Widget<T> + 'static,
 ) -> impl Widget<T> {
+    let insets = Insets::new(1., 1., 0., 0.);
     Flex::row()
-        .with_flex_child(Padding::new(1., w1), 1.0)
-        .with_flex_child(Padding::new(1., w2), 1.0)
-        .with_flex_child(Padding::new(1., w3), 1.0)
-        .with_flex_child(Padding::new(1., w4), 1.0)
+        .with_flex_child(Padding::new(insets.clone(), w1), 1.0)
+        .with_flex_child(Padding::new(insets.clone(), w2), 1.0)
+        .with_flex_child(Padding::new(insets.clone(), w3), 1.0)
+        .with_flex_child(Padding::new(insets, w4), 1.0)
 }
 
 fn build_calc() -> impl Widget<CalcState> {
@@ -243,7 +245,6 @@ fn build_calc() -> impl Widget<CalcState> {
             ),
             1.0,
         )
-        .with_spacer(1.0)
         .with_flex_child(
             flex_row4(
                 digit_button(7),
@@ -253,7 +254,6 @@ fn build_calc() -> impl Widget<CalcState> {
             ),
             1.0,
         )
-        .with_spacer(1.0)
         .with_flex_child(
             flex_row4(
                 digit_button(4),
@@ -263,7 +263,6 @@ fn build_calc() -> impl Widget<CalcState> {
             ),
             1.0,
         )
-        .with_spacer(1.0)
         .with_flex_child(
             flex_row4(
                 digit_button(1),
@@ -273,7 +272,6 @@ fn build_calc() -> impl Widget<CalcState> {
             ),
             1.0,
         )
-        .with_spacer(1.0)
         .with_flex_child(
             flex_row4(
                 op_button('±'),

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -19,7 +19,8 @@ use druid::{
     WindowDesc,
 };
 
-use druid::widget::{CrossAxisAlignment, Flex, Label, Painter};
+use druid::{widget::{CrossAxisAlignment, Flex, Label, Painter, Padding, MainAxisAlignment}, UnitPoint,};
+use druid::{Point, piet::{FixedLinearGradient, GradientStop}};
 
 #[derive(Clone, Data, Lens)]
 struct CalcState {
@@ -118,11 +119,13 @@ impl CalcState {
 fn op_button_label(op: char, label: String) -> impl Widget<CalcState> {
     let painter = Painter::new(|ctx, _, env| {
         let bounds = ctx.size().to_rect();
-
-        ctx.fill(bounds, &env.get(theme::PRIMARY_DARK));
+        let color = env.get(theme::PRIMARY_DARK);
+        let color_hot: Color = Color::from_rgba32_u32(color.clone().as_rgba_u32() + 0x303030);
+        ctx.fill(bounds, &color);
 
         if ctx.is_hot() {
-            ctx.stroke(bounds.inset(-0.5), &Color::WHITE, 1.0);
+            // ctx.stroke(bounds.inset(-0.5), &Color::WHITE, 1.0);
+            ctx.fill(bounds, &color_hot);
         }
 
         if ctx.is_active() {
@@ -145,15 +148,19 @@ fn op_button(op: char) -> impl Widget<CalcState> {
 fn digit_button(digit: u8) -> impl Widget<CalcState> {
     let painter = Painter::new(|ctx, _, env| {
         let bounds = ctx.size().to_rect();
+        let color = env.get(theme::BACKGROUND_LIGHT);
+        let color_hot: Color = Color::from_rgba32_u32(color.clone().as_rgba_u32() + 0x303030);
+        let color_active: Color = Color::from_rgba32_u32(color.clone().as_rgba_u32() + 0x606060);
 
-        ctx.fill(bounds, &env.get(theme::BACKGROUND_LIGHT));
+        ctx.fill(bounds, &color);
 
         if ctx.is_hot() {
-            ctx.stroke(bounds.inset(-0.5), &Color::WHITE, 1.0);
+            // ctx.stroke(bounds.inset(-0.5), &Color::WHITE, 1.0);
+            ctx.fill(bounds, &color_hot);
         }
 
         if ctx.is_active() {
-            ctx.fill(bounds, &Color::rgb8(0x71, 0x71, 0x71));
+            ctx.fill(bounds, &color_active);
         }
     });
 
@@ -165,36 +172,64 @@ fn digit_button(digit: u8) -> impl Widget<CalcState> {
         .on_click(move |_ctx, data: &mut CalcState, _env| data.digit(digit))
 }
 
-fn flex_row<T: Data>(
+fn flex_row3<T: Data>(
+    w1: impl Widget<T> + 'static,
+    w2: impl Widget<T> + 'static,
+    w3: impl Widget<T> + 'static,
+) -> impl Widget<T> {
+    Flex::row()
+        .with_flex_child(Padding::new(1., w1), 2.0)
+        .with_flex_child(Padding::new(1., w2), 1.0)
+        .with_flex_child(Padding::new(1., w3), 1.0)
+}
+
+
+fn flex_row4<T: Data>(
     w1: impl Widget<T> + 'static,
     w2: impl Widget<T> + 'static,
     w3: impl Widget<T> + 'static,
     w4: impl Widget<T> + 'static,
 ) -> impl Widget<T> {
     Flex::row()
-        .with_flex_child(w1, 1.0)
-        .with_spacer(1.0)
-        .with_flex_child(w2, 1.0)
-        .with_spacer(1.0)
-        .with_flex_child(w3, 1.0)
-        .with_spacer(1.0)
-        .with_flex_child(w4, 1.0)
+        .with_flex_child(Padding::new(1., w1), 1.0)
+        .with_flex_child(Padding::new(1., w2), 1.0)
+        .with_flex_child(Padding::new(1., w3), 1.0)
+        .with_flex_child(Padding::new(1., w4), 1.0)
 }
 
 fn build_calc() -> impl Widget<CalcState> {
+    let display_painter = Painter::new(|ctx, _, env| {
+        let bounds = ctx.size().to_rect();
+        if let Ok(brush) = ctx.gradient(FixedLinearGradient{ 
+            start: Point::new(0.,0.), 
+            end: Point::new(100.,100.), 
+            stops: vec![
+                GradientStop{pos: 0.0, color: Color::from_rgba32_u32(0x227788ff)},
+                GradientStop{pos: 1.0, color: Color::from_rgba32_u32(0x115566ff)},
+                ]
+        }) {
+            ctx.fill(bounds, &brush);
+        }
+    });
     let display = Label::new(|data: &String, _env: &_| data.clone())
         .text_size(32.0)
         .lens(CalcState::value)
         .padding(5.0);
+    let display_row = Padding::new(5., Flex::row()
+        .with_flex_child(display, 0.0)
+        .main_axis_alignment(MainAxisAlignment::End)
+        // .cross_axis_alignment(CrossAxisAlignment::End)
+        .expand_width()
+        .background(display_painter));
     Flex::column()
-        .with_flex_spacer(0.2)
-        .with_child(display)
-        .with_flex_spacer(0.2)
+        .with_flex_spacer(0.1)
+        .with_child(display_row)
+        .with_flex_spacer(0.1)
         .cross_axis_alignment(CrossAxisAlignment::End)
         .with_flex_child(
-            flex_row(
+            flex_row3(
                 op_button_label('c', "CE".to_string()),
-                op_button('C'),
+                // op_button('C'),
                 op_button('⌫'),
                 op_button('÷'),
             ),
@@ -202,7 +237,7 @@ fn build_calc() -> impl Widget<CalcState> {
         )
         .with_spacer(1.0)
         .with_flex_child(
-            flex_row(
+            flex_row4(
                 digit_button(7),
                 digit_button(8),
                 digit_button(9),
@@ -212,7 +247,7 @@ fn build_calc() -> impl Widget<CalcState> {
         )
         .with_spacer(1.0)
         .with_flex_child(
-            flex_row(
+            flex_row4(
                 digit_button(4),
                 digit_button(5),
                 digit_button(6),
@@ -222,7 +257,7 @@ fn build_calc() -> impl Widget<CalcState> {
         )
         .with_spacer(1.0)
         .with_flex_child(
-            flex_row(
+            flex_row4(
                 digit_button(1),
                 digit_button(2),
                 digit_button(3),
@@ -232,7 +267,7 @@ fn build_calc() -> impl Widget<CalcState> {
         )
         .with_spacer(1.0)
         .with_flex_child(
-            flex_row(
+            flex_row4(
                 op_button('±'),
                 digit_button(0),
                 op_button('.'),

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -199,7 +199,7 @@ fn flex_row4<T: Data>(
 }
 
 fn build_calc() -> impl Widget<CalcState> {
-    let display_painter = Painter::new(|ctx, _, env| {
+    let display_painter = Painter::new(|ctx, _, _env| {
         let bounds = ctx.size().to_rect();
         if let Ok(brush) = ctx.gradient(FixedLinearGradient {
             start: Point::new(0., 0.),

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -99,10 +99,6 @@ impl CalcState {
                     self.value.push('.');
                 }
             }
-            'c' => {
-                self.value = "0".to_string();
-                self.in_num = false;
-            }
             'C' => {
                 self.value = "0".to_string();
                 self.operator = 'C';
@@ -241,8 +237,7 @@ fn build_calc() -> impl Widget<CalcState> {
         .cross_axis_alignment(CrossAxisAlignment::End)
         .with_flex_child(
             flex_row3(
-                op_button_label('c', "CE".to_string()),
-                // op_button('C'),
+                op_button_label('C', "AC".to_string()),
                 op_button('⌫'),
                 op_button('÷'),
             ),

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -19,8 +19,14 @@ use druid::{
     WindowDesc,
 };
 
-use druid::{widget::{CrossAxisAlignment, Flex, Label, Painter, Padding, MainAxisAlignment}, UnitPoint,};
-use druid::{Point, piet::{FixedLinearGradient, GradientStop}};
+use druid::{
+    piet::{FixedLinearGradient, GradientStop},
+    Point,
+};
+use druid::{
+    widget::{CrossAxisAlignment, Flex, Label, MainAxisAlignment, Padding, Painter},
+    UnitPoint,
+};
 
 #[derive(Clone, Data, Lens)]
 struct CalcState {
@@ -183,7 +189,6 @@ fn flex_row3<T: Data>(
         .with_flex_child(Padding::new(1., w3), 1.0)
 }
 
-
 fn flex_row4<T: Data>(
     w1: impl Widget<T> + 'static,
     w2: impl Widget<T> + 'static,
@@ -200,13 +205,19 @@ fn flex_row4<T: Data>(
 fn build_calc() -> impl Widget<CalcState> {
     let display_painter = Painter::new(|ctx, _, env| {
         let bounds = ctx.size().to_rect();
-        if let Ok(brush) = ctx.gradient(FixedLinearGradient{ 
-            start: Point::new(0.,0.), 
-            end: Point::new(100.,100.), 
+        if let Ok(brush) = ctx.gradient(FixedLinearGradient {
+            start: Point::new(0., 0.),
+            end: Point::new(100., 100.),
             stops: vec![
-                GradientStop{pos: 0.0, color: Color::from_rgba32_u32(0x227788ff)},
-                GradientStop{pos: 1.0, color: Color::from_rgba32_u32(0x115566ff)},
-                ]
+                GradientStop {
+                    pos: 0.0,
+                    color: Color::from_rgba32_u32(0x225553ff),
+                },
+                GradientStop {
+                    pos: 1.0,
+                    color: Color::from_rgba32_u32(0x113333ff),
+                },
+            ],
         }) {
             ctx.fill(bounds, &brush);
         }
@@ -215,12 +226,14 @@ fn build_calc() -> impl Widget<CalcState> {
         .text_size(32.0)
         .lens(CalcState::value)
         .padding(5.0);
-    let display_row = Padding::new(5., Flex::row()
-        .with_flex_child(display, 0.0)
-        .main_axis_alignment(MainAxisAlignment::End)
-        // .cross_axis_alignment(CrossAxisAlignment::End)
-        .expand_width()
-        .background(display_painter));
+    let display_row = Padding::new(
+        5.,
+        Flex::row()
+            .with_flex_child(display, 0.0)
+            .main_axis_alignment(MainAxisAlignment::End)
+            .expand_width()
+            .background(display_painter),
+    );
     Flex::column()
         .with_flex_spacer(0.1)
         .with_child(display_row)


### PR DESCRIPTION
i made some visual changes to the calc example, taking advantage of the .background(painter) method.

removed the C button, since it has exactly the same function as the CE button from what i read.

the C button now expands over 2 "columns", which imo is a nice demo of using flex to get a more complex layout.