### PR TITLE
Actually close GTK windows

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -472,9 +472,7 @@ impl WindowHandle {
     /// Close the window.
     pub fn close(&self) {
         if let Some(state) = self.state.upgrade() {
-            with_application(|app| {
-                app.remove_window(&state.window);
-            });
+            state.window.close();
         }
     }
 


### PR DESCRIPTION
Instead of removing the window from the application, it now gets closed.
This Closes #464 and also fixes the `multiwin` example with GTK.
Closing a window will also remove it from the `Application`