### PR TITLE
Align Flex layout to integers.

### DIFF
--- a/druid/src/box_constraints.rs
+++ b/druid/src/box_constraints.rs
@@ -117,6 +117,11 @@ impl BoxConstraints {
         }
     }
 
+    /// Shrink min and max constraints to integers.
+    pub fn trunc(&self) -> BoxConstraints {
+        BoxConstraints::new(self.min.trunc(), self.max.trunc())
+    }
+
     /// Shrink min and max constraints by size
     pub fn shrink(&self, diff: impl Into<Size>) -> BoxConstraints {
         let diff = diff.into();

--- a/druid/src/box_constraints.rs
+++ b/druid/src/box_constraints.rs
@@ -29,8 +29,12 @@ use log;
 /// Further, a container widget should compute appropriate constraints
 /// for each of its child widgets, and pass those down when recursing.
 ///
+/// The constraints are always [rounded away from zero] to integers
+/// to enable pixel perfect layout.
+///
 /// [`layout`]: trait.Widget.html#tymethod.layout
 /// [Flutter BoxConstraints]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
+/// [rounded away from zero]: struct.Size.html#method.expand
 #[derive(Clone, Copy, Debug)]
 pub struct BoxConstraints {
     min: Size,
@@ -41,14 +45,28 @@ impl BoxConstraints {
     /// Create a new box constraints object.
     ///
     /// Create constraints based on minimum and maximum size.
+    ///
+    /// The given sizes are also [rounded away from zero],
+    /// so that the layout is aligned to integers.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
     pub fn new(min: Size, max: Size) -> BoxConstraints {
-        BoxConstraints { min, max }
+        BoxConstraints {
+            min: min.expand(),
+            max: max.expand(),
+        }
     }
 
     /// Create a "tight" box constraints object.
     ///
     /// A "tight" constraint can only be satisfied by a single size.
+    ///
+    /// The given size is also [rounded away from zero],
+    /// so that the layout is aligned to integers.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
     pub fn tight(size: Size) -> BoxConstraints {
+        let size = size.expand();
         BoxConstraints {
             min: size,
             max: size,
@@ -68,7 +86,7 @@ impl BoxConstraints {
     /// Clamp a given size so that it fits within the constraints.
     ///
     /// The given size is also [rounded away from zero],
-    /// so that the layout is aligned to pixels.
+    /// so that the layout is aligned to integers.
     ///
     /// [rounded away from zero]: struct.Size.html#method.expand
     pub fn constrain(&self, size: impl Into<Size>) -> Size {
@@ -102,7 +120,9 @@ impl BoxConstraints {
         if !(0.0 <= self.min.width
             && self.min.width <= self.max.width
             && 0.0 <= self.min.height
-            && self.min.height <= self.max.height)
+            && self.min.height <= self.max.height
+            && self.min.expand() == self.min
+            && self.max.expand() == self.max)
         {
             log::warn!("Bad BoxConstraints passed to {}:", name);
             log::warn!("{:?}", self);
@@ -117,14 +137,14 @@ impl BoxConstraints {
         }
     }
 
-    /// Shrink min and max constraints to integers.
-    pub fn trunc(&self) -> BoxConstraints {
-        BoxConstraints::new(self.min.trunc(), self.max.trunc())
-    }
-
     /// Shrink min and max constraints by size
+    ///
+    /// The given size is also [rounded away from zero],
+    /// so that the layout is aligned to integers.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
     pub fn shrink(&self, diff: impl Into<Size>) -> BoxConstraints {
-        let diff = diff.into();
+        let diff = diff.into().expand();
         let min = Size::new(
             (self.min().width - diff.width).max(0.),
             (self.min().height - diff.height).max(0.),

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -535,15 +535,12 @@ impl<T: Data> Widget<T> for Flex<T> {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Flex");
-        // Even if given fractional size constraints,
-        // we will only operate on integers to remain aligned to pixels.
-        let int_bc = bc.trunc();
         // we loosen our constraints when passing to children.
-        let loosened_bc = int_bc.loosen();
+        let loosened_bc = bc.loosen();
 
         // Measure non-flex children.
         let mut major_non_flex = 0.0;
-        let mut minor = self.direction.minor(int_bc.min());
+        let mut minor = self.direction.minor(bc.min());
         for child in &mut self.children {
             if child.params.flex == 0.0 {
                 let child_bc = self
@@ -567,7 +564,7 @@ impl<T: Data> Widget<T> for Flex<T> {
             }
         }
 
-        let total_major = self.direction.major(int_bc.max());
+        let total_major = self.direction.major(bc.max());
         let remaining = (total_major - major_non_flex).max(0.0);
         let mut remainder: f64 = 0.0;
         let flex_sum: f64 = self.children.iter().map(|child| child.params.flex).sum();
@@ -600,7 +597,7 @@ impl<T: Data> Widget<T> for Flex<T> {
         } else {
             // if we are *not* expected to fill our available space this usually
             // means we don't have any extra, unless dictated by our constraints.
-            (self.direction.major(int_bc.min()) - (major_non_flex + major_flex)).max(0.0)
+            (self.direction.major(bc.min()) - (major_non_flex + major_flex)).max(0.0)
         };
 
         let spacing = self.main_alignment.spacing(extra, self.children.len());
@@ -746,7 +743,7 @@ impl MainAxisAlignment {
                     let equal_space = extra / count as f64;
                     let mut remainder = 0.;
                     let mut half = 0.;
-                    let mut spaces = Vec::with_capacity(count / 2 + 1);
+                    let mut spaces = Vec::with_capacity(n + 1);
                     for i in 0..count {
                         let desired_space = equal_space + remainder;
                         let actual_space = desired_space.round();

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -533,13 +533,7 @@ impl<T: Data> Widget<T> for Flex<T> {
         }
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Flex");
         // Even if given fractional size constraints,
         // we will only operate on integers to remain aligned to pixels.
@@ -555,7 +549,7 @@ impl<T: Data> Widget<T> for Flex<T> {
                 let child_bc = self
                     .direction
                     .constraints(&loosened_bc, 0., std::f64::INFINITY);
-                let child_size = child.widget.layout(layout_ctx, &child_bc, data, env);
+                let child_size = child.widget.layout(ctx, &child_bc, data, env);
 
                 if child_size.width.is_infinite() {
                     log::warn!("A non-Flex child has an infinite width.");
@@ -590,7 +584,7 @@ impl<T: Data> Widget<T> for Flex<T> {
                 let child_bc = self
                     .direction
                     .constraints(&loosened_bc, min_major, actual_major);
-                let child_size = child.widget.layout(layout_ctx, &child_bc, data, env);
+                let child_size = child.widget.layout(ctx, &child_bc, data, env);
 
                 major_flex += self.direction.major(child_size).expand();
                 minor = minor.max(self.direction.minor(child_size).expand());
@@ -648,7 +642,7 @@ impl<T: Data> Widget<T> for Flex<T> {
 
         let my_bounds = Rect::ZERO.with_size(my_size);
         let insets = child_paint_rect - my_bounds;
-        layout_ctx.set_paint_insets(insets);
+        ctx.set_paint_insets(insets);
         my_size
     }
 


### PR DESCRIPTION
This PR is a continuation of work in #669 and makes `Flex` align everything to integers.

There are multiple possible strategies in choosing which children/paddings get the extra pixels. I based my work on how Chrome 80 handles it with CSS flex. If nothing else it will be the least surprising approach to people familiar with web flex layout.

* If `Flex` is given fractional constraints then it will truncate it to integers for child layout purposes. It will still use the untouched fractional constraints to calculate its own size. This is one behavior that diverges somewhat from Chrome 80. Chrome will round its constraints which means that a 10.5px flex container will actually paint 11px. My guiding principles here were that widgets should not paint beyond what they promise and that `Flex` should always provide its children integer constraints. I'm happy for discussion on this behavior though.
* All children of `Flex` will get integer constraints and origin.
* If any child returns a fractional size, `Flex` will expand it to the nearest integer for layout purposes.
* All `Flex` alignment options now align to integers.

The general strategy for padding and child size calculation can be described as *round and carry over the remainder*. It's pretty straightforward and nicely uses up all the space. It tends to distribute the extra pixels in stripe patterns and so rows/columns won't look out of balance as easily.

With the above changes `Flex` becomes a strong ally in achieving a pixel perfect design. The only weakness that I'm aware of right now is when the `Flex` widget's own origin is fractional. With increasingly more of druid's included widgets and tools working in favor of pixel alignment, this issue is likely to only surface if someone writes their own custom layout without care for alignment. That's a scenario for which a future druid book chapter I'm thinking of writing can be of help.