### PR TITLE
Reduce the flashing in ext_event and identity examples

### DIFF
--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -95,13 +95,13 @@ fn main() {
 
         loop {
             let time_since_start = (Instant::now() - start_time).as_nanos();
-            let previous = split_rgba(&last_color);
+            let (r, g, b, _) = split_rgba(&last_color);
 
             // there is no logic here; it's a very silly way of mutating the color.
             let new_color = match (time_since_start % 2, time_since_start % 3) {
-                (0, _) => Color::rgb8(previous.0.wrapping_add(10), previous.1, previous.2),
-                (_, 0) => Color::rgb8(previous.0, previous.1.wrapping_add(10), previous.2),
-                (_, _) => Color::rgb8(previous.0, previous.1, previous.2.wrapping_add(10)),
+                (0, _) => Color::rgb8(r.wrapping_add(10), g, b),
+                (_, 0) => Color::rgb8(r, g.wrapping_add(10), b),
+                (_, _) => Color::rgb8(r, g, b.wrapping_add(10)),
             };
 
             last_color = new_color.clone();

--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -33,23 +33,13 @@ fn color_eq(one: &Color, two: &Color) -> bool {
     one.as_rgba_u32() == two.as_rgba_u32()
 }
 
-fn split_rgba(rgba: &Color) -> (f64, f64, f64, f64) {
+fn split_rgba(rgba: &Color) -> (u8, u8, u8, u8) {
     let rgba = rgba.as_rgba_u32();
     (
-        (rgba >> 24) as f64 / 255.0,
-        ((rgba >> 16) & 255) as f64 / 255.0,
-        ((rgba >> 8) & 255) as f64 / 255.0,
-        (rgba & 255) as f64 / 255.0,
-    )
-}
-
-fn color_average(one: &Color, two: &Color) -> Color {
-    let one = split_rgba(one);
-    let two = split_rgba(two);
-    Color::rgb8(
-        ((one.0 + two.0 * 19.0) / 20.0 * 255.0) as u8,
-        ((one.1 + two.1 * 19.0) / 20.0 * 255.0) as u8,
-        ((one.2 + two.2 * 19.0) / 20.0 * 255.0) as u8,
+        (rgba >> 24 & 255) as u8,
+        ((rgba >> 16) & 255) as u8,
+        ((rgba >> 8) & 255) as u8,
+        (rgba & 255) as u8,
     )
 }
 
@@ -104,24 +94,20 @@ fn main() {
         let mut last_color = Color::WHITE;
 
         loop {
-            let time_since_start = Instant::now() - start_time;
-            let bits = (time_since_start.as_nanos() % (0xFFFFFF)) as u32;
+            let time_since_start = (Instant::now() - start_time).as_nanos();
+            let previous = split_rgba(&last_color);
 
-            // there is no logic here; it's a very silly way of creating a color.
-            let mask = 0x924924;
-            let red = bits & mask;
-            let red = (red >> 16 | red >> 8 | red) & 0xFF;
-            let green = bits & mask >> 1;
-            let green = (green >> 16 | green >> 8 | green) & 0xFF;
-            let blue = bits & mask >> 2;
-            let blue = (blue >> 16 | blue >> 8 | blue) & 0xFF;
+            // there is no logic here; it's a very silly way of mutating the color.
+            let new_color = match (time_since_start % 2, time_since_start % 3) {
+                (0, _) => Color::rgb8(previous.0.wrapping_add(10), previous.1, previous.2),
+                (_, 0) => Color::rgb8(previous.0, previous.1.wrapping_add(10), previous.2),
+                (_, _) => Color::rgb8(previous.0, previous.1, previous.2.wrapping_add(10)),
+            };
 
-            let new_color = Color::rgb8(red as u8, green as u8, blue as u8);
-            let next_color = color_average(&new_color, &last_color);
-            last_color = next_color.clone();
+            last_color = new_color.clone();
 
             // if this fails we're shutting down
-            if let Err(_) = event_sink.submit_command(SET_COLOR, next_color, None) {
+            if let Err(_) = event_sink.submit_command(SET_COLOR, new_color, None) {
                 break;
             }
             thread::sleep(Duration::from_millis(150));

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -96,13 +96,13 @@ impl Widget<OurData> for ColorWell {
         match event {
             Event::Timer(t) if t == &self.token => {
                 let time_since_start = (Instant::now() - self.start).as_nanos();
-                let previous = split_rgba(&data.color);
+                let (r, g, b, _) = split_rgba(&data.color);
 
                 // there is no logic here; it's a very silly way of mutating the color.
                 data.color = match (time_since_start % 2, time_since_start % 3) {
-                    (0, _) => Color::rgb8(previous.0.wrapping_add(10), previous.1, previous.2),
-                    (_, 0) => Color::rgb8(previous.0, previous.1.wrapping_add(10), previous.2),
-                    (_, _) => Color::rgb8(previous.0, previous.1, previous.2.wrapping_add(10)),
+                    (0, _) => Color::rgb8(r.wrapping_add(10), g, b),
+                    (_, 0) => Color::rgb8(r, g.wrapping_add(10), b),
+                    (_, _) => Color::rgb8(r, g, b.wrapping_add(10)),
                 };
 
                 self.token = ctx.request_timer(Instant::now() + CYCLE_DURATION);

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -53,6 +53,26 @@ fn color_eq(one: &Color, two: &Color) -> bool {
     one.as_rgba_u32() == two.as_rgba_u32()
 }
 
+fn split_rgba(rgba: &Color) -> (f64, f64, f64, f64) {
+    let rgba = rgba.as_rgba_u32();
+    (
+        (rgba >> 24) as f64 / 255.0,
+        ((rgba >> 16) & 255) as f64 / 255.0,
+        ((rgba >> 8) & 255) as f64 / 255.0,
+        (rgba & 255) as f64 / 255.0,
+    )
+}
+
+fn color_average(one: &Color, two: &Color) -> Color {
+    let one = split_rgba(one);
+    let two = split_rgba(two);
+    Color::rgb8(
+        ((one.0 + two.0 * 19.0) / 20.0 * 255.0) as u8,
+        ((one.1 + two.1 * 19.0) / 20.0 * 255.0) as u8,
+        ((one.2 + two.2 * 19.0) / 20.0 * 255.0) as u8,
+    )
+}
+
 /// A widget that displays a color.
 ///
 /// For the purpose of this fairly contrived demo, this widget works in one of two ways:
@@ -96,7 +116,10 @@ impl Widget<OurData> for ColorWell {
                 let blue = bits & mask >> 2;
                 let blue = (blue >> 16 | blue >> 8 | blue) & 0xFF;
 
-                data.color = Color::rgb8(red as u8, green as u8, blue as u8);
+                data.color = color_average(
+                    &Color::rgb8(red as u8, green as u8, blue as u8),
+                    &data.color,
+                );
                 self.token = ctx.request_timer(Instant::now() + CYCLE_DURATION);
                 ctx.request_paint();
             }


### PR DESCRIPTION
This is pretty hacky, let me know if you have a better idea! My main idea is to move only slightly toward the new random color. The result is the color stays pretty subtle, but I didn't want to introduce more state.