### PR TITLE
Make request_focus a no-op when the widget is already focused.

### DIFF
--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -280,11 +280,16 @@ impl<'a> EventCtx<'a> {
 
     /// Request keyboard focus.
     ///
+    /// Calling this when the widget is already focused does nothing.
+    ///
     /// See [`is_focused`] for more information about focus.
     ///
     /// [`is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn request_focus(&mut self) {
-        self.base_state.request_focus = Some(FocusChange::Focus(self.widget_id()));
+        let id = self.widget_id();
+        if self.focus_widget != Some(id) {
+            self.base_state.request_focus = Some(FocusChange::Focus(id));
+        }
     }
 
     /// Transfer focus to the next focusable widget.

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -240,9 +240,7 @@ impl Widget<String> for TextBox {
 
         match event {
             Event::MouseDown(mouse) => {
-                if !ctx.is_focused() {
-                    ctx.request_focus();
-                }
+                ctx.request_focus();
                 ctx.set_active(true);
 
                 let cursor_offset = self.offset_for_point(mouse.pos, &text_layout);


### PR DESCRIPTION
It doesn't really make sense to request focus when you're already focused, but previously you had to check for `is_focused` yourself like `TextBox` or you would run into bugs because `FocusChanged(false)` and `FocusChanged(true)` wouldn't be sent to the same widget during one event run.

This PR makes calling `request_focus` care-free.