### PR TITLE
Turn off event compression for gtk.

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -423,6 +423,11 @@ impl WindowBuilder {
         }));
 
         vbox.pack_end(&drawing_area, true, true, 0);
+        drawing_area.realize();
+        drawing_area
+            .get_window()
+            .expect("realize didn't create window")
+            .set_event_compression(false);
 
         win_state
             .handler


### PR DESCRIPTION
I don't actually know if this is the right thing to do, but I figured it was at least worth bringing up.

By default, gtk compresses mouse motion events so that it delivers at most one per frame. This is causing issues for the toy drawing program that I'm writing, because if I want smooth lines then I need mouse events at the highest possible temporal resolution.

What's the behavior of other backends? If they all compress events, then could there be a knob for turning it off? If they don't compress events, probably gtk shouldn't either.