### PR TITLE
Update X11 CI checkout to v2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     name: cargo test stable (x11)
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install deps
         run: |


### PR DESCRIPTION
#599 introduced initial bare X11 support but based its CI tasks on outdated checkout v1, which is broken. See more in #724.