### PR TITLE
Add method for getting a label's text

### DIFF
--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -145,6 +145,11 @@ impl<T: Data> Label<T> {
         self.text = LabelText::Specific(text.into());
     }
 
+    /// Returns this label's current text.
+    pub fn text(&self) -> &str {
+        self.text.display_text()
+    }
+
     /// Set the text color.
     ///
     /// The argument can be either a `Color` or a [`Key<Color>`].
@@ -190,6 +195,15 @@ impl<T: Data> LabelText<T> {
             LabelText::Specific(s) => cb(s.as_str()),
             LabelText::Localized(s) => cb(s.localized_str()),
             LabelText::Dynamic(s) => cb(s.resolved.as_str()),
+        }
+    }
+
+    /// Return the current resolved text.
+    pub fn display_text(&self) -> &str {
+        match self {
+            LabelText::Specific(s) => s.as_str(),
+            LabelText::Localized(s) => s.localized_str(),
+            LabelText::Dynamic(s) => s.resolved.as_str(),
         }
     }
 


### PR DESCRIPTION
This is another little thing I'll need to get editable labels into runebender.

broken off from #810 