### PR TITLE
Terminate app run loop on Windows when all windows have closed.

### DIFF
--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -84,7 +84,7 @@ impl WinHandler for InvalidateTest {
 }
 
 fn main() {
-    let app = Application::new();
+    let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let inv_test = InvalidateTest {
         size: Default::default(),

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -84,8 +84,8 @@ impl WinHandler for InvalidateTest {
 }
 
 fn main() {
-    let mut app = Application::new(None);
-    let mut builder = WindowBuilder::new();
+    let app = Application::new();
+    let mut builder = WindowBuilder::new(app.clone());
     let inv_test = InvalidateTest {
         size: Default::default(),
         handle: Default::default(),
@@ -98,5 +98,5 @@ fn main() {
 
     let window = builder.build().unwrap();
     window.show();
-    app.run();
+    app.run(None);
 }

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -19,7 +19,7 @@ use time::Instant;
 use piet_common::kurbo::{Line, Rect};
 use piet_common::{Color, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
-use druid_shell::{Application, KeyEvent, WinHandler, WindowBuilder, WindowHandle};
+use druid_shell::{AppState, Application, KeyEvent, WinHandler, WindowBuilder, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
@@ -116,8 +116,9 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    let mut app = Application::new(None);
-    let mut builder = WindowBuilder::new();
+    let state = AppState::new();
+    let mut app = Application::new(state.clone(), None);
+    let mut builder = WindowBuilder::new(state);
     let perf_test = PerfTest {
         size: Default::default(),
         handle: Default::default(),

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -116,7 +116,7 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    let app = Application::new();
+    let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     let perf_test = PerfTest {
         size: Default::default(),

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -19,7 +19,7 @@ use time::Instant;
 use piet_common::kurbo::{Line, Rect};
 use piet_common::{Color, FontBuilder, Piet, RenderContext, Text, TextLayoutBuilder};
 
-use druid_shell::{AppState, Application, KeyEvent, WinHandler, WindowBuilder, WindowHandle};
+use druid_shell::{Application, KeyEvent, WinHandler, WindowBuilder, WindowHandle};
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
 const FG_COLOR: Color = Color::rgb8(0xf0, 0xf0, 0xea);
@@ -107,7 +107,7 @@ impl WinHandler for PerfTest {
     }
 
     fn destroy(&mut self) {
-        Application::quit()
+        Application::global().quit()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {
@@ -116,9 +116,8 @@ impl WinHandler for PerfTest {
 }
 
 fn main() {
-    let state = AppState::new();
-    let mut app = Application::new(state.clone(), None);
-    let mut builder = WindowBuilder::new(state);
+    let app = Application::new();
+    let mut builder = WindowBuilder::new(app.clone());
     let perf_test = PerfTest {
         size: Default::default(),
         handle: Default::default(),
@@ -131,5 +130,5 @@ fn main() {
     let window = builder.build().unwrap();
     window.show();
 
-    app.run();
+    app.run(None);
 }

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -129,7 +129,7 @@ fn main() {
     menubar.add_dropdown(Menu::new(), "Application", true);
     menubar.add_dropdown(file_menu, "&File", true);
 
-    let app = Application::new();
+    let app = Application::new().unwrap();
     let mut builder = WindowBuilder::new(app.clone());
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -18,8 +18,8 @@ use druid_shell::kurbo::{Line, Rect, Vec2};
 use druid_shell::piet::{Color, RenderContext};
 
 use druid_shell::{
-    AppState, Application, Cursor, FileDialogOptions, FileSpec, HotKey, KeyEvent, KeyModifiers,
-    Menu, MouseEvent, SysMods, TimerToken, WinHandler, WindowBuilder, WindowHandle,
+    Application, Cursor, FileDialogOptions, FileSpec, HotKey, KeyEvent, KeyModifiers, Menu,
+    MouseEvent, SysMods, TimerToken, WinHandler, WindowBuilder, WindowHandle,
 };
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
@@ -48,7 +48,7 @@ impl WinHandler for HelloState {
         match id {
             0x100 => {
                 self.handle.close();
-                Application::quit();
+                Application::global().quit()
             }
             0x101 => {
                 let options = FileDialogOptions::new().show_hidden().allowed_types(vec![
@@ -101,7 +101,7 @@ impl WinHandler for HelloState {
     }
 
     fn destroy(&mut self) {
-        Application::quit()
+        Application::global().quit()
     }
 
     fn as_any(&mut self) -> &mut dyn Any {
@@ -129,9 +129,8 @@ fn main() {
     menubar.add_dropdown(Menu::new(), "Application", true);
     menubar.add_dropdown(file_menu, "&File", true);
 
-    let state = AppState::new();
-    let mut app = Application::new(state.clone(), None);
-    let mut builder = WindowBuilder::new(state);
+    let app = Application::new();
+    let mut builder = WindowBuilder::new(app.clone());
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");
     builder.set_menu(menubar);
@@ -139,5 +138,5 @@ fn main() {
     let window = builder.build().unwrap();
     window.show();
 
-    app.run();
+    app.run(None);
 }

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -18,8 +18,8 @@ use druid_shell::kurbo::{Line, Rect, Vec2};
 use druid_shell::piet::{Color, RenderContext};
 
 use druid_shell::{
-    Application, Cursor, FileDialogOptions, FileSpec, HotKey, KeyEvent, KeyModifiers, Menu,
-    MouseEvent, SysMods, TimerToken, WinHandler, WindowBuilder, WindowHandle,
+    AppState, Application, Cursor, FileDialogOptions, FileSpec, HotKey, KeyEvent, KeyModifiers,
+    Menu, MouseEvent, SysMods, TimerToken, WinHandler, WindowBuilder, WindowHandle,
 };
 
 const BG_COLOR: Color = Color::rgb8(0x27, 0x28, 0x22);
@@ -129,8 +129,9 @@ fn main() {
     menubar.add_dropdown(Menu::new(), "Application", true);
     menubar.add_dropdown(file_menu, "&File", true);
 
-    let mut app = Application::new(None);
-    let mut builder = WindowBuilder::new();
+    let state = AppState::new();
+    let mut app = Application::new(state.clone(), None);
+    let mut builder = WindowBuilder::new(state);
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");
     builder.set_menu(menubar);

--- a/druid-shell/src/clipboard.rs
+++ b/druid-shell/src/clipboard.rs
@@ -70,7 +70,7 @@ pub use crate::platform::clipboard as platform;
 /// ```no_run
 /// use druid_shell::{Application, Clipboard};
 ///
-/// let mut clipboard = Application::clipboard();
+/// let mut clipboard = Application::global().clipboard();
 /// clipboard.put_string("watch it there pal");
 /// if let Some(contents) = clipboard.get_string() {
 ///     assert_eq!("what it there pal", contents.as_str());
@@ -83,7 +83,7 @@ pub use crate::platform::clipboard as platform;
 ///  ```no_run
 /// use druid_shell::{Application, Clipboard, ClipboardFormat};
 ///
-/// let mut clipboard = Application::clipboard();
+/// let mut clipboard = Application::global().clipboard();
 ///
 /// let custom_type_id = "io.xieditor.path-clipboard-type";
 ///
@@ -104,7 +104,7 @@ pub use crate::platform::clipboard as platform;
 /// ```no_run
 /// use druid_shell::{Application, Clipboard, ClipboardFormat};
 ///
-/// let clipboard = Application::clipboard();
+/// let clipboard = Application::global().clipboard();
 ///
 /// let custom_type_id = "io.xieditor.path-clipboard-type";
 /// let supported_types = &[custom_type_id, ClipboardFormat::SVG, ClipboardFormat::PDF];

--- a/druid-shell/src/error.rs
+++ b/druid-shell/src/error.rs
@@ -20,8 +20,9 @@ use crate::platform::error as platform;
 
 /// Error codes. At the moment, this is little more than HRESULT, but that
 /// might change.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Error {
+    ApplicationAlreadyExists,
     Other(&'static str),
     Platform(platform::Error),
 }
@@ -29,6 +30,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
+            Error::ApplicationAlreadyExists => {
+                write!(f, "An application instance has already been created.")
+            }
             Error::Other(s) => write!(f, "{}", s),
             Error::Platform(p) => fmt::Display::fmt(&p, f),
         }

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -35,9 +35,10 @@ mod keycodes;
 mod menu;
 mod mouse;
 mod platform;
+mod util;
 mod window;
 
-pub use application::{AppHandler, AppState, Application};
+pub use application::{AppHandler, Application};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -37,7 +37,7 @@ mod mouse;
 mod platform;
 mod window;
 
-pub use application::{AppHandler, Application};
+pub use application::{AppHandler, AppState, Application};
 pub use clipboard::{Clipboard, ClipboardFormat, FormatId};
 pub use common_util::Counter;
 pub use dialog::{FileDialogOptions, FileInfo, FileSpec};

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -31,10 +31,19 @@ thread_local!(
     static GTK_APPLICATION: RefCell<Option<GtkApplication>> = RefCell::new(None);
 );
 
+#[derive(Clone)]
+pub struct AppState;
+
 pub struct Application;
 
+impl AppState {
+    pub(crate) fn new() -> AppState {
+        AppState
+    }
+}
+
 impl Application {
-    pub fn new(_handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new(_state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
         // TODO: we should give control over the application ID to the user
         let application = GtkApplication::new(
             Some("com.github.xi-editor.druid"),

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -32,18 +32,10 @@ thread_local!(
 );
 
 #[derive(Clone)]
-pub struct AppState;
-
-pub struct Application;
-
-impl AppState {
-    pub(crate) fn new() -> AppState {
-        AppState
-    }
-}
+pub(crate) struct Application;
 
 impl Application {
-    pub fn new(_state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new() -> Application {
         // TODO: we should give control over the application ID to the user
         let application = GtkApplication::new(
             Some("com.github.xi-editor.druid"),
@@ -68,7 +60,7 @@ impl Application {
         Application
     }
 
-    pub fn run(&mut self) {
+    pub fn run(self, _handler: Option<Box<dyn AppHandler>>) {
         util::assert_main_thread();
 
         // TODO: should we pass the command line arguments?
@@ -80,7 +72,7 @@ impl Application {
         });
     }
 
-    pub fn quit() {
+    pub fn quit(&self) {
         util::assert_main_thread();
         with_application(|app| {
             match app.get_active_window() {
@@ -95,7 +87,7 @@ impl Application {
         });
     }
 
-    pub fn clipboard() -> Clipboard {
+    pub fn clipboard(&self) -> Clipboard {
         Clipboard
     }
 

--- a/druid-shell/src/platform/gtk/application.rs
+++ b/druid-shell/src/platform/gtk/application.rs
@@ -20,9 +20,11 @@ use gio::prelude::ApplicationExtManual;
 use gio::{ApplicationExt, ApplicationFlags, Cancellable};
 use gtk::{Application as GtkApplication, GtkApplicationExt};
 
-use super::clipboard::Clipboard;
-use super::util;
 use crate::application::AppHandler;
+
+use super::clipboard::Clipboard;
+use super::error::Error;
+use super::util;
 
 // XXX: The application needs to be global because WindowBuilder::build wants
 // to construct an ApplicationWindow, which needs the application, but
@@ -35,7 +37,7 @@ thread_local!(
 pub(crate) struct Application;
 
 impl Application {
-    pub fn new() -> Application {
+    pub fn new() -> Result<Application, Error> {
         // TODO: we should give control over the application ID to the user
         let application = GtkApplication::new(
             Some("com.github.xi-editor.druid"),
@@ -57,7 +59,7 @@ impl Application {
             .expect("Could not register GTK application");
 
         GTK_APPLICATION.with(move |x| *x.borrow_mut() = Some(application));
-        Application
+        Ok(Application)
     }
 
     pub fn run(self, _handler: Option<Box<dyn AppHandler>>) {

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -33,7 +33,7 @@ use gtk::{AccelGroup, ApplicationWindow};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
-use super::application::with_application;
+use super::application::{with_application, AppState};
 use super::dialog;
 use super::menu::Menu;
 use super::util::assert_main_thread;
@@ -111,7 +111,7 @@ pub(crate) struct WindowState {
 }
 
 impl WindowBuilder {
-    pub fn new() -> WindowBuilder {
+    pub fn new(_app_state: AppState) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -33,7 +33,7 @@ use gtk::{AccelGroup, ApplicationWindow};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
-use super::application::{with_application, AppState};
+use super::application::{with_application, Application};
 use super::dialog;
 use super::menu::Menu;
 use super::util::assert_main_thread;
@@ -81,7 +81,7 @@ pub struct WindowHandle {
 }
 
 /// Builder abstraction for creating new windows
-pub struct WindowBuilder {
+pub(crate) struct WindowBuilder {
     handler: Option<Box<dyn WinHandler>>,
     title: String,
     menu: Option<Menu>,
@@ -111,7 +111,7 @@ pub(crate) struct WindowState {
 }
 
 impl WindowBuilder {
-    pub fn new(_app_state: AppState) -> WindowBuilder {
+    pub fn new(_app: Application) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),

--- a/druid-shell/src/platform/mac/application.rs
+++ b/druid-shell/src/platform/mac/application.rs
@@ -32,12 +32,21 @@ use crate::application::AppHandler;
 
 static APP_HANDLER_IVAR: &str = "druidAppHandler";
 
+#[derive(Clone)]
+pub struct AppState;
+
 pub struct Application {
     ns_app: id,
 }
 
+impl AppState {
+    pub(crate) fn new() -> AppState {
+        AppState
+    }
+}
+
 impl Application {
-    pub fn new(handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new(_state: AppState, handler: Option<Box<dyn AppHandler>>) -> Application {
         util::assert_main_thread();
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);

--- a/druid-shell/src/platform/mac/application.rs
+++ b/druid-shell/src/platform/mac/application.rs
@@ -16,11 +16,13 @@
 
 #![allow(non_upper_case_globals)]
 
+use std::cell::RefCell;
 use std::ffi::c_void;
+use std::rc::Rc;
 
 use cocoa::appkit::{NSApp, NSApplication, NSApplicationActivationPolicyRegular};
-use cocoa::base::{id, nil, YES};
-use cocoa::foundation::NSAutoreleasePool;
+use cocoa::base::{id, nil, NO, YES};
+use cocoa::foundation::{NSArray, NSAutoreleasePool};
 use lazy_static::lazy_static;
 use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel};
@@ -33,57 +35,82 @@ use crate::application::AppHandler;
 static APP_HANDLER_IVAR: &str = "druidAppHandler";
 
 #[derive(Clone)]
-pub struct AppState;
-
-pub struct Application {
+pub(crate) struct Application {
     ns_app: id,
+    state: Rc<RefCell<State>>,
 }
 
-impl AppState {
-    pub(crate) fn new() -> AppState {
-        AppState
-    }
+struct State {
+    quitting: bool,
 }
 
 impl Application {
-    pub fn new(_state: AppState, handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new() -> Application {
+        // macOS demands that we run not just on one thread,
+        // but specifically the first thread of the app.
         util::assert_main_thread();
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);
 
+            let ns_app = NSApp();
+            ns_app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
+
+            let state = Rc::new(RefCell::new(State { quitting: false }));
+
+            Application { ns_app, state }
+        }
+    }
+
+    pub fn run(self, handler: Option<Box<dyn AppHandler>>) {
+        unsafe {
+            // Initialize the application delegate
             let delegate: id = msg_send![APP_DELEGATE.0, alloc];
             let () = msg_send![delegate, init];
             let state = DelegateState { handler };
-            let handler_ptr = Box::into_raw(Box::new(state));
-            (*delegate).set_ivar(APP_HANDLER_IVAR, handler_ptr as *mut c_void);
-            let ns_app = NSApp();
-            let () = msg_send![ns_app, setDelegate: delegate];
-            ns_app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
-            Application { ns_app }
-        }
-    }
+            let state_ptr = Box::into_raw(Box::new(state));
+            (*delegate).set_ivar(APP_HANDLER_IVAR, state_ptr as *mut c_void);
+            let () = msg_send![self.ns_app, setDelegate: delegate];
 
-    pub fn run(&mut self) {
-        unsafe {
+            // Run the main app loop
             self.ns_app.run();
+
+            // Clean up the delegate
+            let () = msg_send![self.ns_app, setDelegate: nil];
+            Box::from_raw(state_ptr); // Causes it to drop & dealloc automatically
         }
     }
 
-    pub fn quit() {
-        unsafe {
-            let () = msg_send![NSApp(), terminate: nil];
+    pub fn quit(&self) {
+        if let Ok(mut state) = self.state.try_borrow_mut() {
+            if !state.quitting {
+                state.quitting = true;
+                unsafe {
+                    // We want to queue up the destruction of all our windows.
+                    // Failure to do so will lead to resource leaks.
+                    let windows: id = msg_send![self.ns_app, windows];
+                    for i in 0..windows.count() {
+                        let window: id = windows.objectAtIndex(i);
+                        let () = msg_send![window, performSelectorOnMainThread: sel!(close) withObject: nil waitUntilDone: NO];
+                    }
+                    // Stop sets a stop request flag in the OS.
+                    // The run loop is stopped after dealing with events.
+                    let () = msg_send![self.ns_app, stop: nil];
+                }
+            }
+        } else {
+            log::warn!("Application state already borrowed");
         }
     }
 
     /// Hide the application this window belongs to. (cmd+H)
-    pub fn hide() {
+    pub fn hide(&self) {
         unsafe {
-            let () = msg_send![NSApp(), hide: nil];
+            let () = msg_send![self.ns_app, hide: nil];
         }
     }
 
     /// Hide all other applications. (cmd+opt+H)
-    pub fn hide_others() {
+    pub fn hide_others(&self) {
         unsafe {
             let workspace = class!(NSWorkspace);
             let shared: id = msg_send![workspace, sharedWorkspace];
@@ -91,7 +118,7 @@ impl Application {
         }
     }
 
-    pub fn clipboard() -> Clipboard {
+    pub fn clipboard(&self) -> Clipboard {
         Clipboard
     }
 

--- a/druid-shell/src/platform/mac/application.rs
+++ b/druid-shell/src/platform/mac/application.rs
@@ -28,9 +28,11 @@ use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 
-use super::clipboard::Clipboard;
-use super::util;
 use crate::application::AppHandler;
+
+use super::clipboard::Clipboard;
+use super::error::Error;
+use super::util;
 
 static APP_HANDLER_IVAR: &str = "druidAppHandler";
 
@@ -45,7 +47,7 @@ struct State {
 }
 
 impl Application {
-    pub fn new() -> Application {
+    pub fn new() -> Result<Application, Error> {
         // macOS demands that we run not just on one thread,
         // but specifically the first thread of the app.
         util::assert_main_thread();
@@ -57,7 +59,7 @@ impl Application {
 
             let state = Rc::new(RefCell::new(State { quitting: false }));
 
-            Application { ns_app, state }
+            Ok(Application { ns_app, state })
         }
     }
 

--- a/druid-shell/src/platform/mac/util.rs
+++ b/druid-shell/src/platform/mac/util.rs
@@ -20,7 +20,7 @@ use cocoa::base::{id, nil, BOOL, YES};
 use cocoa::foundation::{NSAutoreleasePool, NSString, NSUInteger};
 use objc::{class, msg_send, sel, sel_impl};
 
-/// Panic if not on the main thread.assert_main_thread()
+/// Panic if not on the main thread.
 ///
 /// Many Cocoa operations are only valid on the main thread, and (I think)
 /// undefined behavior is possible if invoked from other threads. If so,

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -41,7 +41,7 @@ use log::{error, info};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
-use super::application::AppState;
+use super::application::Application;
 use super::dialog;
 use super::menu::Menu;
 use super::util::{assert_main_thread, make_nsstring};
@@ -105,7 +105,7 @@ struct ViewState {
 }
 
 impl WindowBuilder {
-    pub fn new(_app_state: AppState) -> WindowBuilder {
+    pub fn new(_app: Application) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -41,6 +41,7 @@ use log::{error, info};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
+use super::application::AppState;
 use super::dialog;
 use super::menu::Menu;
 use super::util::{assert_main_thread, make_nsstring};
@@ -104,7 +105,7 @@ struct ViewState {
 }
 
 impl WindowBuilder {
-    pub fn new() -> WindowBuilder {
+    pub fn new(_app_state: AppState) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),

--- a/druid-shell/src/platform/web/application.rs
+++ b/druid-shell/src/platform/web/application.rs
@@ -17,10 +17,19 @@
 use super::clipboard::Clipboard;
 use crate::application::AppHandler;
 
+#[derive(Clone)]
+pub struct AppState;
+
 pub struct Application;
 
+impl AppState {
+    pub(crate) fn new() -> AppState {
+        AppState
+    }
+}
+
 impl Application {
-    pub fn new(_handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new(_state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
         Application
     }
 

--- a/druid-shell/src/platform/web/application.rs
+++ b/druid-shell/src/platform/web/application.rs
@@ -18,26 +18,18 @@ use super::clipboard::Clipboard;
 use crate::application::AppHandler;
 
 #[derive(Clone)]
-pub struct AppState;
-
-pub struct Application;
-
-impl AppState {
-    pub(crate) fn new() -> AppState {
-        AppState
-    }
-}
+pub(crate) struct Application;
 
 impl Application {
-    pub fn new(_state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new() -> Application {
         Application
     }
 
-    pub fn run(&mut self) {}
+    pub fn run(self, _handler: Option<Box<dyn AppHandler>>) {}
 
-    pub fn quit() {}
+    pub fn quit(&self) {}
 
-    pub fn clipboard() -> Clipboard {
+    pub fn clipboard(&self) -> Clipboard {
         Clipboard
     }
 

--- a/druid-shell/src/platform/web/application.rs
+++ b/druid-shell/src/platform/web/application.rs
@@ -14,15 +14,17 @@
 
 //! Web implementation of features at the application scope.
 
-use super::clipboard::Clipboard;
 use crate::application::AppHandler;
+
+use super::clipboard::Clipboard;
+use super::error::Error;
 
 #[derive(Clone)]
 pub(crate) struct Application;
 
 impl Application {
-    pub fn new() -> Application {
-        Application
+    pub fn new() -> Result<Application, Error> {
+        Ok(Application)
     }
 
     pub fn run(self, _handler: Option<Box<dyn AppHandler>>) {}

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -29,7 +29,7 @@ use crate::kurbo::{Point, Rect, Size, Vec2};
 
 use crate::piet::RenderContext;
 
-use super::application::AppState;
+use super::application::Application;
 use super::error::Error;
 use super::keycodes::key_to_text;
 use super::menu::Menu;
@@ -60,7 +60,7 @@ type Result<T> = std::result::Result<T, Error>;
 const NOMINAL_DPI: f32 = 96.0;
 
 /// Builder abstraction for creating new windows.
-pub struct WindowBuilder {
+pub(crate) struct WindowBuilder {
     handler: Option<Box<dyn WinHandler>>,
     title: String,
     cursor: Cursor,
@@ -292,7 +292,7 @@ fn setup_web_callbacks(window_state: &Rc<WindowState>) {
 }
 
 impl WindowBuilder {
-    pub fn new(_app_state: AppState) -> WindowBuilder {
+    pub fn new(_app: Application) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -29,6 +29,7 @@ use crate::kurbo::{Point, Rect, Size, Vec2};
 
 use crate::piet::RenderContext;
 
+use super::application::AppState;
 use super::error::Error;
 use super::keycodes::key_to_text;
 use super::menu::Menu;
@@ -291,7 +292,7 @@ fn setup_web_callbacks(window_state: &Rc<WindowState>) {
 }
 
 impl WindowBuilder {
-    pub fn new() -> WindowBuilder {
+    pub fn new(_app_state: AppState) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -28,8 +28,9 @@ use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::shellscalingapi::PROCESS_SYSTEM_DPI_AWARE;
 use winapi::um::wingdi::CreateSolidBrush;
 use winapi::um::winuser::{
-    DispatchMessageW, GetAncestor, GetMessageW, LoadIconW, PostMessageW, RegisterClassW,
-    TranslateAcceleratorW, TranslateMessage, GA_ROOT, IDI_APPLICATION, MSG, WNDCLASSW,
+    DispatchMessageW, GetAncestor, GetMessageW, LoadIconW, PostMessageW, PostQuitMessage,
+    RegisterClassW, TranslateAcceleratorW, TranslateMessage, GA_ROOT, IDI_APPLICATION, MSG,
+    WNDCLASSW,
 };
 
 use crate::application::AppHandler;
@@ -38,111 +39,30 @@ use super::accels;
 use super::clipboard::Clipboard;
 use super::error::Error;
 use super::util::{self, ToWide, CLASS_NAME, OPTIONAL_FUNCTIONS};
-use super::window::{self, DS_REQUEST_QUIT};
-
-thread_local! {
-    static GLOBAL_STATE: RefCell<Option<AppState>> = RefCell::new(None);
-}
+use super::window::{self, DS_REQUEST_DESTROY};
 
 #[derive(Clone)]
-pub struct AppState {
+pub(crate) struct Application {
     state: Rc<RefCell<State>>,
 }
 
 struct State {
     quitting: bool,
-    app_hwnd: Option<HWND>,
     windows: HashSet<HWND>,
 }
 
-pub struct Application;
-
-impl AppState {
-    pub(crate) fn new() -> AppState {
+impl Application {
+    pub fn new() -> Application {
+        Application::init();
         let state = Rc::new(RefCell::new(State {
             quitting: false,
-            app_hwnd: None,
             windows: HashSet::new(),
         }));
-        AppState { state }
-    }
-
-    pub(crate) fn quitting(&self) -> bool {
-        self.state.borrow().quitting
-    }
-
-    pub(crate) fn set_quitting(&self, quitting: bool) {
-        self.state.borrow_mut().quitting = quitting;
-    }
-
-    pub(crate) fn app_hwnd(&self) -> Option<HWND> {
-        self.state.borrow().app_hwnd
-    }
-
-    pub(crate) fn set_app_hwnd(&self, app_hwnd: Option<HWND>) {
-        self.state.borrow_mut().app_hwnd = app_hwnd;
-    }
-
-    /// Returns a set of `HWND` for all the current normal windows.
-    ///
-    /// The returned set should be treated with extremely limited lifetime.
-    /// The window handles it contains can become stale quickly.
-    #[allow(clippy::mutable_key_type)]
-    pub(crate) unsafe fn windows(&self) -> HashSet<HWND> {
-        self.state.borrow().windows.clone()
-    }
-
-    pub(crate) fn add_window(&self, hwnd: HWND) -> bool {
-        self.state.borrow_mut().windows.insert(hwnd)
-    }
-
-    pub(crate) fn remove_window(&self, hwnd: HWND) -> bool {
-        self.state.borrow_mut().windows.remove(&hwnd)
-    }
-}
-
-impl Application {
-    pub fn new(state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
-        util::claim_main_thread();
-        GLOBAL_STATE.with(|global_state| {
-            *global_state.borrow_mut() = Some(state.clone());
-        });
-        Application::init();
-        window::build_app_window(state).expect("Failed to build main message window");
-        Application
-    }
-
-    pub fn run(&mut self) {
-        unsafe {
-            // Handle windows messages
-            loop {
-                let mut msg = mem::MaybeUninit::uninit();
-                let res = GetMessageW(msg.as_mut_ptr(), ptr::null_mut(), 0, 0);
-                if res <= 0 {
-                    if res == -1 {
-                        log::error!(
-                            "GetMessageW failed: {}",
-                            Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
-                        );
-                    }
-                    break;
-                }
-                let mut msg: MSG = msg.assume_init();
-                let accels = accels::find_accels(GetAncestor(msg.hwnd, GA_ROOT));
-                let translated = accels.map_or(false, |it| {
-                    TranslateAcceleratorW(msg.hwnd, it.handle(), &mut msg) != 0
-                });
-                if !translated {
-                    TranslateMessage(&msg);
-                    DispatchMessageW(&msg);
-                }
-            }
-        }
+        Application { state }
     }
 
     /// Initialize the app. At the moment, this is mostly needed for hi-dpi.
     fn init() {
-        util::assert_main_thread();
         util::attach_console();
         if let Some(func) = OPTIONAL_FUNCTIONS.SetProcessDpiAwareness {
             // This function is only supported on windows 10
@@ -174,39 +94,75 @@ impl Application {
         }
     }
 
-    pub fn quit() {
-        util::assert_main_thread();
-        GLOBAL_STATE.with(|global_state| {
-            if let Some(global_state) = global_state.borrow().as_ref() {
-                if let Some(app_hwnd) = global_state.app_hwnd() {
-                    unsafe {
-                        if PostMessageW(app_hwnd, DS_REQUEST_QUIT, 0, 0) == FALSE {
-                            log::error!(
-                                "PostMessageW failed: {}",
+    pub fn add_window(&self, hwnd: HWND) -> bool {
+        self.state.borrow_mut().windows.insert(hwnd)
+    }
+
+    pub fn remove_window(&self, hwnd: HWND) -> bool {
+        self.state.borrow_mut().windows.remove(&hwnd)
+    }
+
+    pub fn run(self, _handler: Option<Box<dyn AppHandler>>) {
+        unsafe {
+            // Handle windows messages
+            loop {
+                let mut msg = mem::MaybeUninit::uninit();
+                let res = GetMessageW(msg.as_mut_ptr(), ptr::null_mut(), 0, 0);
+                if res <= 0 {
+                    if res == -1 {
+                        log::error!(
+                            "GetMessageW failed: {}",
+                            Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                        );
+                    }
+                    break;
+                }
+                let mut msg: MSG = msg.assume_init();
+                let accels = accels::find_accels(GetAncestor(msg.hwnd, GA_ROOT));
+                let translated = accels.map_or(false, |it| {
+                    TranslateAcceleratorW(msg.hwnd, it.handle(), &mut msg) != 0
+                });
+                if !translated {
+                    TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
+                }
+            }
+        }
+    }
+
+    pub fn quit(&self) {
+        if let Ok(mut state) = self.state.try_borrow_mut() {
+            if !state.quitting {
+                state.quitting = true;
+                unsafe {
+                    // We want to queue up the destruction of all our windows.
+                    // Failure to do so will lead to resource leaks
+                    // and an eventual error code exit for the process.
+                    for hwnd in &state.windows {
+                        if PostMessageW(*hwnd, DS_REQUEST_DESTROY, 0, 0) == FALSE {
+                            log::warn!(
+                                "PostMessageW DS_REQUEST_DESTROY failed: {}",
                                 Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
                             );
                         }
                     }
+                    // PostQuitMessage sets a quit request flag in the OS.
+                    // The actual WM_QUIT message is queued but won't be sent
+                    // until all other important events have been handled.
+                    PostQuitMessage(0);
                 }
             }
-        });
+        } else {
+            log::warn!("Application state already borrowed");
+        }
     }
 
-    pub fn clipboard() -> Clipboard {
+    pub fn clipboard(&self) -> Clipboard {
         Clipboard
     }
 
     pub fn get_locale() -> String {
         //TODO ahem
         "en-US".into()
-    }
-}
-
-impl Drop for Application {
-    fn drop(&mut self) {
-        GLOBAL_STATE.with(|global_state| {
-            *global_state.borrow_mut() = None;
-        });
-        util::release_main_thread();
     }
 }

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -14,16 +14,21 @@
 
 //! Windows implementation of features at the application scope.
 
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::mem;
 use std::ptr;
+use std::rc::Rc;
 
-use winapi::shared::minwindef::HINSTANCE;
+use winapi::shared::minwindef::{FALSE, HINSTANCE};
 use winapi::shared::ntdef::LPCWSTR;
-use winapi::shared::windef::HCURSOR;
+use winapi::shared::windef::{HCURSOR, HWND};
+use winapi::shared::winerror::HRESULT_FROM_WIN32;
+use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::shellscalingapi::PROCESS_SYSTEM_DPI_AWARE;
 use winapi::um::wingdi::CreateSolidBrush;
 use winapi::um::winuser::{
-    DispatchMessageW, GetAncestor, GetMessageW, LoadIconW, PostQuitMessage, RegisterClassW,
+    DispatchMessageW, GetAncestor, GetMessageW, LoadIconW, PostMessageW, RegisterClassW,
     TranslateAcceleratorW, TranslateMessage, GA_ROOT, IDI_APPLICATION, MSG, WNDCLASSW,
 };
 
@@ -31,14 +36,79 @@ use crate::application::AppHandler;
 
 use super::accels;
 use super::clipboard::Clipboard;
+use super::error::Error;
 use super::util::{self, ToWide, CLASS_NAME, OPTIONAL_FUNCTIONS};
-use super::window::win_proc_dispatch;
+use super::window::{self, DS_REQUEST_QUIT};
+
+thread_local! {
+    static GLOBAL_STATE: RefCell<Option<AppState>> = RefCell::new(None);
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    state: Rc<RefCell<State>>,
+}
+
+struct State {
+    quitting: bool,
+    app_hwnd: Option<HWND>,
+    windows: HashSet<HWND>,
+}
 
 pub struct Application;
 
+impl AppState {
+    pub(crate) fn new() -> AppState {
+        let state = Rc::new(RefCell::new(State {
+            quitting: false,
+            app_hwnd: None,
+            windows: HashSet::new(),
+        }));
+        AppState { state }
+    }
+
+    pub(crate) fn quitting(&self) -> bool {
+        self.state.borrow().quitting
+    }
+
+    pub(crate) fn set_quitting(&self, quitting: bool) {
+        self.state.borrow_mut().quitting = quitting;
+    }
+
+    pub(crate) fn app_hwnd(&self) -> Option<HWND> {
+        self.state.borrow().app_hwnd
+    }
+
+    pub(crate) fn set_app_hwnd(&self, app_hwnd: Option<HWND>) {
+        self.state.borrow_mut().app_hwnd = app_hwnd;
+    }
+
+    /// Returns a set of `HWND` for all the current normal windows.
+    ///
+    /// The returned set should be treated with extremely limited lifetime.
+    /// The window handles it contains can become stale quickly.
+    #[allow(clippy::mutable_key_type)]
+    pub(crate) unsafe fn windows(&self) -> HashSet<HWND> {
+        self.state.borrow().windows.clone()
+    }
+
+    pub(crate) fn add_window(&self, hwnd: HWND) -> bool {
+        self.state.borrow_mut().windows.insert(hwnd)
+    }
+
+    pub(crate) fn remove_window(&self, hwnd: HWND) -> bool {
+        self.state.borrow_mut().windows.remove(&hwnd)
+    }
+}
+
 impl Application {
-    pub fn new(_handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new(state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
+        util::claim_main_thread();
+        GLOBAL_STATE.with(|global_state| {
+            *global_state.borrow_mut() = Some(state.clone());
+        });
         Application::init();
+        window::build_app_window(state).expect("Failed to build main message window");
         Application
     }
 
@@ -49,14 +119,19 @@ impl Application {
                 let mut msg = mem::MaybeUninit::uninit();
                 let res = GetMessageW(msg.as_mut_ptr(), ptr::null_mut(), 0, 0);
                 if res <= 0 {
-                    return;
+                    if res == -1 {
+                        log::error!(
+                            "GetMessageW failed: {}",
+                            Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                        );
+                    }
+                    break;
                 }
                 let mut msg: MSG = msg.assume_init();
                 let accels = accels::find_accels(GetAncestor(msg.hwnd, GA_ROOT));
                 let translated = accels.map_or(false, |it| {
                     TranslateAcceleratorW(msg.hwnd, it.handle(), &mut msg) != 0
                 });
-
                 if !translated {
                     TranslateMessage(&msg);
                     DispatchMessageW(&msg);
@@ -67,6 +142,7 @@ impl Application {
 
     /// Initialize the app. At the moment, this is mostly needed for hi-dpi.
     fn init() {
+        util::assert_main_thread();
         util::attach_console();
         if let Some(func) = OPTIONAL_FUNCTIONS.SetProcessDpiAwareness {
             // This function is only supported on windows 10
@@ -81,7 +157,7 @@ impl Application {
             let brush = CreateSolidBrush(0xff_ff_ff);
             let wnd = WNDCLASSW {
                 style: 0,
-                lpfnWndProc: Some(win_proc_dispatch),
+                lpfnWndProc: Some(window::win_proc_dispatch),
                 cbClsExtra: 0,
                 cbWndExtra: 0,
                 hInstance: 0 as HINSTANCE,
@@ -99,9 +175,21 @@ impl Application {
     }
 
     pub fn quit() {
-        unsafe {
-            PostQuitMessage(0);
-        }
+        util::assert_main_thread();
+        GLOBAL_STATE.with(|global_state| {
+            if let Some(global_state) = global_state.borrow().as_ref() {
+                if let Some(app_hwnd) = global_state.app_hwnd() {
+                    unsafe {
+                        if PostMessageW(app_hwnd, DS_REQUEST_QUIT, 0, 0) == FALSE {
+                            log::error!(
+                                "PostMessageW failed: {}",
+                                Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                            );
+                        }
+                    }
+                }
+            }
+        });
     }
 
     pub fn clipboard() -> Clipboard {
@@ -111,5 +199,14 @@ impl Application {
     pub fn get_locale() -> String {
         //TODO ahem
         "en-US".into()
+    }
+}
+
+impl Drop for Application {
+    fn drop(&mut self) {
+        GLOBAL_STATE.with(|global_state| {
+            *global_state.borrow_mut() = None;
+        });
+        util::release_main_thread();
     }
 }

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -52,17 +52,18 @@ struct State {
 }
 
 impl Application {
-    pub fn new() -> Application {
-        Application::init();
+    pub fn new() -> Result<Application, Error> {
+        Application::init()?;
         let state = Rc::new(RefCell::new(State {
             quitting: false,
             windows: HashSet::new(),
         }));
-        Application { state }
+        Ok(Application { state })
     }
 
     /// Initialize the app. At the moment, this is mostly needed for hi-dpi.
-    fn init() {
+    fn init() -> Result<(), Error> {
+        // TODO: Report back an error instead of panicking
         util::attach_console();
         if let Some(func) = OPTIONAL_FUNCTIONS.SetProcessDpiAwareness {
             // This function is only supported on windows 10
@@ -70,7 +71,6 @@ impl Application {
                 func(PROCESS_SYSTEM_DPI_AWARE); // TODO: per monitor (much harder)
             }
         }
-
         unsafe {
             let class_name = CLASS_NAME.to_wide();
             let icon = LoadIconW(0 as HINSTANCE, IDI_APPLICATION);
@@ -92,6 +92,7 @@ impl Application {
                 panic!("Error registering class");
             }
         }
+        Ok(())
     }
 
     pub fn add_window(&self, hwnd: HWND) -> bool {

--- a/druid-shell/src/platform/windows/error.rs
+++ b/druid-shell/src/platform/windows/error.rs
@@ -38,8 +38,6 @@ pub enum Error {
     OldWindows,
     /// The `hwnd` pointer was null.
     NullHwnd,
-    /// The main app message window already exists.
-    AppWindowExists,
 }
 
 fn hresult_description(hr: HRESULT) -> Option<String> {
@@ -80,7 +78,6 @@ impl fmt::Display for Error {
             Error::D2Error => write!(f, "Direct2D error"),
             Error::OldWindows => write!(f, "Attempted newer API on older Windows"),
             Error::NullHwnd => write!(f, "Window handle is Null"),
-            Error::AppWindowExists => write!(f, "The main message window already exists"),
         }
     }
 }

--- a/druid-shell/src/platform/windows/error.rs
+++ b/druid-shell/src/platform/windows/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     OldWindows,
     /// The `hwnd` pointer was null.
     NullHwnd,
+    /// The main app message window already exists.
+    AppWindowExists,
 }
 
 fn hresult_description(hr: HRESULT) -> Option<String> {
@@ -78,6 +80,7 @@ impl fmt::Display for Error {
             Error::D2Error => write!(f, "Direct2D error"),
             Error::OldWindows => write!(f, "Attempted newer API on older Windows"),
             Error::NullHwnd => write!(f, "Window handle is Null"),
+            Error::AppWindowExists => write!(f, "The main message window already exists"),
         }
     }
 }

--- a/druid-shell/src/platform/windows/util.rs
+++ b/druid-shell/src/platform/windows/util.rs
@@ -22,12 +22,11 @@ use std::mem;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::ptr;
 use std::slice;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use lazy_static::lazy_static;
 use winapi::ctypes::c_void;
 use winapi::shared::guiddef::REFIID;
-use winapi::shared::minwindef::{DWORD, HMODULE, UINT};
+use winapi::shared::minwindef::{HMODULE, UINT};
 use winapi::shared::ntdef::{HRESULT, LPWSTR};
 use winapi::shared::windef::HMONITOR;
 use winapi::shared::winerror::SUCCEEDED;
@@ -35,7 +34,6 @@ use winapi::um::fileapi::{CreateFileA, GetFileType, OPEN_EXISTING};
 use winapi::um::handleapi::INVALID_HANDLE_VALUE;
 use winapi::um::libloaderapi::{GetModuleHandleW, GetProcAddress, LoadLibraryW};
 use winapi::um::processenv::{GetStdHandle, SetStdHandle};
-use winapi::um::processthreadsapi::GetCurrentThreadId;
 use winapi::um::shellscalingapi::{MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS};
 use winapi::um::unknwnbase::IUnknown;
 use winapi::um::winbase::{FILE_TYPE_UNKNOWN, STD_ERROR_HANDLE, STD_OUTPUT_HANDLE};
@@ -43,60 +41,6 @@ use winapi::um::wincon::{AttachConsole, ATTACH_PARENT_PROCESS};
 use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
 
 use super::error::Error;
-
-static MAIN_THREAD_ID: AtomicU32 = AtomicU32::new(0);
-
-#[inline]
-fn current_thread_id() -> DWORD {
-    unsafe { GetCurrentThreadId() }
-}
-
-pub fn assert_main_thread() {
-    let thread_id = current_thread_id();
-    let main_thread_id = MAIN_THREAD_ID.load(Ordering::Acquire);
-    if thread_id != main_thread_id {
-        panic!(
-            "Main thread assertion failed {} != {}",
-            thread_id, main_thread_id
-        );
-    }
-}
-
-pub fn claim_main_thread() {
-    let thread_id = current_thread_id();
-    let old_thread_id = MAIN_THREAD_ID.compare_and_swap(0, thread_id, Ordering::AcqRel);
-    if old_thread_id != 0 {
-        panic!(
-            "The main thread status has already been claimed by thread {}",
-            thread_id
-        );
-    }
-}
-
-pub fn release_main_thread() {
-    let thread_id = current_thread_id();
-    let old_thread_id = MAIN_THREAD_ID.compare_and_swap(thread_id, 0, Ordering::AcqRel);
-    if old_thread_id == 0 {
-        log::warn!("The main thread status was already vacant.");
-    } else if old_thread_id != thread_id {
-        panic!(
-            "The main thread status is owned by another thread {}",
-            thread_id
-        );
-    }
-}
-
-#[allow(dead_code)]
-pub fn main_thread_id() -> Option<DWORD> {
-    let thread_id = MAIN_THREAD_ID.load(Ordering::Acquire);
-    // Although not explicitly documented, zero is an invalid thread id.
-    // It can be deducted from the behavior of GetThreadId / SetWindowsHookExA.
-    // https://devblogs.microsoft.com/oldnewthing/20040223-00/?p=40503
-    match thread_id {
-        0 => None,
-        id => Some(id),
-    }
-}
 
 pub fn as_result(hr: HRESULT) -> Result<(), Error> {
     if SUCCEEDED(hr) {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -47,7 +47,7 @@ use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
 use super::accels::register_accel;
-use super::application::AppState;
+use super::application::Application;
 use super::dcomp::{D3D11Device, DCompositionDevice, DCompositionTarget, DCompositionVisual};
 use super::dialog::get_file_dialog_path;
 use super::error::Error;
@@ -68,8 +68,8 @@ extern "system" {
 }
 
 /// Builder abstraction for creating new windows.
-pub struct WindowBuilder {
-    app_state: AppState,
+pub(crate) struct WindowBuilder {
+    app: Application,
     handler: Option<Box<dyn WinHandler>>,
     title: String,
     menu: Option<Menu>,
@@ -108,11 +108,6 @@ pub enum PresentStrategy {
     FlipRedirect,
 }
 
-#[derive(Default, Clone)]
-pub struct AppWndHandle {
-    state: Weak<WindowState>,
-}
-
 #[derive(Clone)]
 pub struct WindowHandle {
     dwrite_factory: DwriteFactory,
@@ -149,24 +144,16 @@ struct WindowState {
 trait WndProc {
     fn connect(&self, handle: &WindowHandle, state: WndState);
 
-    fn connect_app(&self, handle: &AppWndHandle);
-
     fn cleanup(&self, hwnd: HWND);
 
     fn window_proc(&self, hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM)
         -> Option<LRESULT>;
 }
 
-// State for the winapi window procedure entry point of the main message window.
-struct AppWndProc {
-    app_state: AppState,
-    handle: RefCell<AppWndHandle>,
-}
-
 // State and logic for the winapi window procedure entry point. Note that this level
 // implements policies such as the use of Direct2D for painting.
 struct MyWndProc {
-    app_state: AppState,
+    app: Application,
     handle: RefCell<WindowHandle>,
     d2d_factory: D2DFactory,
     dwrite_factory: DwriteFactory,
@@ -220,12 +207,7 @@ const DS_RUN_IDLE: UINT = WM_USER;
 /// As a solution, instead of immediately calling `DestroyWindow`, we
 /// send this message to request destroying the window, so that at the
 /// time it is handled, we can successfully borrow the handler.
-const DS_REQUEST_DESTROY: UINT = WM_USER + 1;
-
-/// Message relaying a request to quit the app run loop.
-///
-/// Directly calling `PostQuitMessage` won't do proper cleanup.
-pub const DS_REQUEST_QUIT: UINT = WM_USER + 2;
+pub(crate) const DS_REQUEST_DESTROY: UINT = WM_USER + 1;
 
 impl Default for PresentStrategy {
     fn default() -> PresentStrategy {
@@ -326,64 +308,6 @@ impl WndState {
     }
 }
 
-impl WndProc for AppWndProc {
-    fn connect(&self, _handle: &WindowHandle, _state: WndState) {}
-
-    fn connect_app(&self, handle: &AppWndHandle) {
-        *self.handle.borrow_mut() = handle.clone();
-    }
-
-    fn cleanup(&self, _hwnd: HWND) {
-        self.app_state.set_app_hwnd(None);
-    }
-
-    fn window_proc(
-        &self,
-        hwnd: HWND,
-        msg: UINT,
-        _wparam: WPARAM,
-        _lparam: LPARAM,
-    ) -> Option<LRESULT> {
-        match msg {
-            WM_CREATE => {
-                if let Some(state) = self.handle.borrow().state.upgrade() {
-                    state.hwnd.set(hwnd);
-                }
-                Some(0)
-            }
-            DS_REQUEST_QUIT => {
-                if !self.app_state.quitting() {
-                    self.app_state.set_quitting(true);
-                    unsafe {
-                        // We want to queue up the destruction of all our windows.
-                        // Failure to do so will lead to resource leaks
-                        // and an eventual error code exit for the process.
-                        for hwnd in self
-                            .app_state
-                            .windows()
-                            .into_iter()
-                            .chain(self.app_state.app_hwnd())
-                        {
-                            if PostMessageW(hwnd, DS_REQUEST_DESTROY, 0, 0) == FALSE {
-                                log::warn!(
-                                    "PostMessageW failed: {}",
-                                    Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
-                                );
-                            }
-                        }
-                        // PostQuitMessage sets a quit request flag in the OS.
-                        // The actual WM_QUIT message is queued but won't be sent
-                        // until all other important events have been handled.
-                        PostQuitMessage(0);
-                    }
-                }
-                Some(0)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl MyWndProc {
     /// Create debugging output for dropped messages due to wndproc reentrancy.
     ///
@@ -403,10 +327,8 @@ impl WndProc for MyWndProc {
         *self.state.borrow_mut() = Some(state);
     }
 
-    fn connect_app(&self, _handle: &AppWndHandle) {}
-
     fn cleanup(&self, hwnd: HWND) {
-        self.app_state.remove_window(hwnd);
+        self.app.remove_window(hwnd);
     }
 
     #[allow(clippy::cognitive_complexity)]
@@ -921,9 +843,9 @@ impl WndProc for MyWndProc {
 }
 
 impl WindowBuilder {
-    pub fn new(app_state: AppState) -> WindowBuilder {
+    pub fn new(app: Application) -> WindowBuilder {
         WindowBuilder {
-            app_state,
+            app,
             handler: None,
             title: String::new(),
             menu: None,
@@ -971,7 +893,7 @@ impl WindowBuilder {
             let dwrite_factory = DwriteFactory::new().unwrap();
             let dw_clone = dwrite_factory.clone();
             let wndproc = MyWndProc {
-                app_state: self.app_state.clone(),
+                app: self.app.clone(),
                 handle: Default::default(),
                 d2d_factory: D2DFactory::new().unwrap(),
                 dwrite_factory: dw_clone,
@@ -1053,58 +975,13 @@ impl WindowBuilder {
             if hwnd.is_null() {
                 return Err(Error::NullHwnd);
             }
-            self.app_state.add_window(hwnd);
+            self.app.add_window(hwnd);
 
             if let Some(accels) = accels {
                 register_accel(hwnd, &accels);
             }
             Ok(handle)
         }
-    }
-}
-
-/// Create the main message-only app window.
-pub(crate) fn build_app_window(app_state: AppState) -> Result<HWND, Error> {
-    unsafe {
-        if app_state.app_hwnd() != None {
-            return Err(Error::AppWindowExists);
-        }
-        let class_name = super::util::CLASS_NAME.to_wide();
-        let wndproc = AppWndProc {
-            app_state: app_state.clone(),
-            handle: Default::default(),
-        };
-        let window = WindowState {
-            hwnd: Cell::new(0 as HWND),
-            dpi: Cell::new(96.0),
-            wndproc: Box::new(wndproc),
-            idle_queue: Default::default(),
-            timers: Arc::new(Mutex::new(TimerSlots::new(1))),
-        };
-        let win = Rc::new(window);
-        let handle = AppWndHandle {
-            state: Rc::downgrade(&win),
-        };
-        win.wndproc.connect_app(&handle);
-        let hwnd = create_window(
-            0,
-            class_name.as_ptr(),
-            null(),
-            0,
-            0,
-            0,
-            0,
-            0,
-            HWND_MESSAGE,
-            null_mut(),
-            0 as HINSTANCE,
-            win,
-        );
-        if hwnd.is_null() {
-            return Err(Error::NullHwnd);
-        }
-        app_state.set_app_hwnd(Some(hwnd));
-        Ok(hwnd)
     }
 }
 

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -40,18 +40,10 @@ thread_local! {
 }
 
 #[derive(Clone)]
-pub struct AppState;
-
-pub struct Application;
-
-impl AppState {
-    pub(crate) fn new() -> AppState {
-        AppState
-    }
-}
+pub(crate) struct Application;
 
 impl Application {
-    pub fn new(_state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new() -> Application {
         Application
     }
 
@@ -68,7 +60,7 @@ impl Application {
     }
 
     // TODO(x11/events): handle mouse scroll events
-    pub fn run(&mut self) {
+    pub fn run(self, _handler: Option<Box<dyn AppHandler>>) {
         let conn = XCB_CONNECTION.connection_cloned();
         loop {
             if let Some(ev) = conn.wait_for_event() {
@@ -191,11 +183,11 @@ impl Application {
         }
     }
 
-    pub fn quit() {
+    pub fn quit(&self) {
         // No-op.
     }
 
-    pub fn clipboard() -> Clipboard {
+    pub fn clipboard(&self) -> Clipboard {
         // TODO(x11/clipboard): implement Application::clipboard
         log::warn!("Application::clipboard is currently unimplemented for X11 platforms.");
         Clipboard {}

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -39,10 +39,19 @@ thread_local! {
     static WINDOW_MAP: RefCell<HashMap<u32, XWindow>> = RefCell::new(HashMap::new());
 }
 
+#[derive(Clone)]
+pub struct AppState;
+
 pub struct Application;
 
+impl AppState {
+    pub(crate) fn new() -> AppState {
+        AppState
+    }
+}
+
 impl Application {
-    pub fn new(_handler: Option<Box<dyn AppHandler>>) -> Application {
+    pub fn new(_state: AppState, _handler: Option<Box<dyn AppHandler>>) -> Application {
         Application
     }
 

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -20,11 +20,13 @@ use std::sync::Arc;
 
 use lazy_static::lazy_static;
 
-use super::clipboard::Clipboard;
-use super::window::XWindow;
 use crate::application::AppHandler;
 use crate::kurbo::{Point, Rect};
 use crate::{KeyCode, KeyModifiers, MouseButton, MouseEvent};
+
+use super::clipboard::Clipboard;
+use super::error::Error;
+use super::window::XWindow;
 
 struct XcbConnection {
     connection: Arc<xcb::Connection>,
@@ -43,8 +45,8 @@ thread_local! {
 pub(crate) struct Application;
 
 impl Application {
-    pub fn new() -> Application {
-        Application
+    pub fn new() -> Result<Application, Error> {
+        Ok(Application)
     }
 
     pub(crate) fn add_xwindow(id: u32, xwindow: XWindow) {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -27,12 +27,12 @@ use crate::mouse::{Cursor, MouseEvent};
 use crate::piet::{Piet, RenderContext};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 
-use super::application::{AppState, Application};
+use super::application::Application;
 use super::error::Error;
 use super::menu::Menu;
 use super::util;
 
-pub struct WindowBuilder {
+pub(crate) struct WindowBuilder {
     handler: Option<Box<dyn WinHandler>>,
     title: String,
     size: Size,
@@ -40,7 +40,7 @@ pub struct WindowBuilder {
 }
 
 impl WindowBuilder {
-    pub fn new(_app_state: AppState) -> WindowBuilder {
+    pub fn new(_app: Application) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),
@@ -289,7 +289,7 @@ fn get_visual_from_screen(screen: &xcb::Screen<'_>) -> Option<xcb::xproto::Visua
 }
 
 #[derive(Clone)]
-pub struct IdleHandle;
+pub(crate) struct IdleHandle;
 
 impl IdleHandle {
     pub fn add_idle_callback<F>(&self, _callback: F)
@@ -307,7 +307,7 @@ impl IdleHandle {
 }
 
 #[derive(Clone, Default)]
-pub struct WindowHandle {
+pub(crate) struct WindowHandle {
     window_id: u32,
 }
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -27,7 +27,7 @@ use crate::mouse::{Cursor, MouseEvent};
 use crate::piet::{Piet, RenderContext};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 
-use super::application::Application;
+use super::application::{AppState, Application};
 use super::error::Error;
 use super::menu::Menu;
 use super::util;
@@ -40,7 +40,7 @@ pub struct WindowBuilder {
 }
 
 impl WindowBuilder {
-    pub fn new() -> WindowBuilder {
+    pub fn new(_app_state: AppState) -> WindowBuilder {
         WindowBuilder {
             handler: None,
             title: String::new(),

--- a/druid-shell/src/util.rs
+++ b/druid-shell/src/util.rs
@@ -1,0 +1,82 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utility functions for determining the main thread.
+
+use std::mem;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+
+static MAIN_THREAD_ID: AtomicU64 = AtomicU64::new(0);
+
+#[inline]
+fn current_thread_id() -> u64 {
+    // TODO: Use .as_u64() instead of mem::transmute
+    // when .as_u64() or something similar gets stabilized.
+    unsafe { mem::transmute(thread::current().id()) }
+}
+
+/// Assert that the current thread is the registered main thread.
+///
+/// # Panics
+///
+/// Panics when called from a non-main thread.
+pub fn assert_main_thread() {
+    let thread_id = current_thread_id();
+    let main_thread_id = MAIN_THREAD_ID.load(Ordering::Acquire);
+    if thread_id != main_thread_id {
+        panic!(
+            "Main thread assertion failed {} != {}",
+            thread_id, main_thread_id
+        );
+    }
+}
+
+/// Register the current thread as the main thread.
+///
+/// # Panics
+///
+/// Panics if the main thread has already been claimed by another thread.
+pub fn claim_main_thread() {
+    let thread_id = current_thread_id();
+    let old_thread_id = MAIN_THREAD_ID.compare_and_swap(0, thread_id, Ordering::AcqRel);
+    if old_thread_id != 0 {
+        if old_thread_id == thread_id {
+            log::warn!("The main thread status was already claimed by the current thread.");
+        } else {
+            panic!(
+                "The main thread status has already been claimed by thread {}",
+                thread_id
+            );
+        }
+    }
+}
+
+/// Removes the main thread status of the current thread.
+///
+/// # Panics
+///
+/// Panics if the main thread status is owned by another thread.
+pub fn release_main_thread() {
+    let thread_id = current_thread_id();
+    let old_thread_id = MAIN_THREAD_ID.compare_and_swap(thread_id, 0, Ordering::AcqRel);
+    if old_thread_id == 0 {
+        log::warn!("The main thread status was already vacant.");
+    } else if old_thread_id != thread_id {
+        panic!(
+            "The main thread status is owned by another thread {}",
+            thread_id
+        );
+    }
+}

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -17,7 +17,7 @@
 use std::any::Any;
 use std::time::Duration;
 
-use crate::application::AppState;
+use crate::application::Application;
 use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error;
@@ -214,11 +214,11 @@ pub struct WindowBuilder(platform::WindowBuilder);
 impl WindowBuilder {
     /// Create a new `WindowBuilder`.
     ///
-    /// Takes the [`AppState`] of the application this window is for.
+    /// Takes the [`Application`] that this window is for.
     ///
-    /// [`AppState`]: struct.AppState.html
-    pub fn new(app_state: AppState) -> WindowBuilder {
-        WindowBuilder(platform::WindowBuilder::new(app_state.0))
+    /// [`Application`]: struct.Application.html
+    pub fn new(app: Application) -> WindowBuilder {
+        WindowBuilder(platform::WindowBuilder::new(app.platform_app))
     }
 
     /// Set the [`WinHandler`]. This is the object that will receive

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -17,6 +17,7 @@
 use std::any::Any;
 use std::time::Duration;
 
+use crate::application::AppState;
 use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error;
@@ -211,9 +212,13 @@ impl WindowHandle {
 pub struct WindowBuilder(platform::WindowBuilder);
 
 impl WindowBuilder {
-    /// Create a new `WindowBuilder`
-    pub fn new() -> WindowBuilder {
-        WindowBuilder(platform::WindowBuilder::new())
+    /// Create a new `WindowBuilder`.
+    ///
+    /// Takes the [`AppState`] of the application this window is for.
+    ///
+    /// [`AppState`]: struct.AppState.html
+    pub fn new(app_state: AppState) -> WindowBuilder {
+        WindowBuilder(platform::WindowBuilder::new(app_state.0))
     }
 
     /// Set the [`WinHandler`]. This is the object that will receive

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -114,7 +114,7 @@ impl<T: Data> AppLauncher<T> {
     /// Returns an error if a window cannot be instantiated. This is usually
     /// a fatal error.
     pub fn launch(mut self, data: T) -> Result<(), PlatformError> {
-        let app = Application::new();
+        let app = Application::new()?;
 
         let mut env = theme::init();
         if let Some(f) = self.env_setup.take() {

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -16,9 +16,7 @@
 
 use crate::ext_event::{ExtEventHost, ExtEventSink};
 use crate::kurbo::Size;
-use crate::shell::{
-    AppState as PlatformState, Application, Error as PlatformError, WindowBuilder, WindowHandle,
-};
+use crate::shell::{Application, Error as PlatformError, WindowBuilder, WindowHandle};
 use crate::widget::LabelText;
 use crate::win_handler::{AppHandler, AppState};
 use crate::window::WindowId;
@@ -116,28 +114,28 @@ impl<T: Data> AppLauncher<T> {
     /// Returns an error if a window cannot be instantiated. This is usually
     /// a fatal error.
     pub fn launch(mut self, data: T) -> Result<(), PlatformError> {
+        let app = Application::new();
+
         let mut env = theme::init();
         if let Some(f) = self.env_setup.take() {
             f(&mut env, &data);
         }
 
-        let platform_state = PlatformState::new();
         let mut state = AppState::new(
-            platform_state.clone(),
+            app.clone(),
             data,
             env,
             self.delegate.take(),
             self.ext_event_host,
         );
-        let handler = AppHandler::new(state.clone());
 
-        let mut app = Application::new(platform_state, Some(Box::new(handler)));
         for desc in self.windows {
             let window = desc.build_native(&mut state)?;
             window.show();
         }
 
-        app.run();
+        let handler = AppHandler::new(state);
+        app.run(Some(Box::new(handler)));
         Ok(())
     }
 }
@@ -230,7 +228,7 @@ impl<T: Data> WindowDesc<T> {
 
         let handler = DruidHandler::new_shared(state.clone(), self.id);
 
-        let mut builder = WindowBuilder::new(state.platform_state());
+        let mut builder = WindowBuilder::new(state.app());
 
         builder.resizable(self.resizable);
         builder.show_titlebar(self.show_titlebar);

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -122,6 +122,9 @@ pub mod sys {
     /// should be the id of the window to close.
     pub const CLOSE_WINDOW: Selector = Selector::new("druid-builtin.close-window");
 
+    /// Close all windows.
+    pub const CLOSE_ALL_WINDOWS: Selector = Selector::new("druid-builtin.close-all-windows");
+
     /// The selector for a command to bring a window to the front, and give it focus.
     ///
     /// The command's argument should be the id of the target window.

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -283,7 +283,7 @@ impl Widget<String> for TextBox {
                         || cmd.selector == crate::commands::CUT) =>
             {
                 if let Some(text) = data.slice(self.selection.range()) {
-                    Application::clipboard().put_string(text);
+                    Application::global().clipboard().put_string(text);
                 }
                 if !self.selection.is_caret() && cmd.selector == crate::commands::CUT {
                     edit_action = Some(EditAction::Delete);

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -22,7 +22,8 @@ use std::rc::Rc;
 use crate::kurbo::{Rect, Size, Vec2};
 use crate::piet::Piet;
 use crate::shell::{
-    Application, FileDialogOptions, IdleToken, MouseEvent, WinHandler, WindowHandle,
+    AppState as PlatformState, Application, FileDialogOptions, IdleToken, MouseEvent, WinHandler,
+    WindowHandle,
 };
 
 use crate::app_delegate::{AppDelegate, DelegateCtx};
@@ -72,6 +73,7 @@ pub(crate) struct AppState<T> {
 }
 
 struct Inner<T> {
+    platform_state: PlatformState,
     delegate: Option<Box<dyn AppDelegate<T>>>,
     command_queue: CommandQueue,
     ext_event_host: ExtEventHost,
@@ -118,6 +120,10 @@ impl<T> Windows<T> {
     fn get_mut(&mut self, id: WindowId) -> Option<&mut Window<T>> {
         self.windows.get_mut(&id)
     }
+
+    fn count(&self) -> usize {
+        self.windows.len() + self.pending.len()
+    }
 }
 
 impl<T> AppHandler<T> {
@@ -128,12 +134,14 @@ impl<T> AppHandler<T> {
 
 impl<T> AppState<T> {
     pub(crate) fn new(
+        platform_state: PlatformState,
         data: T,
         env: Env,
         delegate: Option<Box<dyn AppDelegate<T>>>,
         ext_event_host: ExtEventHost,
     ) -> Self {
         let inner = Rc::new(RefCell::new(Inner {
+            platform_state,
             delegate,
             command_queue: VecDeque::new(),
             root_menu: None,
@@ -144,6 +152,10 @@ impl<T> AppState<T> {
         }));
 
         AppState { inner }
+    }
+
+    pub(crate) fn platform_state(&self) -> PlatformState {
+        self.inner.borrow().platform_state.clone()
     }
 }
 
@@ -220,7 +232,11 @@ impl<T: Data> Inner<T> {
             if self.windows.windows.is_empty() {
                 // on mac we need to keep the menu around
                 self.root_menu = win.menu.take();
-                //FIXME: on windows we need to shutdown the app here?
+                // If there are even no pending windows, we quit the run loop.
+                if self.windows.count() == 0 {
+                    #[cfg(target_os = "windows")]
+                    Application::quit();
+                }
             }
         }
 
@@ -258,6 +274,13 @@ impl<T: Data> Inner<T> {
     /// our handlers `destroy()` method, at which point we can do our cleanup.
     fn request_close_window(&mut self, window_id: WindowId) {
         if let Some(win) = self.windows.get_mut(window_id) {
+            win.handle.close();
+        }
+    }
+
+    /// Requests the platform to close all windows.
+    fn request_close_all_windows(&mut self) {
+        for win in self.windows.iter_mut() {
             win.handle.close();
         }
     }
@@ -502,7 +525,7 @@ impl<T: Data> AppState<T> {
     fn handle_cmd(&mut self, target: Target, cmd: Command) {
         use Target as T;
         match (target, &cmd.selector) {
-            // these are handled the same no matter where they  come from
+            // these are handled the same no matter where they come from
             (_, &sys_cmd::QUIT_APP) => self.quit(),
             (_, &sys_cmd::HIDE_APPLICATION) => self.hide_app(),
             (_, &sys_cmd::HIDE_OTHERS) => self.hide_others(),
@@ -511,8 +534,9 @@ impl<T: Data> AppState<T> {
                     log::error!("failed to create window: '{}'", e);
                 }
             }
+            (_, &sys_cmd::CLOSE_ALL_WINDOWS) => self.request_close_all_windows(),
             // these should come from a window
-            // FIXME: we need to be  able to open a file without a window handle
+            // FIXME: we need to be able to open a file without a window handle
             (T::Window(id), &sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
             (T::Window(id), &sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
             (T::Window(id), &sys_cmd::CLOSE_WINDOW) => self.request_close_window(cmd, id),
@@ -572,6 +596,10 @@ impl<T: Data> AppState<T> {
     fn request_close_window(&mut self, cmd: Command, window_id: WindowId) {
         let id = cmd.get_object().unwrap_or(&window_id);
         self.inner.borrow_mut().request_close_window(*id);
+    }
+
+    fn request_close_all_windows(&mut self) {
+        self.inner.borrow_mut().request_close_all_windows();
     }
 
     fn show_window(&mut self, cmd: Command) {


### PR DESCRIPTION
This PR solves one of the most reported annoyances of druid (Fixes #265, #362, #395, #438, #674, #681). When all windows have been closed on Windows, the `Application::run` loop now returns execution back to the host app.