### PR TITLE
Add Event::MouseLeave for windows

### DIFF
--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -607,7 +607,7 @@ impl WndProc for MyWndProc {
                     let y = HIWORD(lparam as u32) as i16 as i32;
 
                     // When the mouse first enters the window client rect we need to register for the
-                    // WM_MOUSELEAVE event. Note that WM_MOUSEMOVE is called even when the change
+                    // WM_MOUSELEAVE event. Note that WM_MOUSEMOVE is also called even when the
                     // window under the cursor changes without moving the mouse, for example when
                     // our window is first opened under the mouse cursor.
                     if !s.has_mouse_focus && is_point_in_client_rect(hwnd, x, y) {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -619,7 +619,12 @@ impl WndProc for MyWndProc {
                             dwHoverTime: HOVER_DEFAULT,
                         };
                         unsafe {
-                            TrackMouseEvent(&mut desc);
+                            if TrackMouseEvent(&mut desc) == FALSE {
+                                warn!(
+                                    "failed to TrackMouseEvent: {}",
+                                    Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                                );
+                            }
                         }
                     }
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -613,7 +613,7 @@ impl WndProc for MyWndProc {
                     if !s.has_mouse_focus && is_point_in_client_rect(hwnd, x, y) {
                         s.has_mouse_focus = true;
                         let mut desc = TRACKMOUSEEVENT {
-                            cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as DWORD,
+                            cbSize: mem::size_of::<TRACKMOUSEEVENT>() as DWORD,
                             dwFlags: TME_LEAVE,
                             hwndTrack: hwnd,
                             dwHoverTime: HOVER_DEFAULT,

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -611,7 +611,6 @@ impl WndProc for MyWndProc {
                     // window under the cursor changes without moving the mouse, for example when
                     // our window is first opened under the mouse cursor.
                     if !s.has_mouse_focus && is_point_in_client_rect(hwnd, x, y) {
-                        s.has_mouse_focus = true;
                         let mut desc = TRACKMOUSEEVENT {
                             cbSize: mem::size_of::<TRACKMOUSEEVENT>() as DWORD,
                             dwFlags: TME_LEAVE,
@@ -619,7 +618,9 @@ impl WndProc for MyWndProc {
                             dwHoverTime: HOVER_DEFAULT,
                         };
                         unsafe {
-                            if TrackMouseEvent(&mut desc) == FALSE {
+                            if TrackMouseEvent(&mut desc) != FALSE {
+                                s.has_mouse_focus = true;
+                            } else {
                                 warn!(
                                     "failed to TrackMouseEvent: {}",
                                     Error::Hr(HRESULT_FROM_WIN32(GetLastError()))

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -333,6 +333,9 @@ pub trait WinHandler {
     #[allow(unused_variables)]
     fn mouse_up(&mut self, event: &MouseEvent) {}
 
+    /// Called when the mouse cursor has left the application window
+    fn mouse_leave(&mut self) {}
+
     /// Called on timer event.
     ///
     /// This is called at (approximately) the requested deadline by a

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -417,14 +417,14 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 mouse_event.pos -= rect.origin().to_vec2();
                 Event::MouseMove(mouse_event)
             }
-            Event::MouseLeft => {
+            Event::MouseLeave => {
                 let had_hot = child_ctx.base_state.is_hot;
                 child_ctx.base_state.is_hot = false;
                 if had_hot {
                     hot_changed = Some(false);
                 }
                 recurse = had_active || had_hot;
-                Event::MouseLeft
+                Event::MouseLeave
             }
             Event::KeyDown(e) => {
                 recurse = child_ctx.has_focus();

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -417,6 +417,15 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 mouse_event.pos -= rect.origin().to_vec2();
                 Event::MouseMove(mouse_event)
             }
+            Event::MouseLeft => {
+                let had_hot = child_ctx.base_state.is_hot;
+                child_ctx.base_state.is_hot = false;
+                if had_hot {
+                    hot_changed = Some(false);
+                }
+                recurse = had_active || had_hot;
+                Event::MouseLeft
+            }
             Event::KeyDown(e) => {
                 recurse = child_ctx.has_focus();
                 Event::KeyDown(*e)

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -86,9 +86,9 @@ pub enum Event {
     MouseMove(MouseEvent),
     /// Called when the mouse has left the application area.
     ///
-    /// The `MouseLeft` event is propagated to the active widget, if
+    /// The `MouseLeave` event is propagated to the active widget, if
     /// there is one, otherwise to hot widgets (see `HotChanged`).
-    MouseLeft,
+    MouseLeave,
     /// Called when a key is pressed.
     ///
     /// Note: the intent is for each physical key press to correspond to

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -84,10 +84,9 @@ pub enum Event {
     ///
     /// [`set_cursor`]: struct.EventCtx.html#method.set_cursor
     MouseMove(MouseEvent),
-    /// Called when the mouse has left the application area.
+    /// Called when the mouse has left the window.
     ///
-    /// The `MouseLeave` event is propagated to the active widget, if
-    /// there is one, otherwise to hot widgets (see `HotChanged`).
+    /// The `MouseLeave` event is propagated to both active and hot widgets.
     MouseLeave,
     /// Called when a key is pressed.
     ///

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -84,6 +84,11 @@ pub enum Event {
     ///
     /// [`set_cursor`]: struct.EventCtx.html#method.set_cursor
     MouseMove(MouseEvent),
+    /// Called when the mouse has left the application area.
+    ///
+    /// The `MouseLeft` event is propagated to the active widget, if
+    /// there is one, otherwise to hot widgets (see `HotChanged`).
+    MouseLeft,
     /// Called when a key is pressed.
     ///
     /// Note: the intent is for each physical key press to correspond to

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -639,6 +639,11 @@ impl<T: Data> WinHandler for DruidHandler<T> {
         self.app_state.do_window_event(event, self.window_id);
     }
 
+    fn mouse_leave(&mut self) {
+        self.app_state
+            .do_window_event(Event::MouseLeft, self.window_id);
+    }
+
     fn key_down(&mut self, event: KeyEvent) -> bool {
         self.app_state
             .do_window_event(Event::KeyDown(event), self.window_id)

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -641,7 +641,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
 
     fn mouse_leave(&mut self) {
         self.app_state
-            .do_window_event(Event::MouseLeft, self.window_id);
+            .do_window_event(Event::MouseLeave, self.window_id);
     }
 
     fn key_down(&mut self, event: KeyEvent) -> bool {


### PR DESCRIPTION
Adds a new new event `MouseLeft`, and implemented it for windows.
The purpose for this event is to give a possibility of the OS to notifiy the druid app that it is no longer going to receive mouse events for some time. Either because the mouse has left the window rect, or because another app is blocking the mouse cursor. 