### PR TITLE
Add logging when WM_CAPTURECHANGED is dropped

### DIFF
--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -272,18 +272,9 @@ impl WndState {
         self.captured_mouse_buttons |= 1 << (button as u32);
     }
 
-    fn exit_mouse_capture(&mut self, button: MouseButton) {
+    fn exit_mouse_capture(&mut self, button: MouseButton) -> bool {
         self.captured_mouse_buttons &= !(1 << (button as u32));
-        if self.captured_mouse_buttons == 0 {
-            unsafe {
-                if ReleaseCapture() == FALSE {
-                    warn!(
-                        "failed to release mouse capture: {}",
-                        Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
-                    );
-                }
-            }
-        }
+        self.captured_mouse_buttons == 0
     }
 }
 
@@ -625,6 +616,7 @@ impl WndProc for MyWndProc {
             WM_LBUTTONDBLCLK | WM_LBUTTONDOWN | WM_LBUTTONUP | WM_MBUTTONDBLCLK
             | WM_MBUTTONDOWN | WM_MBUTTONUP | WM_RBUTTONDBLCLK | WM_RBUTTONDOWN | WM_RBUTTONUP
             | WM_XBUTTONDBLCLK | WM_XBUTTONDOWN | WM_XBUTTONUP => {
+                let mut should_release_capture = false;
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let s = s.as_mut().unwrap();
                     let button = match msg {
@@ -666,11 +658,26 @@ impl WndProc for MyWndProc {
                         s.handler.mouse_down(&event);
                     } else {
                         s.handler.mouse_up(&event);
-                        s.exit_mouse_capture(button);
+                        should_release_capture = s.exit_mouse_capture(button);
                     }
                 } else {
                     self.log_dropped_msg(hwnd, msg, wparam, lparam);
                 }
+
+                // ReleaseCapture() is deferred: it needs to be called without having a mutable
+                // reference to the window state, because it will generate a reentrant
+                // WM_CAPTURECHANGED event.
+                if should_release_capture {
+                    unsafe {
+                        if ReleaseCapture() == FALSE {
+                            warn!(
+                                "failed to release mouse capture: {}",
+                                Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                            );
+                        }
+                    }
+                }
+
                 Some(0)
             }
             XI_REQUEST_DESTROY => {
@@ -705,6 +712,8 @@ impl WndProc for MyWndProc {
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let s = s.as_mut().unwrap();
                     s.captured_mouse_buttons = 0;
+                } else {
+                    self.log_dropped_msg(hwnd, msg, wparam, lparam);
                 }
                 Some(0)
             }


### PR DESCRIPTION
This is a small clean up of #695. It was considered alright to drop `WM_CAPTURECHANGED` messages when the window state is locked, because this happens when we call `ReleaseCapture` ourselves, and in that case we already update the relevant state ourselves and don't need the callback.

However I think it's actually better if we have the log in `WM_CAPTURECHANGED` in case it will be called reentrantly in another situation that we don't know about. Instead, I've made sure that we defer calling `ReleaseCapture` to a point where we're not locking the window state.