### PR TITLE
Rename Event::MouseMoved to Event::MouseMove

### DIFF
--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -262,7 +262,7 @@ impl Widget<AppData> for GameOfLifeWidget {
                     data.drawing = false;
                 }
             }
-            Event::MouseMoved(e) => {
+            Event::MouseMove(e) => {
                 if data.drawing {
                     let grid_pos_opt = self.grid_pos(e.pos);
                     grid_pos_opt.iter().for_each(|pos| data.grid[*pos] = true);

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -177,7 +177,7 @@ impl<'a> EventCtx<'a> {
     /// event handler, but can also be called in response to other events,
     /// for example pressing a key to change the behavior of a widget.
     ///
-    /// [`MouseMove`]: enum.Event.html#variant.MouseDown
+    /// [`MouseMove`]: enum.Event.html#variant.MouseMove
     pub fn set_cursor(&mut self, cursor: &Cursor) {
         *self.cursor = Some(cursor.clone());
     }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -173,11 +173,11 @@ impl<'a> EventCtx<'a> {
     /// only has the effect of the last one (ie no need to worry about
     /// flashing).
     ///
-    /// This method is expected to be called mostly from the [`MouseMoved`]
+    /// This method is expected to be called mostly from the [`MouseMove`]
     /// event handler, but can also be called in response to other events,
     /// for example pressing a key to change the behavior of a widget.
     ///
-    /// [`MouseMoved`]: enum.Event.html#variant.MouseDown
+    /// [`MouseMove`]: enum.Event.html#variant.MouseDown
     pub fn set_cursor(&mut self, cursor: &Cursor) {
         *self.cursor = Some(cursor.clone());
     }

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -406,7 +406,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 mouse_event.pos -= rect.origin().to_vec2();
                 Event::MouseUp(mouse_event)
             }
-            Event::MouseMoved(mouse_event) => {
+            Event::MouseMove(mouse_event) => {
                 let had_hot = child_ctx.base_state.is_hot;
                 child_ctx.base_state.is_hot = rect.winding(mouse_event.pos) != 0;
                 if had_hot != child_ctx.base_state.is_hot {
@@ -415,7 +415,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 recurse = had_active || had_hot || child_ctx.base_state.is_hot;
                 let mut mouse_event = mouse_event.clone();
                 mouse_event.pos -= rect.origin().to_vec2();
-                Event::MouseMoved(mouse_event)
+                Event::MouseMove(mouse_event)
             }
             Event::KeyDown(e) => {
                 recurse = child_ctx.has_focus();

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -73,17 +73,17 @@ pub enum Event {
     MouseUp(MouseEvent),
     /// Called when the mouse is moved.
     ///
-    /// The `MouseMoved` event is propagated to the active widget, if
+    /// The `MouseMove` event is propagated to the active widget, if
     /// there is one, otherwise to hot widgets (see `HotChanged`).
     ///
-    /// The `MouseMoved` event is also the primary mechanism for widgets
+    /// The `MouseMove` event is also the primary mechanism for widgets
     /// to set a cursor, for example to an I-bar inside a text widget. A
     /// simple tactic is for the widget to unconditionally call
-    /// [`set_cursor`] in the MouseMoved handler, as `MouseMove` is only
+    /// [`set_cursor`] in the MouseMove handler, as `MouseMove` is only
     /// propagated to active or hot widgets.
     ///
     /// [`set_cursor`]: struct.EventCtx.html#method.set_cursor
-    MouseMoved(MouseEvent),
+    MouseMove(MouseEvent),
     /// Called when a key is pressed.
     ///
     /// Note: the intent is for each physical key press to correspond to
@@ -172,7 +172,7 @@ pub enum LifeCycle {
     ///
     /// This will always be called _before_ the event that triggered it; that is,
     /// when the mouse moves over a widget, that widget will receive
-    /// `LifeCycle::HotChanged` before it receives `Event::MouseMoved`.
+    /// `LifeCycle::HotChanged` before it receives `Event::MouseMove`.
     ///
     /// See [`is_hot`](struct.EventCtx.html#method.is_hot) for
     /// discussion about the hot status.
@@ -259,11 +259,11 @@ impl Event {
                     None
                 }
             }
-            Event::MouseMoved(mouse_event) => {
+            Event::MouseMove(mouse_event) => {
                 if force || viewport.winding(mouse_event.pos) != 0 {
                     let mut mouse_event = mouse_event.clone();
                     mouse_event.pos += offset;
-                    Some(Event::MouseMoved(mouse_event))
+                    Some(Event::MouseMove(mouse_event))
                 } else {
                     None
                 }

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -72,50 +72,50 @@ fn propogate_hot() {
         // and verifying both the widget's `is_hot` status and also that
         // each widget received the expected HotChanged messages.
 
-        harness.event(Event::MouseMoved(make_mouse(10., 10.)));
+        harness.event(Event::MouseMove(make_mouse(10., 10.)));
         assert!(harness.get_state(root).is_hot);
         assert!(harness.get_state(empty).is_hot);
         assert!(!harness.get_state(pad).is_hot);
 
         assert_matches!(root_rec.next(), Record::L(LifeCycle::HotChanged(true)));
-        assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(root_rec.next(), Record::E(Event::MouseMove(_)));
         assert!(root_rec.is_empty() && padding_rec.is_empty() && button_rec.is_empty());
 
-        harness.event(Event::MouseMoved(make_mouse(210., 10.)));
+        harness.event(Event::MouseMove(make_mouse(210., 10.)));
 
         assert!(harness.get_state(root).is_hot);
         assert!(!harness.get_state(empty).is_hot);
         assert!(!harness.get_state(button).is_hot);
         assert!(harness.get_state(pad).is_hot);
 
-        assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(root_rec.next(), Record::E(Event::MouseMove(_)));
         assert_matches!(padding_rec.next(), Record::L(LifeCycle::HotChanged(true)));
-        assert_matches!(padding_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(padding_rec.next(), Record::E(Event::MouseMove(_)));
         assert!(root_rec.is_empty() && padding_rec.is_empty() && button_rec.is_empty());
 
-        harness.event(Event::MouseMoved(make_mouse(260., 60.)));
+        harness.event(Event::MouseMove(make_mouse(260., 60.)));
         assert!(harness.get_state(root).is_hot);
         assert!(!harness.get_state(empty).is_hot);
         assert!(harness.get_state(button).is_hot);
         assert!(harness.get_state(pad).is_hot);
 
-        assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
-        assert_matches!(padding_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(root_rec.next(), Record::E(Event::MouseMove(_)));
+        assert_matches!(padding_rec.next(), Record::E(Event::MouseMove(_)));
         assert_matches!(button_rec.next(), Record::L(LifeCycle::HotChanged(true)));
-        assert_matches!(button_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(button_rec.next(), Record::E(Event::MouseMove(_)));
         assert!(root_rec.is_empty() && padding_rec.is_empty() && button_rec.is_empty());
 
-        harness.event(Event::MouseMoved(make_mouse(10., 10.)));
+        harness.event(Event::MouseMove(make_mouse(10., 10.)));
         assert!(harness.get_state(root).is_hot);
         assert!(harness.get_state(empty).is_hot);
         assert!(!harness.get_state(button).is_hot);
         assert!(!harness.get_state(pad).is_hot);
 
-        assert_matches!(root_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(root_rec.next(), Record::E(Event::MouseMove(_)));
         assert_matches!(padding_rec.next(), Record::L(LifeCycle::HotChanged(false)));
-        assert_matches!(padding_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(padding_rec.next(), Record::E(Event::MouseMove(_)));
         assert_matches!(button_rec.next(), Record::L(LifeCycle::HotChanged(false)));
-        assert_matches!(button_rec.next(), Record::E(Event::MouseMoved(_)));
+        assert_matches!(button_rec.next(), Record::E(Event::MouseMove(_)));
         assert!(root_rec.is_empty() && padding_rec.is_empty() && button_rec.is_empty());
     });
 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -297,7 +297,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         let viewport = Rect::from_origin_size(Point::ORIGIN, size);
 
         let scrollbar_is_hovered = match event {
-            Event::MouseMoved(e) | Event::MouseUp(e) | Event::MouseDown(e) => {
+            Event::MouseMove(e) | Event::MouseUp(e) | Event::MouseDown(e) => {
                 let offset_pos = e.pos + self.scroll_offset;
                 self.point_hits_vertical_bar(viewport, offset_pos, &env)
                     || self.point_hits_horizontal_bar(viewport, offset_pos, &env)
@@ -308,7 +308,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         if self.scrollbars.are_held() {
             // if we're dragging a scrollbar
             match event {
-                Event::MouseMoved(event) => {
+                Event::MouseMove(event) => {
                     match self.scrollbars.held {
                         BarHeldState::Vertical(offset) => {
                             let scale_y = viewport.height() / self.child_size.height;
@@ -342,7 +342,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         } else if scrollbar_is_hovered {
             // if we're over a scrollbar but not dragging
             match event {
-                Event::MouseMoved(event) => {
+                Event::MouseMove(event) => {
                     let offset_pos = event.pos + self.scroll_offset;
                     if self.point_hits_vertical_bar(viewport, offset_pos, &env) {
                         self.scrollbars.hovered = BarHoveredState::Vertical;
@@ -381,7 +381,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             };
 
             match event {
-                Event::MouseMoved(_) => {
+                Event::MouseMove(_) => {
                     // if we have just stopped hovering
                     if self.scrollbars.hovered.is_hovered() && !scrollbar_is_hovered {
                         self.scrollbars.hovered = BarHoveredState::None;

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -97,7 +97,7 @@ impl Widget<f64> for Slider {
                     ctx.request_paint();
                 }
             }
-            Event::MouseMoved(mouse) => {
+            Event::MouseMove(mouse) => {
                 if ctx.is_active() {
                     *data = self.calculate_value(mouse.pos.x, knob_size, slider_width);
                     ctx.request_paint();

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -294,7 +294,7 @@ impl<T: Data> Widget<T> for Split<T> {
                         ctx.request_paint();
                     }
                 }
-                Event::MouseMoved(mouse) => {
+                Event::MouseMove(mouse) => {
                     if ctx.is_active() {
                         self.update_split_point(ctx.size(), mouse.pos);
                         ctx.request_layout();

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -134,7 +134,7 @@ impl Widget<bool> for Switch {
                 self.animation_in_progress = true;
                 ctx.request_anim_frame();
             }
-            Event::MouseMoved(mouse) => {
+            Event::MouseMove(mouse) => {
                 if ctx.is_active() {
                     self.knob_pos.x = mouse.pos.x.min(on_pos).max(off_pos);
                     self.knob_dragged = true;

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -254,7 +254,7 @@ impl Widget<String> for TextBox {
 
                 ctx.request_paint();
             }
-            Event::MouseMoved(mouse) => {
+            Event::MouseMove(mouse) => {
                 ctx.set_cursor(&Cursor::IBeam);
                 if ctx.is_active() {
                     let cursor_offset = self.offset_for_point(mouse.pos, &text_layout);

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -635,7 +635,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
     }
 
     fn mouse_move(&mut self, event: &MouseEvent) {
-        let event = Event::MouseMoved(event.clone().into());
+        let event = Event::MouseMove(event.clone().into());
         self.app_state.do_window_event(event, self.window_id);
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -111,7 +111,7 @@ impl<T: Data> Window<T> {
         env: &Env,
     ) -> bool {
         let mut cursor = match event {
-            Event::MouseMoved(..) => Some(Cursor::Arrow),
+            Event::MouseMove(..) => Some(Cursor::Arrow),
             _ => None,
         };
 


### PR DESCRIPTION
As discussed in #821, this renames `MouseMoved` to `MouseMove` for consistency with web API's.