### PR TITLE
Fix ownership issue with KeyOrValue

### DIFF
--- a/druid/src/env.rs
+++ b/druid/src/env.rs
@@ -441,14 +441,31 @@ impl<'a, T: ValueType<'a>> KeyOrValue<T> {
     }
 }
 
-impl<T: Into<Value>> From<T> for KeyOrValue<T> {
-    fn from(value: T) -> KeyOrValue<T> {
+impl<'a, V: Into<Value>, T: ValueType<'a, Owned = V>> From<V> for KeyOrValue<T> {
+    fn from(value: V) -> KeyOrValue<T> {
         KeyOrValue::Concrete(value.into())
     }
 }
 
-impl<T: Into<Value>> From<Key<T>> for KeyOrValue<T> {
+impl<'a, T: ValueType<'a>> From<Key<T>> for KeyOrValue<T> {
     fn from(key: Key<T>) -> KeyOrValue<T> {
         KeyOrValue::Key(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_key_or_value() {
+        const MY_KEY: Key<&str> = Key::new("test.my-string-key");
+        let env = Env::default().adding(MY_KEY, "Owned".to_string());
+        assert_eq!(env.get(MY_KEY), "Owned");
+
+        let key: KeyOrValue<&str> = MY_KEY.into();
+        let value: KeyOrValue<&str> = "Owned".to_string().into();
+
+        assert_eq!(key.resolve(&env), value.resolve(&env));
     }
 }


### PR DESCRIPTION
A `Key<T>` does not always return a value, `T`; it can return a borrowed
value. This is only really exercised by String, which we return by reference.

In a situation like this, we cannot have `From<T>` for `KeyOrValue<T>` as well as `From<Key<T>>` for `KeyOrValue<T>`, because the owned type may be different then the type used by the key.

This is fixed by explicitly implementing `From` in terms of our `ValueType` trait, so that we can reference the owned type directly.

This should unblock #785.

cc @futurepaul, who might be curious about this.