### PR TITLE
Call update on system commands

### DIFF
--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -487,7 +487,8 @@ impl<T: Data> AppState<T> {
             Some(cmd) => self.inner.borrow_mut().append_command(target, cmd),
             None => log::warn!("No command for menu id {}", cmd_id),
         }
-        self.process_commands()
+        self.process_commands();
+        self.inner.borrow_mut().do_update();
     }
 
     /// Handle a command. Top level commands (e.g. for creating and destroying


### PR DESCRIPTION
When a system command is handled, widgets don't get updated even if the command changed the data.
I'm not sure if this is the best place to do an update.
Related issue #754