### PR TITLE
Adds support for invalidating a single rectangle.

### DIFF
--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -14,12 +14,12 @@
 
 use std::any::Any;
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use druid_shell::kurbo::{Point, Rect};
 use druid_shell::piet::{Color, Piet, RenderContext};
 
-use druid_shell::{Application, WinHandler, WindowBuilder, WindowHandle};
+use druid_shell::{Application, TimerToken, WinHandler, WindowBuilder, WindowHandle};
 
 struct InvalidateTest {
     handle: WindowHandle,
@@ -49,13 +49,17 @@ impl InvalidateTest {
 impl WinHandler for InvalidateTest {
     fn connect(&mut self, handle: &WindowHandle) {
         self.handle = handle.clone();
+        self.handle.request_timer(Duration::from_millis(60));
+    }
+
+    fn timer(&mut self, _id: TimerToken) {
+        self.update_color_and_rect();
+        self.handle.invalidate_rect(self.rect);
+        self.handle.request_timer(Duration::from_millis(60));
     }
 
     fn paint(&mut self, piet: &mut Piet, rect: Rect) -> bool {
-        self.update_color_and_rect();
         piet.fill(rect, &self.color);
-
-        self.handle.invalidate_rect(self.rect);
         false
     }
 

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -1,0 +1,107 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use std::time::Instant;
+
+use piet_common::kurbo::{Point, Rect};
+use piet_common::{Color, Piet, RenderContext};
+
+use druid_shell::{Application, WinHandler, WindowBuilder, WindowHandle};
+
+struct InvalidateTest {
+    handle: WindowHandle,
+    size: (f64, f64),
+    start_time: Instant,
+    color: Color,
+    rect: Rect,
+}
+
+fn split_rgb(c: &Color) -> (u8, u8, u8) {
+    let rgba = c.as_rgba_u32();
+    (
+        (rgba >> 24 & 255) as u8,
+        (rgba >> 16 & 255) as u8,
+        (rgba >> 8 & 255) as u8,
+    )
+}
+
+impl InvalidateTest {
+    fn update_color_and_rect(&mut self) {
+        let time_since_start = (Instant::now() - self.start_time).as_nanos();
+        let (r, g, b) = split_rgb(&self.color);
+        self.color = match (time_since_start % 2, time_since_start % 3) {
+            (0, _) => Color::rgb8(r.wrapping_add(10), g, b),
+            (_, 0) => Color::rgb8(r, g.wrapping_add(10), b),
+            (_, _) => Color::rgb8(r, g, b.wrapping_add(10)),
+        };
+
+        self.rect.x0 = (self.rect.x0 + 5.0) % self.size.0;
+        self.rect.x1 = (self.rect.x1 + 5.5) % self.size.0;
+        self.rect.y0 = (self.rect.y0 + 3.0) % self.size.1;
+        self.rect.y1 = (self.rect.y1 + 3.5) % self.size.1;
+    }
+}
+
+impl WinHandler for InvalidateTest {
+    fn connect(&mut self, handle: &WindowHandle) {
+        self.handle = handle.clone();
+    }
+
+    fn paint(&mut self, piet: &mut Piet, rect: Rect) -> bool {
+        self.update_color_and_rect();
+        piet.fill(rect, &self.color);
+
+        self.handle.invalidate_rect(self.rect);
+        false
+    }
+
+    fn size(&mut self, width: u32, height: u32) {
+        let dpi = self.handle.get_dpi();
+        let dpi_scale = dpi as f64 / 96.0;
+        let width_f = (width as f64) / dpi_scale;
+        let height_f = (height as f64) / dpi_scale;
+        self.size = (width_f, height_f);
+    }
+
+    fn command(&mut self, id: u32) {
+        match id {
+            0x100 => self.handle.close(),
+            _ => println!("unexpected id {}", id),
+        }
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+fn main() {
+    let mut app = Application::new(None);
+    let mut builder = WindowBuilder::new();
+    let inv_test = InvalidateTest {
+        size: Default::default(),
+        handle: Default::default(),
+        start_time: Instant::now(),
+        rect: Rect::from_origin_size(Point::ZERO, (10.0, 20.0)),
+        color: Color::WHITE,
+    };
+    builder.set_handler(Box::new(inv_test));
+    builder.set_title("Invalidate tester");
+
+    let window = builder.build().unwrap();
+    window.show();
+    app.run();
+}

--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -16,8 +16,8 @@ use std::any::Any;
 
 use std::time::Instant;
 
-use piet_common::kurbo::{Point, Rect};
-use piet_common::{Color, Piet, RenderContext};
+use druid_shell::kurbo::{Point, Rect};
+use druid_shell::piet::{Color, Piet, RenderContext};
 
 use druid_shell::{Application, WinHandler, WindowBuilder, WindowHandle};
 
@@ -29,19 +29,10 @@ struct InvalidateTest {
     rect: Rect,
 }
 
-fn split_rgb(c: &Color) -> (u8, u8, u8) {
-    let rgba = c.as_rgba_u32();
-    (
-        (rgba >> 24 & 255) as u8,
-        (rgba >> 16 & 255) as u8,
-        (rgba >> 8 & 255) as u8,
-    )
-}
-
 impl InvalidateTest {
     fn update_color_and_rect(&mut self) {
         let time_since_start = (Instant::now() - self.start_time).as_nanos();
-        let (r, g, b) = split_rgb(&self.color);
+        let (r, g, b, _) = self.color.as_rgba_u8();
         self.color = match (time_since_start % 2, time_since_start % 3) {
             (0, _) => Color::rgb8(r.wrapping_add(10), g, b),
             (_, 0) => Color::rgb8(r, g.wrapping_add(10), b),

--- a/druid-shell/examples/perftest.rs
+++ b/druid-shell/examples/perftest.rs
@@ -36,7 +36,7 @@ impl WinHandler for PerfTest {
         self.handle = handle.clone();
     }
 
-    fn paint(&mut self, piet: &mut Piet) -> bool {
+    fn paint(&mut self, piet: &mut Piet, _: Rect) -> bool {
         let (width, height) = self.size;
         let rect = Rect::new(0.0, 0.0, width, height);
         piet.fill(rect, &BG_COLOR);

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -36,7 +36,7 @@ impl WinHandler for HelloState {
         self.handle = handle.clone();
     }
 
-    fn paint(&mut self, piet: &mut piet_common::Piet) -> bool {
+    fn paint(&mut self, piet: &mut piet_common::Piet, _: Rect) -> bool {
         let (width, height) = self.size;
         let rect = Rect::new(0.0, 0.0, width, height);
         piet.fill(rect, &BG_COLOR);

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -651,7 +651,7 @@ impl WindowHandle {
         );
         unsafe {
             // We could share impl with redraw, but we'd need to deal with nil.
-            let () = msg_send![*self.nsview.load(), setNeedsDisplay: rect];
+            let () = msg_send![*self.nsview.load(), setNeedsDisplayInRect: rect];
         }
     }
 

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -38,7 +38,7 @@ use objc::{class, msg_send, sel, sel_impl};
 use cairo::{Context, QuartzSurface};
 use log::{error, info};
 
-use crate::kurbo::{Point, Size, Vec2};
+use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
 use super::dialog;
@@ -503,6 +503,10 @@ extern "C" fn draw_rect(this: &mut Object, _: Sel, dirtyRect: NSRect) {
         let frame = NSView::frame(this as *mut _);
         let width = frame.size.width as u32;
         let height = frame.size.height as u32;
+        let rect = Rect::from_origin_size(
+            (dirtyRect.origin.x, dirtyRect.origin.y),
+            (dirtyRect.size.width, dirtyRect.size.height),
+        );
         let cairo_surface =
             QuartzSurface::create_for_cg_context(cgcontext, width, height).expect("cairo surface");
         let mut cairo_ctx = Context::new(&cairo_surface);
@@ -511,7 +515,7 @@ extern "C" fn draw_rect(this: &mut Object, _: Sel, dirtyRect: NSRect) {
         let mut piet_ctx = Piet::new(&mut cairo_ctx);
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
-        let anim = (*view_state).handler.paint(&mut piet_ctx);
+        let anim = (*view_state).handler.paint(&mut piet_ctx, rect);
         if let Err(e) = piet_ctx.finish() {
             error!("{}", e)
         }
@@ -636,6 +640,18 @@ impl WindowHandle {
         unsafe {
             // We could share impl with redraw, but we'd need to deal with nil.
             let () = msg_send![*self.nsview.load(), setNeedsDisplay: YES];
+        }
+    }
+
+    /// Request invalidation of one rectangle.
+    pub fn invalidate_rect(&self, rect: Rect) {
+        let rect = NSRect::new(
+            NSPoint::new(rect.x0, rect.y0),
+            NSSize::new(rect.width(), rect.height()),
+        );
+        unsafe {
+            // We could share impl with redraw, but we'd need to deal with nil.
+            let () = msg_send![*self.nsview.load(), setNeedsDisplay: rect];
         }
     }
 

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -93,11 +93,9 @@ struct WindowState {
 }
 
 impl WindowState {
-    fn render(&self, rect: Rect) -> bool {
-        self.context
-            .clear_rect(0.0, 0.0, self.get_width() as f64, self.get_height() as f64);
+    fn render(&self, invalid_rect: Rect) -> bool {
         let mut piet_ctx = piet_common::Piet::new(self.context.clone(), self.window.clone());
-        let want_anim_frame = self.handler.borrow_mut().paint(&mut piet_ctx, rect);
+        let want_anim_frame = self.handler.borrow_mut().paint(&mut piet_ctx, invalid_rect);
         if let Err(e) = piet_ctx.finish() {
             log::error!("piet error on render: {:?}", e);
         }
@@ -501,6 +499,7 @@ impl WindowHandle {
         if let Some(s) = self.0.upgrade() {
             let handle = self.clone();
             let rect = s.invalid_rect.get();
+            s.invalid_rect.set(Rect::ZERO);
             let state = s.clone();
             s.request_animation_frame(move || {
                 let want_anim_frame = state.render(rect);

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -25,7 +25,7 @@ use instant::Instant;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-use crate::kurbo::{Point, Size, Vec2};
+use crate::kurbo::{Point, Rect, Size, Vec2};
 
 use crate::piet::RenderContext;
 
@@ -89,14 +89,15 @@ struct WindowState {
     window: web_sys::Window,
     canvas: web_sys::HtmlCanvasElement,
     context: web_sys::CanvasRenderingContext2d,
+    invalid_rect: Cell<Rect>,
 }
 
 impl WindowState {
-    fn render(&self) -> bool {
+    fn render(&self, rect: Rect) -> bool {
         self.context
             .clear_rect(0.0, 0.0, self.get_width() as f64, self.get_height() as f64);
         let mut piet_ctx = piet_common::Piet::new(self.context.clone(), self.window.clone());
-        let want_anim_frame = self.handler.borrow_mut().paint(&mut piet_ctx);
+        let want_anim_frame = self.handler.borrow_mut().paint(&mut piet_ctx, rect);
         if let Err(e) = piet_ctx.finish() {
             log::error!("piet error on render: {:?}", e);
         }
@@ -370,6 +371,7 @@ impl WindowBuilder {
             window,
             canvas,
             context,
+            invalid_rect: Cell::new(Rect::ZERO),
         });
 
         setup_web_callbacks(&window);
@@ -411,7 +413,27 @@ impl WindowHandle {
         log::warn!("bring_to_frontand_focus unimplemented for web");
     }
 
+    pub fn invalidate_rect(&self, rect: Rect) {
+        if let Some(s) = self.0.upgrade() {
+            let cur_rect = s.invalid_rect.get();
+            if cur_rect.width() == 0.0 || cur_rect.height() == 0.0 {
+                s.invalid_rect.set(rect);
+            } else if rect.width() != 0.0 && rect.height() != 0.0 {
+                s.invalid_rect.set(cur_rect.union(rect));
+            }
+        }
+        self.render_soon();
+    }
+
     pub fn invalidate(&self) {
+        if let Some(s) = self.0.upgrade() {
+            let rect = Rect::from_origin_size(
+                Point::ORIGIN,
+                // FIXME: does this need scaling? Not sure exactly where dpr enters...
+                (s.get_width() as f64, s.get_height() as f64),
+            );
+            s.invalid_rect.set(rect);
+        }
         self.render_soon();
     }
 
@@ -478,9 +500,10 @@ impl WindowHandle {
     fn render_soon(&self) {
         if let Some(s) = self.0.upgrade() {
             let handle = self.clone();
+            let rect = s.invalid_rect.get();
             let state = s.clone();
             s.request_animation_frame(move || {
-                let want_anim_frame = state.render();
+                let want_anim_frame = state.render(rect);
                 if want_anim_frame {
                     handle.render_soon();
                 }

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -23,7 +23,7 @@ use lazy_static::lazy_static;
 use super::clipboard::Clipboard;
 use super::window::XWindow;
 use crate::application::AppHandler;
-use crate::kurbo::Point;
+use crate::kurbo::{Point, Rect};
 use crate::{KeyCode, KeyModifiers, MouseButton, MouseEvent};
 
 struct XcbConnection {
@@ -76,10 +76,16 @@ impl Application {
                     xcb::EXPOSE => {
                         let expose: &xcb::ExposeEvent = unsafe { xcb::cast_event(&ev) };
                         let window_id = expose.window();
+                        // TODO(x11/dpi_scaling): when dpi scaling is
+                        // implemented, it needs to be used here too
+                        let rect = Rect::from_origin_size(
+                            (expose.x() as f64, expose.y() as f64),
+                            (expose.width() as f64, expose.height() as f64),
+                        );
                         WINDOW_MAP.with(|map| {
                             let mut windows = map.borrow_mut();
                             if let Some(w) = windows.get_mut(&window_id) {
-                                w.render();
+                                w.render(rect);
                             }
                         })
                     }

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -21,7 +21,7 @@ use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
 use crate::error::Error;
 use crate::keyboard::{KeyEvent, KeyModifiers};
-use crate::kurbo::{Point, Size, Vec2};
+use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::menu::Menu;
 use crate::mouse::{Cursor, MouseEvent};
 use crate::platform::window as platform;
@@ -129,6 +129,11 @@ impl WindowHandle {
     /// Request invalidation of the entire window contents.
     pub fn invalidate(&self) {
         self.0.invalidate()
+    }
+
+    /// Request invalidation of a region of the window.
+    pub fn invalidate_rect(&self, rect: Rect) {
+        self.0.invalidate_rect(rect);
     }
 
     /// Set the title for this menu.
@@ -278,8 +283,9 @@ pub trait WinHandler {
 
     /// Request the handler to paint the window contents. Return value
     /// indicates whether window is animating, i.e. whether another paint
-    /// should be scheduled for the next animation frame.
-    fn paint(&mut self, piet: &mut piet_common::Piet) -> bool;
+    /// should be scheduled for the next animation frame. `invalid_rect` is the
+    /// rectangle that needs to be repainted.
+    fn paint(&mut self, piet: &mut piet_common::Piet, invalid_rect: Rect) -> bool;
 
     /// Called when the resources need to be rebuilt.
     ///

--- a/druid/examples/invalidation.rs
+++ b/druid/examples/invalidation.rs
@@ -1,0 +1,88 @@
+// Copyright 2019 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Demonstrates how to debug invalidation regions, and also shows the
+//! invalidation behavior of several build-in widgets.
+
+use druid::kurbo::{Circle, Shape};
+use druid::widget::prelude::*;
+use druid::widget::{Button, Flex, Scroll, Split, TextBox};
+use druid::{AppLauncher, Color, Data, Lens, LocalizedString, Point, WidgetExt, WindowDesc};
+
+pub fn main() {
+    let window = WindowDesc::new(build_widget).title(
+        LocalizedString::new("invalidate-demo-window-title").with_placeholder("Invalidate demo"),
+    );
+    let state = AppState {
+        label: "My label".into(),
+        circle_pos: Point::new(0.0, 0.0),
+    };
+    AppLauncher::with_window(window)
+        .use_simple_logger()
+        .launch(state)
+        .expect("launch failed");
+}
+
+#[derive(Clone, Data, Lens)]
+struct AppState {
+    label: String,
+    circle_pos: Point,
+}
+
+fn build_widget() -> impl Widget<AppState> {
+    let mut col = Flex::column();
+    col.add_child(TextBox::new().lens(AppState::label).padding(3.0));
+    for i in 0..30 {
+        col.add_child(Button::new(format!("Button {}", i)).padding(3.0));
+    }
+    Split::columns(Scroll::new(col), CircleView.lens(AppState::circle_pos)).debug_invalidation()
+}
+
+struct CircleView;
+
+const RADIUS: f64 = 25.0;
+
+impl Widget<Point> for CircleView {
+    fn event(&mut self, ctx: &mut EventCtx, ev: &Event, data: &mut Point, _env: &Env) {
+        if let Event::MouseDown(ev) = ev {
+            // Move the circle to a new location, invalidating both the old and new locations.
+            ctx.request_paint_rect(Circle::new(*data, RADIUS).bounding_box());
+            ctx.request_paint_rect(Circle::new(ev.pos, RADIUS).bounding_box());
+            *data = ev.pos;
+        }
+    }
+
+    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _ev: &LifeCycle, _data: &Point, _env: &Env) {}
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _old: &Point, _new: &Point, _env: &Env) {}
+
+    fn layout(
+        &mut self,
+        _ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        _data: &Point,
+        _env: &Env,
+    ) -> Size {
+        bc.max()
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &Point, _env: &Env) {
+        ctx.with_save(|ctx| {
+            let rect = ctx.size().to_rect();
+            ctx.clip(rect);
+            ctx.fill(rect, &Color::WHITE);
+            ctx.fill(Circle::new(*data, RADIUS), &Color::BLACK);
+        })
+    }
+}

--- a/druid/examples/wasm/src/lib.rs
+++ b/druid/examples/wasm/src/lib.rs
@@ -45,6 +45,7 @@ impl_example!(game_of_life);
 impl_example!(hello);
 impl_example!(identity);
 impl_example!(image);
+impl_example!(invalidation);
 impl_example!(layout);
 impl_example!(lens);
 impl_example!(list);

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -474,6 +474,7 @@ impl<'a> LifeCycleCtx<'a> {
     /// Request an animation frame.
     pub fn request_anim_frame(&mut self) {
         self.base_state.request_anim = true;
+        self.request_paint();
     }
 
     /// Submit a [`Command`] to be run after this event is handled.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -335,9 +335,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// [`paint`]: trait.Widget.html#tymethod.paint
     /// [`paint_with_offset`]: #method.paint_with_offset
     pub fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
-        let mut child_region = ctx.region.clone();
-        child_region -= self.state.layout_rect().origin().to_vec2();
-        child_region.intersect_with(self.state.paint_rect());
         let mut inner_ctx = PaintCtx {
             render_ctx: ctx.render_ctx,
             window_id: ctx.window_id,
@@ -390,7 +387,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         ctx.with_save(|ctx| {
             let layout_origin = self.layout_rect().origin().to_vec2();
             ctx.transform(Affine::translate(layout_origin));
-            let visible = ctx.region().to_rect() - layout_origin;
+            let visible = ctx.region().to_rect().intersect(self.state.paint_rect()) - layout_origin;
             ctx.with_child_ctx(visible, |ctx| self.paint(ctx, data, env));
         });
     }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -19,11 +19,12 @@ use std::collections::VecDeque;
 use log;
 
 use crate::bloom::Bloom;
-use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size};
+use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size, Vec2};
 use crate::piet::RenderContext;
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
-    LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Target, UpdateCtx, Widget, WidgetId, WindowId,
+    LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Region, Target, UpdateCtx, Widget, WidgetId,
+    WindowId,
 };
 
 /// Our queue type
@@ -75,11 +76,15 @@ pub(crate) struct BaseState {
     /// drop shadows or overflowing text.
     pub(crate) paint_insets: Insets,
 
+    // The region that needs to be repainted, relative to the widget's bounds.
+    pub(crate) invalid: Region,
+
+    // The part of this widget that is visible on the screen is offset by this
+    // much. This will be non-zero for widgets that are children of `Scroll`, or
+    // similar, and it is used for propagating invalid regions.
+    pub(crate) viewport_offset: Vec2,
+
     // TODO: consider using bitflags for the booleans.
-
-    // This should become an invalidation rect.
-    pub(crate) needs_inval: bool,
-
     pub(crate) is_hot: bool,
 
     pub(crate) is_active: bool,
@@ -212,6 +217,28 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         self.state.layout_rect.unwrap_or_default()
     }
 
+    /// Set the viewport offset.
+    ///
+    /// This is relevant only for children of a scroll view (or similar). It must
+    /// be set by the parent widget whenever it modifies the position of its child
+    /// while painting it and propagating events. As a rule of thumb, you need this
+    /// if and only if you `Affine::translate` the paint context before painting
+    /// your child. For an example, see the implentation of [`Scroll`].
+    ///
+    /// [`Scroll`]: widget/struct.Scroll.html
+    pub fn set_viewport_offset(&mut self, offset: Vec2) {
+        self.state.viewport_offset = offset;
+    }
+
+    /// The viewport offset.
+    ///
+    /// This will be the same value as set by [`set_viewport_offset`].
+    ///
+    /// [`set_viewport_offset`]: #method.viewport_offset
+    pub fn viewport_offset(&self) -> Vec2 {
+        self.state.viewport_offset
+    }
+
     /// Get the widget's paint [`Rect`].
     ///
     /// This is the [`Rect`] that widget has indicated it needs to paint in.
@@ -308,6 +335,9 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
     /// [`paint`]: trait.Widget.html#tymethod.paint
     /// [`paint_with_offset`]: #method.paint_with_offset
     pub fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        let mut child_region = ctx.region.clone();
+        child_region -= self.state.layout_rect().origin().to_vec2();
+        child_region.intersect_with(self.state.paint_rect());
         let mut inner_ctx = PaintCtx {
             render_ctx: ctx.render_ctx,
             window_id: ctx.window_id,
@@ -327,7 +357,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             inner_ctx.stroke(rect, &color, BORDER_WIDTH);
         }
 
-        self.state.needs_inval = false;
+        self.state.invalid = Region::EMPTY;
     }
 
     /// Paint the widget, translating it by the origin of its layout rectangle.
@@ -742,7 +772,8 @@ impl BaseState {
             id,
             layout_rect: None,
             paint_insets: Insets::ZERO,
-            needs_inval: false,
+            invalid: Region::EMPTY,
+            viewport_offset: Vec2::ZERO,
             is_hot: false,
             needs_layout: false,
             is_active: false,
@@ -759,7 +790,15 @@ impl BaseState {
 
     /// Update to incorporate state changes from a child.
     fn merge_up(&mut self, child_state: &BaseState) {
-        self.needs_inval |= child_state.needs_inval;
+        let mut child_region = child_state.invalid.clone();
+        child_region += child_state.layout_rect().origin().to_vec2() - child_state.viewport_offset;
+        let clip = self
+            .layout_rect()
+            .with_origin(Point::ORIGIN)
+            .inset(self.paint_insets);
+        child_region.intersect_with(clip);
+        self.invalid.merge_with(child_region);
+
         self.needs_layout |= child_state.needs_layout;
         self.request_anim |= child_state.request_anim;
         self.request_timer |= child_state.request_timer;
@@ -783,8 +822,6 @@ impl BaseState {
         self.layout_rect.unwrap_or_default() + self.paint_insets
     }
 
-    #[cfg(test)]
-    #[allow(dead_code)]
     pub(crate) fn layout_rect(&self) -> Rect {
         self.layout_rect.unwrap_or_default()
     }

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -263,9 +263,13 @@ impl<T: Data> Harness<'_, T> {
         self.inner.layout(&mut self.piet)
     }
 
+    pub fn paint_rect(&mut self, invalid_rect: Rect) {
+        self.inner.paint_rect(&mut self.piet, invalid_rect)
+    }
+
     #[allow(dead_code)]
     pub fn paint(&mut self) {
-        self.inner.paint(&mut self.piet)
+        self.paint_rect(self.window_size.to_rect())
     }
 }
 
@@ -290,9 +294,9 @@ impl<T: Data> Inner<T> {
     }
 
     #[allow(dead_code)]
-    fn paint(&mut self, piet: &mut Piet) {
+    fn paint_rect(&mut self, piet: &mut Piet, invalid_rect: Rect) {
         self.window
-            .do_paint(piet, &mut self.cmds, &self.data, &self.env);
+            .do_paint(piet, invalid_rect, &mut self.cmds, &self.data, &self.env);
     }
 }
 

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -91,7 +91,7 @@ pub enum Record {
     /// A `LifeCycle` event.
     L(LifeCycle),
     Layout(Size),
-    Update(bool),
+    Update(Rect),
     Paint,
     // instead of always returning an Option<Record>, we have a none variant;
     // this would be code smell elsewhere but here I think it makes the tests
@@ -289,8 +289,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
-        let inval = ctx.base_state.needs_inval;
-        self.recording.push(Record::Update(inval));
+        self.recording
+            .push(Record::Update(ctx.base_state.invalid.to_rect()));
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/invalidation.rs
+++ b/druid/src/widget/invalidation.rs
@@ -1,0 +1,66 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::widget::prelude::*;
+use crate::Data;
+
+/// A widget that draws semi-transparent rectangles of changing colors to help debug invalidation
+/// regions.
+pub struct DebugInvalidation<T, W> {
+    inner: W,
+    debug_color: u64,
+    marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Data, W: Widget<T>> DebugInvalidation<T, W> {
+    /// Wraps a widget in a `DebugInvalidation`.
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner,
+            debug_color: 0,
+            marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        self.inner.event(ctx, event, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        self.inner.lifecycle(ctx, event, data, env)
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        self.inner.update(ctx, old_data, data, env);
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        self.inner.layout(ctx, bc, data, env)
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        self.inner.paint(ctx, data, env);
+
+        let color = env.get_debug_color(self.debug_color).with_alpha(0.5);
+        let rect = ctx.region().to_rect();
+        ctx.fill(rect, &color);
+        self.debug_color += 1;
+    }
+
+    fn id(&self) -> Option<WidgetId> {
+        self.inner.id()
+    }
+}

--- a/druid/src/widget/invalidation.rs
+++ b/druid/src/widget/invalidation.rs
@@ -54,9 +54,10 @@ impl<T: Data, W: Widget<T>> Widget<T> for DebugInvalidation<T, W> {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
         self.inner.paint(ctx, data, env);
 
-        let color = env.get_debug_color(self.debug_color).with_alpha(0.5);
-        let rect = ctx.region().to_rect();
-        ctx.fill(rect, &color);
+        let color = env.get_debug_color(self.debug_color);
+        let stroke_width = 2.0;
+        let rect = ctx.region().to_rect().inset(-stroke_width / 2.0);
+        ctx.stroke(rect, &color, stroke_width);
         self.debug_color += 1;
     }
 

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -28,6 +28,7 @@ mod identity_wrapper;
 #[cfg(feature = "image")]
 #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
 mod image;
+mod invalidation;
 mod label;
 mod list;
 mod padding;
@@ -64,6 +65,7 @@ pub use either::Either;
 pub use env_scope::EnvScope;
 pub use flex::{CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
+pub use invalidation::DebugInvalidation;
 pub use label::{Label, LabelText};
 pub use list::{List, ListIter};
 pub use padding::Padding;

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -65,7 +65,6 @@ pub use either::Either;
 pub use env_scope::EnvScope;
 pub use flex::{CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use identity_wrapper::IdentityWrapper;
-pub use invalidation::DebugInvalidation;
 pub use label::{Label, LabelText};
 pub use list::{List, ListIter};
 pub use padding::Padding;

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -163,6 +163,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         offset.y = offset.y.min(self.child_size.height - size.height).max(0.0);
         if (offset - self.scroll_offset).hypot2() > 1e-12 {
             self.scroll_offset = offset;
+            self.child.set_viewport_offset(offset);
             true
         } else {
             false
@@ -381,7 +382,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             let force_event = self.child.is_hot() || self.child.is_active();
             let child_event = event.transform_scroll(self.scroll_offset, viewport, force_event);
             if let Some(child_event) = child_event {
-                self.child.event(ctx, &child_event, data, env)
+                self.child.event(ctx, &child_event, data, env);
             };
 
             match event {

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -453,7 +453,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             ctx.clip(viewport);
             ctx.transform(Affine::translate(-self.scroll_offset));
 
-            let visible = viewport.with_origin(self.scroll_offset.to_point());
+            let visible = ctx.region().to_rect() + self.scroll_offset;
             ctx.with_child_ctx(visible, |ctx| self.child.paint(ctx, data, env));
 
             self.draw_bars(ctx, viewport, env);

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -14,9 +14,10 @@
 
 //! Convenience methods for widgets.
 
+use super::invalidation::DebugInvalidation;
 use super::{
-    Align, BackgroundBrush, Click, Container, Controller, ControllerHost, DebugInvalidation,
-    EnvScope, IdentityWrapper, Padding, Parse, SizedBox, WidgetId,
+    Align, BackgroundBrush, Click, Container, Controller, ControllerHost, EnvScope,
+    IdentityWrapper, Padding, Parse, SizedBox, WidgetId,
 };
 use crate::{Color, Data, Env, EventCtx, Insets, KeyOrValue, Lens, LensWrap, UnitPoint, Widget};
 

--- a/druid/src/widget/widget_ext.rs
+++ b/druid/src/widget/widget_ext.rs
@@ -15,8 +15,8 @@
 //! Convenience methods for widgets.
 
 use super::{
-    Align, BackgroundBrush, Click, Container, Controller, ControllerHost, EnvScope,
-    IdentityWrapper, Padding, Parse, SizedBox, WidgetId,
+    Align, BackgroundBrush, Click, Container, Controller, ControllerHost, DebugInvalidation,
+    EnvScope, IdentityWrapper, Padding, Parse, SizedBox, WidgetId,
 };
 use crate::{Color, Data, Env, EventCtx, Insets, KeyOrValue, Lens, LensWrap, UnitPoint, Widget};
 
@@ -179,6 +179,12 @@ pub trait WidgetExt<T: Data>: Widget<T> + Sized + 'static {
     /// [`layout`]: trait.Widget.html#tymethod.layout
     fn debug_paint_layout(self) -> EnvScope<T, Self> {
         EnvScope::new(|env, _| env.set(Env::DEBUG_PAINT, true), self)
+    }
+
+    /// Draw a color-changing rectangle over this widget, allowing you to see the
+    /// invalidation regions.
+    fn debug_invalidation(self) -> DebugInvalidation<T, Self> {
+        DebugInvalidation::new(self)
     }
 
     /// Set the [`DEBUG_WIDGET`] env variable for this widget (and its descendants).

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -19,7 +19,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
-use crate::kurbo::{Size, Vec2};
+use crate::kurbo::{Rect, Size, Vec2};
 use crate::piet::Piet;
 use crate::shell::{
     Application, FileDialogOptions, IdleToken, MouseEvent, WinHandler, WindowHandle,
@@ -269,9 +269,9 @@ impl<T: Data> Inner<T> {
     }
 
     /// Returns `true` if an animation frame was requested.
-    fn paint(&mut self, window_id: WindowId, piet: &mut Piet) -> bool {
+    fn paint(&mut self, window_id: WindowId, piet: &mut Piet, rect: Rect) -> bool {
         if let Some(win) = self.windows.get_mut(window_id) {
-            win.do_paint(piet, &mut self.command_queue, &self.data, &self.env);
+            win.do_paint(piet, rect, &mut self.command_queue, &self.data, &self.env);
             win.wants_animation_frame()
         } else {
             false
@@ -436,8 +436,8 @@ impl<T: Data> AppState<T> {
         result
     }
 
-    fn paint_window(&mut self, window_id: WindowId, piet: &mut Piet) -> bool {
-        self.inner.borrow_mut().paint(window_id, piet)
+    fn paint_window(&mut self, window_id: WindowId, piet: &mut Piet, rect: Rect) -> bool {
+        self.inner.borrow_mut().paint(window_id, piet, rect)
     }
 
     fn idle(&mut self, token: IdleToken) {
@@ -611,8 +611,8 @@ impl<T: Data> WinHandler for DruidHandler<T> {
         self.app_state.do_window_event(event, self.window_id);
     }
 
-    fn paint(&mut self, piet: &mut Piet) -> bool {
-        self.app_state.paint_window(self.window_id, piet)
+    fn paint(&mut self, piet: &mut Piet, rect: Rect) -> bool {
+        self.app_state.paint_window(self.window_id, piet, rect)
     }
 
     fn size(&mut self, width: u32, height: u32) {

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -272,7 +272,12 @@ impl<T: Data> Inner<T> {
     fn paint(&mut self, window_id: WindowId, piet: &mut Piet, rect: Rect) -> bool {
         if let Some(win) = self.windows.get_mut(window_id) {
             win.do_paint(piet, rect, &mut self.command_queue, &self.data, &self.env);
-            win.wants_animation_frame()
+            if win.wants_animation_frame() {
+                win.handle.invalidate();
+                true
+            } else {
+                false
+            }
         } else {
             false
         }

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -348,14 +348,13 @@ impl<T: Data> Window<T> {
             focus_widget: self.focus,
             region: invalid_rect.into(),
         };
-        let visible = Rect::from_origin_size(Point::ZERO, self.size);
-        ctx.with_child_ctx(visible, |ctx| self.root.paint(ctx, data, env));
+        ctx.with_child_ctx(invalid_rect, |ctx| self.root.paint(ctx, data, env));
 
         let mut z_ops = mem::take(&mut ctx.z_ops);
         z_ops.sort_by_key(|k| k.z_index);
 
         for z_op in z_ops.into_iter() {
-            ctx.with_child_ctx(visible, |ctx| {
+            ctx.with_child_ctx(invalid_rect, |ctx| {
                 ctx.with_save(|ctx| {
                     ctx.render_ctx.transform(z_op.transform);
                     (z_op.paint_func)(ctx);

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -301,7 +301,10 @@ impl<T: Data> Window<T> {
             self.layout(piet, queue, data, env);
         }
 
-        piet.clear(env.get(crate::theme::WINDOW_BACKGROUND_COLOR));
+        piet.fill(
+            invalid_rect,
+            &env.get(crate::theme::WINDOW_BACKGROUND_COLOR),
+        );
         self.paint(piet, invalid_rect, data, env);
     }
 


### PR DESCRIPTION
This adds support in druid-shell for invalidating a single rectangle.

Caveats/questions:
 - I checked that the win/mac changes compile, but I can't test them. Mac is particularly likely to be wrong, since I have no idea how rust-objc works, and how it maps to the apple docs online.
- Should the plain `invalidate` methods be deprecated? Or should I just keep the name and introduce the rect parameter?