### PR TITLE
Split `druid` derive attribute into `data` and `lens`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "druid"
 version = "0.5.0"
 dependencies = [
- "druid-derive 0.2.0",
+ "druid-derive 0.3.0",
  "druid-shell 0.5.0",
  "fluent-bundle 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-langneg 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "druid-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "druid 0.5.0",
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/docs/book_examples/src/data_md.rs
+++ b/docs/book_examples/src/data_md.rs
@@ -19,7 +19,7 @@ struct TodoItem {
     due_date: Option<Arc<DateTime>>,
     // you can specify a custom comparison fn
     // (anything with the signature (&T, &T) -> bool)
-    #[druid(same_fn = "PartialEq::eq")]
+    #[data(same_fn = "PartialEq::eq")]
     added_date: DateTime,
     title: String,
     note: Option<String>,

--- a/docs/book_examples/src/lens_md.rs
+++ b/docs/book_examples/src/lens_md.rs
@@ -72,7 +72,7 @@ impl Lens<TodoItem, bool> for CompletedLens {
 // ANCHOR: lens_name
 #[derive(Lens)]
 struct Item {
-    #[druid(lens_name = "count_lens")]
+    #[lens(name = "count_lens")]
     count: usize,
 }
 

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-derive"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 authors = ["Druid authors"]
 description = "derive impls for druid, a Rust UI toolkit."

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -111,7 +111,7 @@ impl Field {
 
         for attr in field.attrs.iter() {
             if attr.path.is_ident(BASE_DRUID_DEPRECATED_ATTR_PATH) {
-                panic(
+                panic!(
                     "The 'druid' attribute has been replaced with separate \
                     'lens' and 'data' attributes.",
                 );

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -111,11 +111,10 @@ impl Field {
 
         for attr in field.attrs.iter() {
             if attr.path.is_ident(BASE_DRUID_DEPRECATED_ATTR_PATH) {
-                return Err(Error::new(
-                    attr.path.span(),
+                panic(
                     "The 'druid' attribute has been replaced with separate \
                     'lens' and 'data' attributes.",
-                ));
+                );
             } else if attr.path.is_ident(BASE_DATA_ATTR_PATH) {
                 match attr.parse_meta()? {
                     Meta::List(meta) => {

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -154,17 +154,6 @@ impl Field {
                     Meta::List(meta) => {
                         for nested in meta.nested.iter() {
                             match nested {
-                                NestedMeta::Meta(Meta::Path(path))
-                                    if path.is_ident(IGNORE_ATTR_PATH) =>
-                                {
-                                    if ignore {
-                                        return Err(Error::new(
-                                            nested.span(),
-                                            "Duplicate attribute",
-                                        ));
-                                    }
-                                    ignore = true;
-                                }
                                 NestedMeta::Meta(Meta::NameValue(meta))
                                     if meta.path.is_ident(LENS_NAME_OVERRIDE_ATTR_PATH) =>
                                 {

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -111,7 +111,11 @@ impl Field {
 
         for attr in field.attrs.iter() {
             if attr.path.is_ident(BASE_DRUID_DEPRECATED_ATTR_PATH) {
-                panic!("druid attribute is deprecated, please update it, it won't work")
+                return Err(Error::new(
+                    attr.path.span(),
+                    "The 'druid' attribute has been replaced with separate \
+                    'lens' and 'data' attributes.",
+                ));
             } else if attr.path.is_ident(BASE_DATA_ATTR_PATH) {
                 match attr.parse_meta()? {
                     Meta::List(meta) => {

--- a/druid-derive/src/attr.rs
+++ b/druid-derive/src/attr.rs
@@ -15,14 +15,18 @@
 //! parsing #[druid(attributes)]
 
 use proc_macro2::{Ident, Literal, Span, TokenStream, TokenTree};
-use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::{Error, ExprPath, Meta, NestedMeta};
 
-const BASE_ATTR_PATH: &str = "druid";
+use quote::{quote, quote_spanned};
+
+//show error to tell users of old API that it doesn't work anymore
+const BASE_DRUID_DEPRECATED_ATTR_PATH: &str = "druid";
+const BASE_DATA_ATTR_PATH: &str = "data";
+const BASE_LENS_ATTR_PATH: &str = "lens";
 const IGNORE_ATTR_PATH: &str = "ignore";
-const SAME_FN_ATTR_PATH: &str = "same_fn";
-const LENS_NAME_OVERRIDE_ATTR_PATH: &str = "lens_name";
+const DATA_SAME_FN_ATTR_PATH: &str = "same_fn";
+const LENS_NAME_OVERRIDE_ATTR_PATH: &str = "name";
 
 /// The fields for a struct or an enum variant.
 #[derive(Debug)]
@@ -105,52 +109,82 @@ impl Field {
         let mut same_fn = None;
         let mut lens_name_override = None;
 
-        for attr in field
-            .attrs
-            .iter()
-            .filter(|attr| attr.path.is_ident(BASE_ATTR_PATH))
-        {
-            match attr.parse_meta()? {
-                Meta::List(meta) => {
-                    for nested in meta.nested.iter() {
-                        match nested {
-                            NestedMeta::Meta(Meta::Path(path))
-                                if path.is_ident(IGNORE_ATTR_PATH) =>
-                            {
-                                if ignore {
-                                    return Err(Error::new(nested.span(), "Duplicate attribute"));
+        for attr in field.attrs.iter() {
+            if attr.path.is_ident(BASE_DRUID_DEPRECATED_ATTR_PATH) {
+                panic!("druid attribute is deprecated, please update it, it won't work")
+            } else if attr.path.is_ident(BASE_DATA_ATTR_PATH) {
+                match attr.parse_meta()? {
+                    Meta::List(meta) => {
+                        for nested in meta.nested.iter() {
+                            match nested {
+                                NestedMeta::Meta(Meta::Path(path))
+                                    if path.is_ident(IGNORE_ATTR_PATH) =>
+                                {
+                                    if ignore {
+                                        return Err(Error::new(
+                                            nested.span(),
+                                            "Duplicate attribute",
+                                        ));
+                                    }
+                                    ignore = true;
                                 }
-                                ignore = true;
-                            }
-                            NestedMeta::Meta(Meta::NameValue(meta))
-                                if meta.path.is_ident(SAME_FN_ATTR_PATH) =>
-                            {
-                                if same_fn.is_some() {
-                                    return Err(Error::new(meta.span(), "Duplicate attribute"));
-                                }
+                                NestedMeta::Meta(Meta::NameValue(meta))
+                                    if meta.path.is_ident(DATA_SAME_FN_ATTR_PATH) =>
+                                {
+                                    if same_fn.is_some() {
+                                        return Err(Error::new(meta.span(), "Duplicate attribute"));
+                                    }
 
-                                let path = parse_lit_into_expr_path(&meta.lit)?;
-                                same_fn = Some(path);
-                            }
-                            NestedMeta::Meta(Meta::NameValue(meta))
-                                if meta.path.is_ident(LENS_NAME_OVERRIDE_ATTR_PATH) =>
-                            {
-                                if lens_name_override.is_some() {
-                                    return Err(Error::new(meta.span(), "Duplicate attribute"));
+                                    let path = parse_lit_into_expr_path(&meta.lit)?;
+                                    same_fn = Some(path);
                                 }
-
-                                let ident = parse_lit_into_ident(&meta.lit)?;
-                                lens_name_override = Some(ident);
+                                other => return Err(Error::new(other.span(), "Unknown attribute")),
                             }
-                            other => return Err(Error::new(other.span(), "Unknown attribute")),
                         }
                     }
+                    other => {
+                        return Err(Error::new(
+                            other.span(),
+                            "Expected attribute list (the form #[data(one, two)])",
+                        ));
+                    }
                 }
-                other => {
-                    return Err(Error::new(
-                        other.span(),
-                        "Expected attribute list (the form #[druid(one, two)])",
-                    ))
+            } else if attr.path.is_ident(BASE_LENS_ATTR_PATH) {
+                match attr.parse_meta()? {
+                    Meta::List(meta) => {
+                        for nested in meta.nested.iter() {
+                            match nested {
+                                NestedMeta::Meta(Meta::Path(path))
+                                    if path.is_ident(IGNORE_ATTR_PATH) =>
+                                {
+                                    if ignore {
+                                        return Err(Error::new(
+                                            nested.span(),
+                                            "Duplicate attribute",
+                                        ));
+                                    }
+                                    ignore = true;
+                                }
+                                NestedMeta::Meta(Meta::NameValue(meta))
+                                    if meta.path.is_ident(LENS_NAME_OVERRIDE_ATTR_PATH) =>
+                                {
+                                    if lens_name_override.is_some() {
+                                        return Err(Error::new(meta.span(), "Duplicate attribute"));
+                                    }
+
+                                    let ident = parse_lit_into_ident(&meta.lit)?;
+                                    lens_name_override = Some(ident);
+                                }
+                                other => return Err(Error::new(other.span(), "Unknown attribute")),
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(Error::new(
+                            other.span(),
+                            "Expected attribute list (the form #[data(one, two)])",
+                        ));
+                    }
                 }
             }
         }

--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -24,7 +24,7 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 /// Generates implementations of the `Data` trait.
-#[proc_macro_derive(Data, attributes(druid))]
+#[proc_macro_derive(Data, attributes(data))]
 pub fn derive_data(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     data::derive_data_impl(input)
@@ -36,7 +36,7 @@ pub fn derive_data(input: TokenStream) -> TokenStream {
 ///
 /// An associated constant is defined on the struct for each field,
 /// having the same name as the field.
-#[proc_macro_derive(Lens, attributes(druid))]
+#[proc_macro_derive(Lens, attributes(lens))]
 pub fn derive_lens(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     lens::derive_lens_impl(input)

--- a/druid-derive/tests/ignore.rs
+++ b/druid-derive/tests/ignore.rs
@@ -7,7 +7,7 @@ fn simple_ignore() {
     #[derive(Clone, Data)]
     struct Point {
         x: f64,
-        #[druid(ignore)]
+        #[data(ignore)]
         y: f64,
     }
     let p1 = Point { x: 0.0, y: 1.0 };
@@ -22,7 +22,7 @@ fn ignore_item_without_data_impl() {
     #[derive(Clone, Data)]
     struct CoolStruct {
         len: usize,
-        #[druid(ignore)]
+        #[data(ignore)]
         path: PathBuf,
     }
 }
@@ -30,7 +30,7 @@ fn ignore_item_without_data_impl() {
 #[test]
 fn tuple_struct() {
     #[derive(Clone, Data)]
-    struct Tup(usize, #[druid(ignore)] usize);
+    struct Tup(usize, #[data(ignore)] usize);
 
     let one = Tup(1, 1);
     let two = Tup(1, 5);
@@ -43,10 +43,10 @@ fn enums() {
     enum Hmm {
         Named {
             one: usize,
-            #[druid(ignore)]
+            #[data(ignore)]
             two: usize,
         },
-        Tuple(#[druid(ignore)] usize, usize),
+        Tuple(#[data(ignore)] usize, usize),
     }
 
     let name_one = Hmm::Named { one: 5, two: 4 };

--- a/druid-derive/tests/with_lens.rs
+++ b/druid-derive/tests/with_lens.rs
@@ -5,7 +5,7 @@ fn derive_lens() {
     #[derive(Clone, Lens, Debug)]
     struct Foo {
         text: String,
-        #[druid(lens_name = "lens_number")]
+        #[lens(name = "lens_number")]
         number: f64,
     }
 

--- a/druid-derive/tests/with_lens.rs
+++ b/druid-derive/tests/with_lens.rs
@@ -1,8 +1,9 @@
+use druid::Data;
 use druid::Lens;
 
 #[test]
 fn derive_lens() {
-    #[derive(Clone, Lens, Debug)]
+    #[derive(Lens)]
     struct Foo {
         text: String,
         #[lens(name = "lens_number")]
@@ -25,4 +26,43 @@ fn derive_lens() {
 
     assert_eq!(foo.text, "2.0");
     assert_eq!(foo.number, 2.0);
+}
+
+#[test]
+fn mix_with_data_lens() {
+    #[derive(Clone, Lens, Data)]
+    struct Foo {
+        #[data(ignore)]
+        text: String,
+        #[data(same_fn = "same_sign")]
+        #[lens(name = "lens_number")]
+        number: f64,
+    }
+
+    //test lens
+    let mut foo = Foo {
+        text: "1.0".into(),
+        number: 1.0,
+    };
+    let text_lens = Foo::text;
+    let number_lens = Foo::lens_number; //named lens for number
+
+    text_lens.with(&foo, |data| assert_eq!(data, "1.0"));
+    number_lens.with(&foo, |data| assert_eq!(*data, 1.0));
+
+    text_lens.with_mut(&mut foo, |data| *data = "2.0".into());
+    number_lens.with_mut(&mut foo, |data| *data = 2.0);
+
+    assert_eq!(foo.text, "2.0");
+    assert_eq!(foo.number, 2.0);
+
+    //test data
+    let two = Foo {
+        text: "666".into(),
+        number: 200.0,
+    };
+    assert!(foo.same(&two))
+}
+fn same_sign(one: &f64, two: &f64) -> bool {
+    one.signum() == two.signum()
 }

--- a/druid-derive/tests/with_same.rs
+++ b/druid-derive/tests/with_same.rs
@@ -5,7 +5,7 @@ fn same_fn() {
     #[derive(Clone, Data)]
     struct Nanana {
         bits: f64,
-        #[druid(same_fn = "PartialEq::eq")]
+        #[data(same_fn = "PartialEq::eq")]
         peq: f64,
     }
 
@@ -42,10 +42,10 @@ fn enums() {
             bits: f64,
         },
         Two {
-            #[druid(same_fn = "same_sign")]
+            #[data(same_fn = "same_sign")]
             bits: f64,
         },
-        Tri(#[druid(same_fn = "same_sign")] f64),
+        Tri(#[data(same_fn = "same_sign")] f64),
     }
 
     let oneone = Hi::One {

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -42,4 +42,4 @@ version = "0.5.0"
 
 [dependencies.druid-derive]
 path = "../druid-derive"
-version = "0.2.0"
+version = "0.3.0"

--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -27,7 +27,7 @@ const SET_COLOR: Selector = Selector::new("event-example.set-color");
 struct ColorWell;
 
 #[derive(Debug, Clone, Data)]
-struct MyColor(#[druid(same_fn = "color_eq")] Color);
+struct MyColor(#[data(same_fn = "color_eq")] Color);
 
 fn color_eq(one: &Color, two: &Color) -> bool {
     one.as_rgba_u32() == two.as_rgba_u32()

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -45,7 +45,7 @@ const UNFREEZE_COLOR: Selector = Selector::new("identity-example.unfreeze-color"
 /// Honestly: it's just a color in fancy clothing.
 #[derive(Debug, Clone, Data, Lens)]
 struct OurData {
-    #[druid(same_fn = "color_eq")]
+    #[data(same_fn = "color_eq")]
     color: Color,
 }
 

--- a/druid/examples/lens.rs
+++ b/druid/examples/lens.rs
@@ -31,7 +31,7 @@ fn main() {
 
 #[derive(Clone, Debug, Data, Lens)]
 struct MyComplexState {
-    #[druid(lens_name = "term_lens")]
+    #[lens(name = "term_lens")]
     term: String,
     scale: f64,
 }

--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -54,7 +54,7 @@ pub use druid_derive::Data;
 /// If the type you are implementing `Data` on contains some fields that are
 /// not relevant to the `Data` impl, you can ignore them with this attribute.
 ///
-/// - **`#[druid(same_fn = "path")]`**
+/// - **`#[data(same_fn = "path")]`**
 ///
 /// Use a specific function to compute `same`ness.
 ///
@@ -74,11 +74,11 @@ pub use druid_derive::Data;
 /// #[derive(Clone, Data)]
 /// struct PathEntry {
 ///     // There's no Data impl for PathBuf, but no problem
-///     #[druid(same_fn = "PartialEq::eq")]
+///     #[data(same_fn = "PartialEq::eq")]
 ///     path: PathBuf,
 ///     priority: usize,
 ///     // This field is not part of our data model.
-///     #[druid(ignore)]
+///     #[data(ignore)]
 ///     last_read: Instant,
 /// }
 /// ```


### PR DESCRIPTION
Implemented #723 

It will not compile with old druid attribute.

Note, ignore is parsed for both (never used for lens and not parsed), but saved to the same variable. 
Should I use ignore attribute for lens? Or Remove possibility to use it? Removed of now.

I'm thinking whether we should have single Field struct for attributes, or have separate struct for each base attribute, which probably will have some duplicated code.

And I would like to add documentation of which attributes are supported, it's not clear now. But I don't see a good place where to do it.