### PR TITLE
Add WidgetPath and use it to fix widget focus.

### DIFF
--- a/druid-shell/src/common_util.rs
+++ b/druid-shell/src/common_util.rs
@@ -55,7 +55,7 @@ impl<F: FnOnce(&dyn Any) + Send> IdleCallback for F {
 ///
 /// This can be used safely from multiple threads.
 ///
-/// The counter will overflow if `next()` iscalled 2^64 - 2 times.
+/// The counter will overflow if `next()` is called 2^64 - 2 times.
 /// If this is possible for your application, and reuse would be undesirable,
 /// use something else.
 pub struct Counter(AtomicU64);

--- a/druid/src/bloom.rs
+++ b/druid/src/bloom.rs
@@ -71,10 +71,12 @@ impl<T: ?Sized + Hash> Bloom<T> {
         self.entry_count += 1;
     }
 
-    /// Return whether an item exists in the filter.
+    /// Returns `true` if the item may have been added to the filter.
     ///
     /// This can return false positives, but never false negatives.
-    pub fn contains(&self, item: &T) -> bool {
+    /// Thus `true` means that the item may have been added - or not,
+    /// while `false` means that the item has definitely not been added.
+    pub fn may_contain(&self, item: &T) -> bool {
         let mask = self.make_bit_mask(item);
         self.bits & mask == mask
     }
@@ -134,11 +136,11 @@ mod tests {
         let mut bloom = Bloom::default();
         for i in 0..100 {
             bloom.add(&i);
-            assert!(bloom.contains(&i));
+            assert!(bloom.may_contain(&i));
         }
         bloom.clear();
         for i in 0..100 {
-            assert!(!bloom.contains(&i));
+            assert!(!bloom.may_contain(&i));
         }
     }
 
@@ -147,18 +149,18 @@ mod tests {
         let mut bloom1 = Bloom::default();
         bloom1.add(&0);
         bloom1.add(&1);
-        assert!(!bloom1.contains(&2));
-        assert!(!bloom1.contains(&3));
+        assert!(!bloom1.may_contain(&2));
+        assert!(!bloom1.may_contain(&3));
         let mut bloom2 = Bloom::default();
         bloom2.add(&2);
         bloom2.add(&3);
-        assert!(!bloom2.contains(&0));
-        assert!(!bloom2.contains(&1));
+        assert!(!bloom2.may_contain(&0));
+        assert!(!bloom2.may_contain(&1));
 
         let bloom3 = bloom1.union(bloom2);
-        assert!(bloom3.contains(&0));
-        assert!(bloom3.contains(&1));
-        assert!(bloom3.contains(&2));
-        assert!(bloom3.contains(&3));
+        assert!(bloom3.may_contain(&0));
+        assert!(bloom3.may_contain(&1));
+        assert!(bloom3.may_contain(&2));
+        assert!(bloom3.may_contain(&3));
     }
 }

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -19,7 +19,9 @@ use crate::kurbo::{Rect, Shape, Size, Vec2};
 use druid_shell::{Clipboard, KeyEvent, KeyModifiers, TimerToken};
 
 use crate::mouse::MouseEvent;
-use crate::{Command, Target, WidgetId};
+#[cfg(test)]
+use crate::WidgetId;
+use crate::{Command, Target, WidgetPath};
 
 /// An event, propagated downwards during event flow.
 ///
@@ -179,10 +181,10 @@ pub enum LifeCycle {
     HotChanged(bool),
     /// Internal: used by the framework to route the `FocusChanged` event.
     RouteFocusChanged {
-        /// the widget that is losing focus, if any
-        old: Option<WidgetId>,
-        /// the widget that is gaining focus, if any
-        new: Option<WidgetId>,
+        /// the widget path that is losing focus, if any
+        old: Option<WidgetPath>,
+        /// the widget path that is gaining focus, if any
+        new: Option<WidgetPath>,
     },
     /// Called when the focus status changes.
     ///

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -157,7 +157,7 @@ pub use lens::{Lens, LensExt, LensWrap};
 pub use localization::LocalizedString;
 pub use menu::{sys as platform_menus, ContextMenu, MenuDesc, MenuItem};
 pub use mouse::MouseEvent;
-pub use widget::{Widget, WidgetExt, WidgetId};
+pub use widget::{Widget, WidgetExt, WidgetId, WidgetPath};
 pub use win_handler::DruidHandler;
 pub use window::{Window, WindowId};
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -83,7 +83,7 @@ pub use switch::Switch;
 pub use textbox::TextBox;
 pub use view_switcher::ViewSwitcher;
 #[doc(hidden)]
-pub use widget::{Widget, WidgetId};
+pub use widget::{Widget, WidgetId, WidgetPath};
 #[doc(hidden)]
 pub use widget_ext::WidgetExt;
 

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -240,7 +240,7 @@ impl Widget<String> for TextBox {
 
         match event {
             Event::MouseDown(mouse) => {
-                if !ctx.has_focus() {
+                if !ctx.is_focused() {
                     ctx.request_focus();
                 }
                 ctx.set_active(true);
@@ -281,7 +281,7 @@ impl Widget<String> for TextBox {
                 }
             }
             Event::Command(ref cmd)
-                if ctx.has_focus()
+                if ctx.is_focused()
                     && (cmd.selector == crate::commands::COPY
                         || cmd.selector == crate::commands::CUT) =>
             {
@@ -392,9 +392,9 @@ impl Widget<String> for TextBox {
         let placeholder_color = env.get(theme::PLACEHOLDER_COLOR);
         let cursor_color = env.get(theme::CURSOR_COLOR);
 
-        let has_focus = ctx.has_focus();
+        let is_focused = ctx.is_focused();
 
-        let border_color = if has_focus {
+        let border_color = if is_focused {
             env.get(theme::PRIMARY_LIGHT)
         } else {
             env.get(theme::BORDER_DARK)
@@ -449,7 +449,7 @@ impl Widget<String> for TextBox {
             rc.draw_text(&text_layout, text_pos, color);
 
             // Paint the cursor if focused and there's no selection
-            if has_focus && self.cursor_on && self.selection.is_caret() {
+            if is_focused && self.cursor_on && self.selection.is_caret() {
                 let cursor_x = self.x_for_offset(&text_layout, self.cursor());
                 let xy = text_pos + Vec2::new(cursor_x, 2. - font_size);
                 let x2y2 = xy + Vec2::new(0., font_size + 2.);


### PR DESCRIPTION
## Background
I started looking into the widget id system after @sjoshid ran into some trouble with checking for descendants and talked about it on [zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/druid.23494.20(associate.20timers.20with.20widget.20ids)).

The current way is to check a bloom filter, which gives false positives. Now that on its own isn't necessarily a problem, but that fact is easily forgotten, as indeed evidenced in druid code itself.

The `has_focus` methods for example use the bloom filter and thus can return `true` even if the widget nor its descendants actually have focus. This is not documented for `has_focus`.

This leads into a chain reaction, because now we get to `TextBox` which uses `has_focus` thinking it's safe and proceeds to paint its border and caret even when it's not actually focused. This issue could be solved perhaps with better documentation for `has_focus` and fixing internal widgets like `TextBox` to properly use `is_focused` instead.

However the issue runs deeper because the druid inner event passing system uses `has_focus` to determine whether to pass down key press events. This means that widgets that aren't actually focused are getting key press events. Widgets like `TextBox` have no `is_focused` guards before handling key press events, so this means that if there's a bloom filter collision, multiple  textboxes will handle the key press inputs at once even though only one of them is focused. In theory this issue could also be solved by better documentation informing people that widgets can arbitrarily receive key press events.

That's a lot of documentation and random behavior though. Behavior that won't manifest under normal testing, but will manifest later for some customers using the final application and experiencing unexpected behavior. Behavior that the developer can't reproduce.

I think druid should have reliable and reproducible behavior whenever possible. It leads to easier debugging and fewer surprises. Thus I think that `has_focus` should always be correct, with no false positives.

## The changes in this PR
* `has_focus` no longer returns false positives and can be relied on.
* Renamed the bloom filter's `contains` to `may_contain` so that its behavior is signaled even to people who don't have the documentation at hand, e.g. people glancing at changes on GitHub.
* Improved the bloom filter documentation to really drive home the false positive nature of it. Also added comments to locations where it is used.
* Focus cycling now works even when starting from a non-registered-for-focus widget that merely called `request_focus`. The cycle is still only between registered-for-focus widgets.
* Improved `WidgetId` documentation by adding info about how there's not necessarily a one-id to one-widget relationship.

The reliability of `has_focus` is achieved by introducing a new struct `WidgetPath`. It's basically a `Vec<WidgetId>` that describes the path that needs to be taken in the widget tree to reach the target. Its implementation uses a tiny bit of unsafe to guarantee fast code (even in debug builds!) by being less general than a full `Vec` thanks to `WidgetId`.

I know the reason a bloom filter is used for tracking children in `BaseState` is because the exponential nature of `BaseState` would cause memory exhaustion. Thus this PR doesn't replace the bloom filter completely. Instead it is right now used only for focus purposes. Although it can become useful for other future cases too.

## Potential improvements
There is the question of the focus cycle (`focus_chain`) though. Right now `focus_chain` lives in `BaseState` and I just did a naive update there by replacing `WidgetId` with `WidgetPath`. This isn't too bad, but could be possibly better. I just don't know all the goals of the system.

Do widgets need to be able to change their position in the tree without re-registering for focus? Because if not, then this PR could perhaps be updated in a way that `focus_chain` would revert back to only knowing the leaf `WidgetId`, but there would be an additional payload generating the `WidgetPath` as a result of `register_for_focus` and then that `WidgetPath` would be stored in the window state as a `HashMap`. When a `focus_chain` widget needs to get focus, that goes through the window anyway, so the window could just do a lookup for the `WidgetPath` there. Then there would be no need to always store partial `WidgetPath`s in `BaseState`.
