### PR TITLE
Reimplement Button using on_click

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ druid's existing functionality and widgets.
 ## Screenshots
 
 #### Linux
-
 [![calc.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/calc.png)](./druid/examples/calc.rs)
 [![custom_widget.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/custom_widget.png)](./druid/examples/custom_widget.rs)
 [![hello.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/hello.png)](./druid/examples/hello.rs)
@@ -252,12 +251,12 @@ instructions.
 Druid is only one of many ongoing [Rust-native GUI experiments]. To mention a
 few:
 
-- [Azul](https://github.com/maps4print/azul)
-- [Conrod](https://github.com/PistonDevelopers/conrod)
-- [Iced](https://github.com/hecrj/iced)
-- [Makepad](https://github.com/makepad/makepad)
-- [Moxie](https://github.com/anp/moxie)
-- [Reclutch](https://github.com/jazzfool/reclutch)
+* [Azul](https://github.com/maps4print/azul)
+* [Conrod](https://github.com/PistonDevelopers/conrod)
+* [Iced](https://github.com/hecrj/iced)
+* [Makepad](https://github.com/makepad/makepad)
+* [Moxie](https://github.com/anp/moxie)
+* [Reclutch](https://github.com/jazzfool/reclutch)
 
 ## Contributions
 
@@ -272,18 +271,18 @@ chat instance], in the #druid channel.
 The main authors are Raph Levien and Colin Rofls, with much support from an
 active and friendly community.
 
-[runebender]: https://github.com/linebender/runebender
+[Runebender]: https://github.com/linebender/runebender
 [the examples folder]: ./druid/examples
 [piet library]: https://github.com/linebender/piet
 [custom_widget]: ./druid/examples/custom_widget.rs
 [basic utility and layout widgets]: ./druid/src/widget
-[flutter's box layout model]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
+[Flutter's box layout model]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
 [value types]: https://sinusoid.es/lager/model.html#id2
 [cairo]: https://www.cairographics.org
 [gtk-rs dependencies]: http://gtk-rs.org/docs/requirements.html
-[rust-native gui experiments]: https://areweguiyet.com
-[contributing.md]: ./CONTRIBUTING.md
-[zulip chat instance]: https://xi.zulipchat.com
+[Rust-native GUI experiments]: https://areweguiyet.com
+[CONTRIBUTING.md]: ./CONTRIBUTING.md
+[Zulip chat instance]: https://xi.zulipchat.com
 [non-druid examples]: ./druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
 [EventCtx]: https://docs.rs/druid/0.4.0/druid/struct.EventCtx.html

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fn ui_builder() -> impl Widget<u32> {
     let label = Label::new(text)
         .padding(5.0)
         .center();
-    let button = Button::new("increment", |_ctx, data, _env| *data += 1)
+    let button = Button::new("increment").on_click(|_ctx, data, _env| *data += 1)
         .padding(5.0);
 
     Flex::column()
@@ -58,6 +58,7 @@ druid's existing functionality and widgets.
 ## Screenshots
 
 #### Linux
+
 [![calc.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/calc.png)](./druid/examples/calc.rs)
 [![custom_widget.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/custom_widget.png)](./druid/examples/custom_widget.rs)
 [![hello.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/hello.png)](./druid/examples/hello.rs)
@@ -157,8 +158,7 @@ implement your own. You can also compose widgets into new widgets:
 fn build_widget() -> impl Widget<u32> {
     let mut col = Flex::column();
     for i in 0..30 {
-        let button = Button::new(format!("Button {}", i), Button::noop)
-            .padding(5.0);
+        let button = Button::new(format!("Button {}", i).padding(5.0);
         col.add_child(button, 0.0);
     }
     Scroll::new(col)
@@ -252,12 +252,12 @@ instructions.
 Druid is only one of many ongoing [Rust-native GUI experiments]. To mention a
 few:
 
-* [Azul](https://github.com/maps4print/azul)
-* [Conrod](https://github.com/PistonDevelopers/conrod)
-* [Iced](https://github.com/hecrj/iced)
-* [Makepad](https://github.com/makepad/makepad)
-* [Moxie](https://github.com/anp/moxie)
-* [Reclutch](https://github.com/jazzfool/reclutch)
+- [Azul](https://github.com/maps4print/azul)
+- [Conrod](https://github.com/PistonDevelopers/conrod)
+- [Iced](https://github.com/hecrj/iced)
+- [Makepad](https://github.com/makepad/makepad)
+- [Moxie](https://github.com/anp/moxie)
+- [Reclutch](https://github.com/jazzfool/reclutch)
 
 ## Contributions
 
@@ -272,18 +272,18 @@ chat instance], in the #druid channel.
 The main authors are Raph Levien and Colin Rofls, with much support from an
 active and friendly community.
 
-[Runebender]: https://github.com/linebender/runebender
+[runebender]: https://github.com/linebender/runebender
 [the examples folder]: ./druid/examples
 [piet library]: https://github.com/linebender/piet
 [custom_widget]: ./druid/examples/custom_widget.rs
 [basic utility and layout widgets]: ./druid/src/widget
-[Flutter's box layout model]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
+[flutter's box layout model]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
 [value types]: https://sinusoid.es/lager/model.html#id2
 [cairo]: https://www.cairographics.org
 [gtk-rs dependencies]: http://gtk-rs.org/docs/requirements.html
-[Rust-native GUI experiments]: https://areweguiyet.com
-[CONTRIBUTING.md]: ./CONTRIBUTING.md
-[Zulip chat instance]: https://xi.zulipchat.com
+[rust-native gui experiments]: https://areweguiyet.com
+[contributing.md]: ./CONTRIBUTING.md
+[zulip chat instance]: https://xi.zulipchat.com
 [non-druid examples]: ./druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
 [EventCtx]: https://docs.rs/druid/0.4.0/druid/struct.EventCtx.html

--- a/druid/examples/flex.rs
+++ b/druid/examples/flex.rs
@@ -234,11 +234,13 @@ fn build_widget(state: &Params) -> Box<dyn Widget<AppState>> {
     let mut flex = flex.with_child(TextBox::new().lens(DemoState::input_text));
     space_if_needed(&mut flex, state);
 
-    flex.add_child(Button::new("Clear", |_ctx, data: &mut DemoState, _env| {
-        data.input_text.clear();
-        data.enabled = false;
-        data.volume = 0.0;
-    }));
+    flex.add_child(
+        Button::new("Clear").on_click(|_ctx, data: &mut DemoState, _env| {
+            data.input_text.clear();
+            data.enabled = false;
+            data.volume = 0.0;
+        }),
+    );
 
     space_if_needed(&mut flex, state);
 

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -375,28 +375,27 @@ fn make_widget() -> impl Widget<AppData> {
                     Flex::row()
                         .with_flex_child(
                             // pause / resume button
-                            Button::new(
-                                |data: &bool, _: &Env| match data {
-                                    true => "Resume".into(),
-                                    false => "Pause".into(),
-                                },
-                                |ctx, data: &mut bool, _: &Env| {
-                                    *data = !*data;
-                                    ctx.request_layout();
-                                },
-                            )
+                            Button::new(|data: &bool, _: &Env| match data {
+                                true => "Resume".into(),
+                                false => "Pause".into(),
+                            })
+                            .on_click(|ctx, data: &mut bool, _: &Env| {
+                                *data = !*data;
+                                ctx.request_layout();
+                            })
                             .lens(AppData::paused)
                             .padding((5., 5.)),
                             1.0,
                         )
                         .with_flex_child(
                             // clear button
-                            Button::new("Clear", |ctx, data: &mut Grid, _: &Env| {
-                                data.clear();
-                                ctx.request_paint();
-                            })
-                            .lens(AppData::grid)
-                            .padding((5., 5.)),
+                            Button::new("Clear")
+                                .on_click(|ctx, data: &mut Grid, _: &Env| {
+                                    data.clear();
+                                    ctx.request_paint();
+                                })
+                                .lens(AppData::grid)
+                                .padding((5., 5.)),
                             1.0,
                         )
                         .padding(8.0),

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -169,13 +169,16 @@ fn make_ui() -> impl Widget<OurData> {
                 .cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_flex_child(ColorWell::new(false).with_id(ID_ONE), 1.0)
                 .with_spacer(10.0)
-                .with_child(Button::<OurData>::new("freeze", move |ctx, data, _env| {
-                    ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), ID_ONE)
-                }))
+                .with_child(
+                    Button::<OurData>::new("freeze").on_click(move |ctx, data, _env| {
+                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), ID_ONE)
+                    }),
+                )
                 .with_spacer(10.0)
-                .with_child(Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
-                    ctx.submit_command(UNFREEZE_COLOR, ID_ONE)
-                })),
+                .with_child(
+                    Button::<OurData>::new("unfreeze")
+                        .on_click(move |ctx, _, _env| ctx.submit_command(UNFREEZE_COLOR, ID_ONE)),
+                ),
             0.5,
         )
         .with_spacer(10.0)
@@ -184,13 +187,16 @@ fn make_ui() -> impl Widget<OurData> {
                 .cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_flex_child(ColorWell::new(false).with_id(id_two), 1.)
                 .with_spacer(10.0)
-                .with_child(Button::<OurData>::new("freeze", move |ctx, data, _env| {
-                    ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_two)
-                }))
+                .with_child(
+                    Button::<OurData>::new("freeze").on_click(move |ctx, data, _env| {
+                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_two)
+                    }),
+                )
                 .with_spacer(10.0)
-                .with_child(Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
-                    ctx.submit_command(UNFREEZE_COLOR, id_two)
-                })),
+                .with_child(
+                    Button::<OurData>::new("unfreeze")
+                        .on_click(move |ctx, _, _env| ctx.submit_command(UNFREEZE_COLOR, id_two)),
+                ),
             0.5,
         )
         .with_spacer(10.0)
@@ -199,13 +205,16 @@ fn make_ui() -> impl Widget<OurData> {
                 .cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_flex_child(ColorWell::new(false).with_id(id_three), 1.)
                 .with_spacer(10.0)
-                .with_child(Button::<OurData>::new("freeze", move |ctx, data, _env| {
-                    ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_three)
-                }))
+                .with_child(
+                    Button::<OurData>::new("freeze").on_click(move |ctx, data, _env| {
+                        ctx.submit_command(Command::new(FREEZE_COLOR, data.color.clone()), id_three)
+                    }),
+                )
                 .with_spacer(10.0)
-                .with_child(Button::<OurData>::new("unfreeze", move |ctx, _, _env| {
-                    ctx.submit_command(UNFREEZE_COLOR, id_three)
-                })),
+                .with_child(
+                    Button::<OurData>::new("unfreeze")
+                        .on_click(move |ctx, _, _env| ctx.submit_command(UNFREEZE_COLOR, id_three)),
+                ),
             0.5,
         )
         .padding(10.)

--- a/druid/examples/layout.rs
+++ b/druid/examples/layout.rs
@@ -33,7 +33,7 @@ fn build_app() -> impl Widget<u32> {
     // Spacing element that will fill all available space in between label
     // and a button. Notice that weight is non-zero.
     header.add_flex_spacer(1.0);
-    header.add_child(Button::new("Two", Button::noop).padding(20.));
+    header.add_child(Button::new("Two").padding(20.));
     col.add_child(
         header
             .fix_height(100.0)
@@ -46,7 +46,7 @@ fn build_app() -> impl Widget<u32> {
         let weight = if i == 2 { 3.0 } else { 1.0 };
         // call `expand_height` to force the buttons to use all their provided flex
         col.add_flex_child(
-            Button::new(format!("Button #{}", i), Button::noop).expand_height(),
+            Button::new(format!("Button #{}", i)).expand_height(),
             weight,
         );
     }

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -47,17 +47,18 @@ fn ui_builder() -> impl Widget<AppData> {
 
     // Build a button to add children to both lists
     root.add_child(
-        Button::new("Add", |_, data: &mut AppData, _| {
-            // Add child to left list
-            let value = data.left.len() + 1;
-            Arc::make_mut(&mut data.left).push(value as u32);
+        Button::new("Add")
+            .on_click(|_, data: &mut AppData, _| {
+                // Add child to left list
+                let value = data.left.len() + 1;
+                Arc::make_mut(&mut data.left).push(value as u32);
 
-            // Add child to right list
-            let value = data.right.len() + 1;
-            Arc::make_mut(&mut data.right).push(value as u32);
-        })
-        .fix_height(30.0)
-        .expand_width(),
+                // Add child to right list
+                let value = data.right.len() + 1;
+                Arc::make_mut(&mut data.right).push(value as u32);
+            })
+            .fix_height(30.0)
+            .expand_width(),
     );
 
     let mut lists = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);
@@ -89,16 +90,14 @@ fn ui_builder() -> impl Widget<AppData> {
                 )
                 .with_flex_spacer(1.0)
                 .with_child(
-                    Button::new(
-                        "Delete",
-                        |_ctx, (shared, item): &mut (Arc<Vec<u32>>, u32), _env| {
+                    Button::new("Delete")
+                        .on_click(|_ctx, (shared, item): &mut (Arc<Vec<u32>>, u32), _env| {
                             // We have access to both child's data and shared data.
                             // Remove element from right list.
                             Arc::make_mut(shared).retain(|v| v != item);
-                        },
-                    )
-                    .fix_size(80.0, 20.0)
-                    .align_vertical(UnitPoint::CENTER),
+                        })
+                        .fix_size(80.0, 20.0)
+                        .align_vertical(UnitPoint::CENTER),
                 )
                 .padding(10.0)
                 .background(Color::rgb(0.5, 0.0, 0.5))

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -17,8 +17,8 @@
 use druid::widget::{Align, Button, Flex, Label, Padding};
 use druid::{
     commands as sys_cmds, AppDelegate, AppLauncher, Command, ContextMenu, Data, DelegateCtx, Env,
-    Event, EventCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, Widget, WindowDesc,
-    WindowId,
+    Event, EventCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, Widget, WidgetExt,
+    WindowDesc, WindowId,
 };
 
 use log::info;
@@ -63,11 +63,11 @@ fn ui_builder() -> impl Widget<State> {
     let text = LocalizedString::new("hello-counter")
         .with_arg("count", |data: &State, _env| data.menu_count.into());
     let label = Label::new(text);
-    let inc_button = Button::<State>::new("Add menu item", |ctx, data, _env| {
+    let inc_button = Button::<State>::new("Add menu item").on_click(|ctx, data, _env| {
         data.menu_count += 1;
         ctx.set_menu(make_menu::<State>(data));
     });
-    let dec_button = Button::<State>::new("Remove menu item", |ctx, data, _env| {
+    let dec_button = Button::<State>::new("Remove menu item").on_click(|ctx, data, _env| {
         data.menu_count = data.menu_count.saturating_sub(1);
         ctx.set_menu(make_menu::<State>(data));
     });

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -17,8 +17,8 @@
 use druid::widget::{Align, Button, Flex, Label, Padding};
 use druid::{
     commands as sys_cmds, AppDelegate, AppLauncher, Command, ContextMenu, Data, DelegateCtx, Env,
-    Event, EventCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, Widget, WidgetExt,
-    WindowDesc, WindowId,
+    Event, EventCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, Widget, WindowDesc,
+    WindowId,
 };
 
 use log::info;

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -28,7 +28,7 @@ fn main() {
     use log::error;
 
     use druid::{
-        widget::{Button, FillStrat, Flex, Svg, SvgData, WidgetExt},
+        widget::{FillStrat, Flex, Svg, SvgData, WidgetExt},
         AppLauncher, LocalizedString, Widget, WindowDesc,
     };
 
@@ -54,14 +54,7 @@ fn main() {
 
         col.add_flex_child(Svg::new(tiger_svg.clone()).fix_width(60.0).center(), 1.0);
         col.add_flex_child(Svg::new(tiger_svg.clone()).fill_mode(FillStrat::Fill), 1.0);
-        col.add_flex_child(Svg::new(tiger_svg.clone()), 1.0);
-        col.add_flex_child(
-            Button::with_child(Svg::new(tiger_svg))
-                .fix_width(100.0)
-                .fix_height(100.0)
-                .center(),
-            1.0,
-        );
-        col
+        col.add_flex_child(Svg::new(tiger_svg), 1.0);
+        col.debug_paint_layout()
     }
 }

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -28,7 +28,7 @@ fn main() {
     use log::error;
 
     use druid::{
-        widget::{FillStrat, Flex, Svg, SvgData, WidgetExt},
+        widget::{Button, FillStrat, Flex, Svg, SvgData, WidgetExt},
         AppLauncher, LocalizedString, Widget, WindowDesc,
     };
 
@@ -54,7 +54,14 @@ fn main() {
 
         col.add_flex_child(Svg::new(tiger_svg.clone()).fix_width(60.0).center(), 1.0);
         col.add_flex_child(Svg::new(tiger_svg.clone()).fill_mode(FillStrat::Fill), 1.0);
-        col.add_flex_child(Svg::new(tiger_svg), 1.0);
-        col.debug_paint_layout()
+        col.add_flex_child(Svg::new(tiger_svg.clone()), 1.0);
+        col.add_flex_child(
+            Button::with_child(Svg::new(tiger_svg))
+                .fix_width(100.0)
+                .fix_height(100.0)
+                .center(),
+            1.0,
+        );
+        col
     }
 }

--- a/druid/examples/view_switcher.rs
+++ b/druid/examples/view_switcher.rs
@@ -44,10 +44,11 @@ fn make_ui() -> impl Widget<AppState> {
     for i in 0..6 {
         switcher_column.add_spacer(80.);
         switcher_column.add_child(
-            Button::<u32>::new(format!("View {}", i), move |_event, data, _env| {
-                *data = i;
-            })
-            .lens(AppState::current_view),
+            Button::new(format!("View {}", i))
+                .on_click(move |_event, data: &mut u32, _env| {
+                    *data = i;
+                })
+                .lens(AppState::current_view),
         );
     }
 
@@ -55,20 +56,21 @@ fn make_ui() -> impl Widget<AppState> {
         |data: &AppState, _env| data.current_view,
         |selector, _data, _env| match selector {
             0 => Box::new(Label::new("Simple Label").center()),
-            1 => Box::new(Button::new("Simple Button", |_event, _data, _env| {
-                println!("Simple button clicked!");
-            })),
-            2 => Box::new(Button::new(
-                "Another Simple Button",
-                |_event, _data, _env| {
+            1 => Box::new(
+                Button::new("Simple Button").on_click(|_event, _data, _env| {
+                    println!("Simple button clicked!");
+                }),
+            ),
+            2 => Box::new(
+                Button::new("Another Simple Button").on_click(|_event, _data, _env| {
                     println!("Another simple button clicked!");
-                },
-            )),
+                }),
+            ),
             3 => Box::new(
                 Flex::column()
                     .with_flex_child(Label::new("Here is a label").center(), 1.0)
                     .with_flex_child(
-                        Button::new("Button", |_event, _data, _env| {
+                        Button::new("Button").on_click(|_event, _data, _env| {
                             println!("Complex button clicked!");
                         }),
                         1.0,

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -38,7 +38,6 @@ fn propogate_hot() {
     let widget = Split::vertical(
         SizedBox::empty().with_id(empty),
         Button::new("hot")
-            .on_click(|_, _, _| {})
             .record(&button_rec)
             .with_id(button)
             .padding(50.)

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -37,7 +37,8 @@ fn propogate_hot() {
 
     let widget = Split::vertical(
         SizedBox::empty().with_id(empty),
-        Button::new("hot", |_, _, _| {})
+        Button::new("hot")
+            .on_click(|_, _, _| {})
             .record(&button_rec)
             .with_id(button)
             .padding(50.)

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -50,9 +50,10 @@ impl<T: Data> Button<T> {
             let is_active = ctx.is_active();
             let is_hot = ctx.is_hot();
             let size = ctx.size();
+            let border_width = env.get(theme::BUTTON_BORDER_WIDTH);
 
             let rounded_rect = Rect::from_origin_size(Point::ORIGIN, size)
-                .inset(-1.0)
+                .inset(border_width / -2.0)
                 .to_rounded_rect(env.get(theme::BUTTON_BORDER_RADIUS));
 
             let bg_gradient = if is_active {
@@ -75,11 +76,7 @@ impl<T: Data> Button<T> {
                 env.get(theme::BORDER_DARK)
             };
 
-            ctx.stroke(
-                rounded_rect,
-                &border_color,
-                env.get(theme::BUTTON_BORDER_WIDTH),
-            );
+            ctx.stroke(rounded_rect, &border_color, border_width);
 
             ctx.fill(rounded_rect, &bg_gradient);
         })

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -14,10 +14,9 @@
 
 //! A button widget.
 use crate::theme;
-use crate::widget::{Label, LabelText, Painter};
+use crate::widget::{Flex, Label, LabelText, MainAxisAlignment, Painter};
 use crate::{
-    Affine, BoxConstraints, Data, Env, Event, EventCtx, Insets, LayoutCtx, LifeCycle, LifeCycleCtx,
-    LinearGradient, PaintCtx, Point, Rect, RenderContext, Size, UnitPoint, UpdateCtx, Widget,
+    Data, Env, EventCtx, Insets, LinearGradient, Point, Rect, RenderContext, UnitPoint, Widget,
     WidgetExt,
 };
 
@@ -39,7 +38,9 @@ impl<T: Data> Button<T> {
         action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static,
     ) -> impl Widget<T> {
         let painter = Self::painter();
-        CenteredLabel::new(text)
+        Flex::row()
+            .with_child(Label::new(text))
+            .main_axis_alignment(MainAxisAlignment::Center)
             .padding(LABEL_INSETS)
             .background(painter)
             .on_click(action)
@@ -92,55 +93,4 @@ impl<T: Data> Button<T> {
     /// let button = Button::<u32>::new("hello", Button::noop);
     /// ```
     pub fn noop(_: &mut EventCtx, _: &mut T, _: &Env) {}
-}
-
-struct CenteredLabel<T> {
-    label: Label<T>,
-    label_size: Size,
-}
-
-impl<T: Data> CenteredLabel<T> {
-    pub fn new(text: impl Into<LabelText<T>>) -> CenteredLabel<T> {
-        CenteredLabel {
-            label: Label::new(text),
-            label_size: Size::ZERO,
-        }
-    }
-}
-
-impl<T: Data> Widget<T> for CenteredLabel<T> {
-    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
-
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
-        if let LifeCycle::HotChanged(_) = event {
-            ctx.request_paint();
-        }
-        self.label.lifecycle(ctx, event, data, env)
-    }
-
-    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.label.update(ctx, old_data, data, env)
-    }
-
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
-        bc.debug_check("CenteredLabel");
-        let label_bc = bc.loosen();
-        self.label_size = self.label.layout(layout_ctx, &label_bc, data, env);
-        bc.constrain(self.label_size)
-    }
-
-    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        let label_offset = (ctx.size().to_vec2() - self.label_size.to_vec2()) / 2.0;
-
-        ctx.with_save(|ctx| {
-            ctx.transform(Affine::translate(label_offset));
-            self.label.paint(ctx, data, env);
-        });
-    }
 }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -13,25 +13,22 @@
 // limitations under the License.
 
 //! A button widget.
-
 use crate::theme;
-use crate::widget::{Label, LabelText};
+use crate::widget::{Label, LabelText, Painter};
 use crate::{
     Affine, BoxConstraints, Data, Env, Event, EventCtx, Insets, LayoutCtx, LifeCycle, LifeCycleCtx,
     LinearGradient, PaintCtx, Point, Rect, RenderContext, Size, UnitPoint, UpdateCtx, Widget,
+    WidgetExt,
 };
 
 // the minimum padding added to a button.
 // NOTE: these values are chosen to match the existing look of TextBox; these
 // should be reevaluated at some point.
-const LABEL_INSETS: Insets = Insets::uniform_xy(8., 2.);
+const LABEL_INSETS: Insets = Insets::uniform_xy(8., 4.);
 
 /// A button with a text label.
 pub struct Button<T> {
-    label: Label<T>,
-    label_size: Size,
-    /// A closure that will be invoked when the button is clicked.
-    action: Box<dyn Fn(&mut EventCtx, &mut T, &Env)>,
+    phantom: std::marker::PhantomData<T>,
 }
 
 impl<T: Data> Button<T> {
@@ -40,12 +37,52 @@ impl<T: Data> Button<T> {
     pub fn new(
         text: impl Into<LabelText<T>>,
         action: impl Fn(&mut EventCtx, &mut T, &Env) + 'static,
-    ) -> Button<T> {
-        Button {
-            label: Label::new(text),
-            label_size: Size::ZERO,
-            action: Box::new(action),
-        }
+    ) -> impl Widget<T> {
+        let painter = Self::painter();
+        CenteredLabel::new(text)
+            .padding(LABEL_INSETS)
+            .background(painter)
+            .on_click(action)
+    }
+
+    fn painter() -> Painter<T> {
+        Painter::new(|ctx, _, env| {
+            let is_active = ctx.is_active();
+            let is_hot = ctx.is_hot();
+            let size = ctx.size();
+
+            let rounded_rect = Rect::from_origin_size(Point::ORIGIN, size)
+                .inset(-1.0)
+                .to_rounded_rect(env.get(theme::BUTTON_BORDER_RADIUS));
+
+            let bg_gradient = if is_active {
+                LinearGradient::new(
+                    UnitPoint::TOP,
+                    UnitPoint::BOTTOM,
+                    (env.get(theme::BUTTON_DARK), env.get(theme::BUTTON_LIGHT)),
+                )
+            } else {
+                LinearGradient::new(
+                    UnitPoint::TOP,
+                    UnitPoint::BOTTOM,
+                    (env.get(theme::BUTTON_LIGHT), env.get(theme::BUTTON_DARK)),
+                )
+            };
+
+            let border_color = if is_hot {
+                env.get(theme::BORDER_LIGHT)
+            } else {
+                env.get(theme::BORDER_DARK)
+            };
+
+            ctx.stroke(
+                rounded_rect,
+                &border_color,
+                env.get(theme::BUTTON_BORDER_WIDTH),
+            );
+
+            ctx.fill(rounded_rect, &bg_gradient);
+        })
     }
 
     /// A function that can be passed to `Button::new`, for buttons with no action.
@@ -60,25 +97,22 @@ impl<T: Data> Button<T> {
     pub fn noop(_: &mut EventCtx, _: &mut T, _: &Env) {}
 }
 
-impl<T: Data> Widget<T> for Button<T> {
-    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
-        match event {
-            Event::MouseDown(_) => {
-                ctx.set_active(true);
-                ctx.request_paint();
-            }
-            Event::MouseUp(_) => {
-                if ctx.is_active() {
-                    ctx.set_active(false);
-                    ctx.request_paint();
-                    if ctx.is_hot() {
-                        (self.action)(ctx, data, env);
-                    }
-                }
-            }
-            _ => (),
+struct CenteredLabel<T> {
+    label: Label<T>,
+    label_size: Size,
+}
+
+impl<T: Data> CenteredLabel<T> {
+    pub fn new(text: impl Into<LabelText<T>>) -> CenteredLabel<T> {
+        CenteredLabel {
+            label: Label::new(text),
+            label_size: Size::ZERO,
         }
     }
+}
+
+impl<T: Data> Widget<T> for CenteredLabel<T> {
+    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut T, _env: &Env) {}
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::HotChanged(_) = event {
@@ -98,57 +132,14 @@ impl<T: Data> Widget<T> for Button<T> {
         data: &T,
         env: &Env,
     ) -> Size {
-        bc.debug_check("Button");
-        let padding = Size::new(LABEL_INSETS.x_value(), LABEL_INSETS.y_value());
-        let label_bc = bc.shrink(padding).loosen();
+        bc.debug_check("CenteredLabel");
+        let label_bc = bc.loosen();
         self.label_size = self.label.layout(layout_ctx, &label_bc, data, env);
-        // HACK: to make sure we look okay at default sizes when beside a textbox,
-        // we make sure we will have at least the same height as the default textbox.
-        let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
-
-        bc.constrain(Size::new(
-            self.label_size.width + padding.width,
-            (self.label_size.height + padding.height).max(min_height),
-        ))
+        bc.constrain(self.label_size)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        let is_active = ctx.is_active();
-        let is_hot = ctx.is_hot();
-        let size = ctx.size();
-
-        let rounded_rect = Rect::from_origin_size(Point::ORIGIN, size)
-            .to_rounded_rect(env.get(theme::BUTTON_BORDER_RADIUS));
-
-        let bg_gradient = if is_active {
-            LinearGradient::new(
-                UnitPoint::TOP,
-                UnitPoint::BOTTOM,
-                (env.get(theme::BUTTON_LIGHT), env.get(theme::BUTTON_DARK)),
-            )
-        } else {
-            LinearGradient::new(
-                UnitPoint::TOP,
-                UnitPoint::BOTTOM,
-                (env.get(theme::BUTTON_DARK), env.get(theme::BUTTON_LIGHT)),
-            )
-        };
-
-        let border_color = if is_hot {
-            env.get(theme::BORDER_LIGHT)
-        } else {
-            env.get(theme::BORDER_DARK)
-        };
-
-        ctx.stroke(
-            rounded_rect,
-            &border_color,
-            env.get(theme::BUTTON_BORDER_WIDTH),
-        );
-
-        ctx.fill(rounded_rect, &bg_gradient);
-
-        let label_offset = (size.to_vec2() - self.label_size.to_vec2()) / 2.0;
+        let label_offset = (ctx.size().to_vec2() - self.label_size.to_vec2()) / 2.0;
 
         ctx.with_save(|ctx| {
             ctx.transform(Affine::translate(label_offset));

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -15,19 +15,19 @@
 //! A button widget.
 use crate::theme;
 use crate::widget::prelude::*;
-use crate::widget::{
-    Click, Container, ControllerHost, Flex, Label, LabelText, MainAxisAlignment, Padding, Painter,
-};
-use crate::{Data, Insets, LinearGradient, Point, Rect, RenderContext, UnitPoint, Widget};
+use crate::widget::{Click, ControllerHost, Label, LabelText};
+
+use crate::{Affine, Data, Insets, LinearGradient, Point, Rect, RenderContext, UnitPoint, Widget};
 
 // the minimum padding added to a button.
 // NOTE: these values are chosen to match the existing look of TextBox; these
 // should be reevaluated at some point.
-const LABEL_INSETS: Insets = Insets::uniform_xy(8., 4.);
+const LABEL_INSETS: Insets = Insets::uniform_xy(8., 2.);
 
 /// A button with a text label.
 pub struct Button<T> {
-    child: Box<dyn Widget<T>>,
+    label: Label<T>,
+    label_size: Size,
 }
 
 impl<T: Data> Button<T> {
@@ -46,24 +46,9 @@ impl<T: Data> Button<T> {
     /// });
     /// ```
     pub fn new(text: impl Into<LabelText<T>>) -> Button<T> {
-        Button::with_child(
-            Flex::row()
-                .with_child(Label::new(text))
-                .main_axis_alignment(MainAxisAlignment::Center),
-        )
-    }
-
-    /// Create a new button that wraps a child widget.
-    ///
-    /// The widget will receive padding and a styled background and border. If
-    /// you want a clickable widget without the styling, consider just using
-    /// `.on_click` from [`WidgetExt`] without the Button.
-    ///
-    /// [`WidgetExt`]: trait.WidgetExt.html#method.on_click
-    pub fn with_child(child: impl Widget<T> + 'static) -> Button<T> {
-        let painter = Self::painter();
         Button {
-            child: Box::new(Container::new(Padding::new(LABEL_INSETS, child)).background(painter)),
+            label: Label::new(text),
+            label_size: Size::ZERO,
         }
     }
 
@@ -74,47 +59,10 @@ impl<T: Data> Button<T> {
     ) -> ControllerHost<Self, Click<T>> {
         ControllerHost::new(self, Click::new(f))
     }
-
-    fn painter() -> Painter<T> {
-        Painter::new(|ctx, _, env| {
-            let is_active = ctx.is_active();
-            let is_hot = ctx.is_hot();
-            let size = ctx.size();
-            let border_width = env.get(theme::BUTTON_BORDER_WIDTH);
-
-            let rounded_rect = Rect::from_origin_size(Point::ORIGIN, size)
-                .inset(border_width / -2.0)
-                .to_rounded_rect(env.get(theme::BUTTON_BORDER_RADIUS));
-
-            let bg_gradient = if is_active {
-                LinearGradient::new(
-                    UnitPoint::TOP,
-                    UnitPoint::BOTTOM,
-                    (env.get(theme::BUTTON_DARK), env.get(theme::BUTTON_LIGHT)),
-                )
-            } else {
-                LinearGradient::new(
-                    UnitPoint::TOP,
-                    UnitPoint::BOTTOM,
-                    (env.get(theme::BUTTON_LIGHT), env.get(theme::BUTTON_DARK)),
-                )
-            };
-
-            let border_color = if is_hot {
-                env.get(theme::BORDER_LIGHT)
-            } else {
-                env.get(theme::BORDER_DARK)
-            };
-
-            ctx.stroke(rounded_rect, &border_color, border_width);
-
-            ctx.fill(rounded_rect, &bg_gradient);
-        })
-    }
 }
 
 impl<T: Data> Widget<T> for Button<T> {
-    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut T, _env: &Env) {
         match event {
             Event::MouseDown(_) => {
                 ctx.set_active(true);
@@ -128,27 +76,81 @@ impl<T: Data> Widget<T> for Button<T> {
             }
             _ => (),
         }
-
-        self.child.event(ctx, event, data, env)
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         if let LifeCycle::HotChanged(_) = event {
             ctx.request_paint();
         }
-        self.child.lifecycle(ctx, event, data, env)
+        self.label.lifecycle(ctx, event, data, env)
     }
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
-        self.child.update(ctx, old_data, data, env)
+        self.label.update(ctx, old_data, data, env)
     }
 
-    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+    fn layout(
+        &mut self,
+        layout_ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &T,
+        env: &Env,
+    ) -> Size {
         bc.debug_check("Button");
-        self.child.layout(ctx, bc, data, env)
+        let padding = Size::new(LABEL_INSETS.x_value(), LABEL_INSETS.y_value());
+        let label_bc = bc.shrink(padding).loosen();
+        self.label_size = self.label.layout(layout_ctx, &label_bc, data, env);
+        // HACK: to make sure we look okay at default sizes when beside a textbox,
+        // we make sure we will have at least the same height as the default textbox.
+        let min_height = env.get(theme::BORDERED_WIDGET_HEIGHT);
+
+        bc.constrain(Size::new(
+            self.label_size.width + padding.width,
+            (self.label_size.height + padding.height).max(min_height),
+        ))
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        self.child.paint(ctx, data, env)
+        let is_active = ctx.is_active();
+        let is_hot = ctx.is_hot();
+        let size = ctx.size();
+
+        let rounded_rect = Rect::from_origin_size(Point::ORIGIN, size)
+            .to_rounded_rect(env.get(theme::BUTTON_BORDER_RADIUS));
+
+        let bg_gradient = if is_active {
+            LinearGradient::new(
+                UnitPoint::TOP,
+                UnitPoint::BOTTOM,
+                (env.get(theme::BUTTON_DARK), env.get(theme::BUTTON_LIGHT)),
+            )
+        } else {
+            LinearGradient::new(
+                UnitPoint::TOP,
+                UnitPoint::BOTTOM,
+                (env.get(theme::BUTTON_LIGHT), env.get(theme::BUTTON_DARK)),
+            )
+        };
+
+        let border_color = if is_hot {
+            env.get(theme::BORDER_LIGHT)
+        } else {
+            env.get(theme::BORDER_DARK)
+        };
+
+        ctx.stroke(
+            rounded_rect,
+            &border_color,
+            env.get(theme::BUTTON_BORDER_WIDTH),
+        );
+
+        ctx.fill(rounded_rect, &bg_gradient);
+
+        let label_offset = (size.to_vec2() - self.label_size.to_vec2()) / 2.0;
+
+        ctx.with_save(|ctx| {
+            ctx.transform(Affine::translate(label_offset));
+            self.label.paint(ctx, data, env);
+        });
     }
 }

--- a/druid/src/widget/button.rs
+++ b/druid/src/widget/button.rs
@@ -39,7 +39,7 @@ impl<T: Data> Button<T> {
     /// # Examples
     ///
     /// ```
-    /// use druid::widget::{Button};
+    /// use druid::widget::Button;
     ///
     /// let button = Button::new("Increment").on_click(|_ctx, data: &mut u32, _env| {
     ///     *data += 1;


### PR DESCRIPTION
closes #745 

This behaves and scales pretty much exactly like the standard button. The only change is I flipped the gradient so that it's light on top — not sure how it got flipped in the first place. I also believe I have the correct inset on the background size so the border doesn't paint outside its bounds anymore (#628).

I'm not super excited about needing this CenteredLabel widget for centering the label, but I couldn't figure out how to do it with standard layout widgets. (See [related zulip discussion](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/ConstrainedBox) for my tale of woe)