### PR TITLE
Default to showing both scrollbars in the scroll example.

### DIFF
--- a/druid/examples/scroll.rs
+++ b/druid/examples/scroll.rs
@@ -33,7 +33,11 @@ fn main() {
 fn build_widget() -> impl Widget<u32> {
     let mut col = Flex::column();
     for i in 0..30 {
-        col.add_child(Padding::new(3.0, OverPainter(i)));
+        let mut row = Flex::row();
+        for j in 0..10 {
+            row.add_child(Padding::new(3.0, OverPainter(i * j)));
+        }
+        col.add_child(row);
     }
     Scroll::new(col)
 }


### PR DESCRIPTION
When testing #709 I needed both scroll directions. I think this will be a useful addition to the scroll example in general.