### PR TITLE
Move internal events to a separate enum.

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -366,7 +366,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
 
         // log if we seem not to be laid out when we should be
-        if !matches!(event, Event::WindowConnected | Event::Internal(InternalEvent::Size(_)))
+        if !matches!(event, Event::WindowConnected | Event::WindowSize(_))
             && self.state.layout_rect.is_none()
         {
             log::warn!(
@@ -404,11 +404,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut hot_changed = None;
         let child_event = match event {
             Event::Internal(internal) => match internal {
-                InternalEvent::Size(size) => {
-                    child_ctx.request_layout();
-                    recurse = ctx.is_root;
-                    Event::Internal(InternalEvent::Size(*size))
-                }
                 InternalEvent::MouseLeave => {
                     let had_hot = child_ctx.base_state.is_hot;
                     child_ctx.base_state.is_hot = false;
@@ -437,6 +432,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 }
             },
             Event::WindowConnected => Event::WindowConnected,
+            Event::WindowSize(size) => {
+                child_ctx.request_layout();
+                recurse = ctx.is_root;
+                Event::WindowSize(*size)
+            }
             Event::MouseDown(mouse_event) => {
                 let had_hot = child_ctx.base_state.is_hot;
                 let now_hot = rect.winding(mouse_event.pos) != 0;

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -56,6 +56,13 @@ pub enum Event {
     ///
     /// [`LifeCycle::WidgetAdded`]: enum.LifeCycle.html#variant.WidgetAdded
     WindowConnected,
+    /// Called on the root widget when the window size changes.
+    ///
+    /// Discussion: it's not obvious this should be propagated to user
+    /// widgets. It *is* propagated through the RootWidget and handled
+    /// in the WindowPod, but after that it might be considered better
+    /// to just handle it in `layout`.
+    WindowSize(Size),
     /// Called when a mouse button is pressed.
     MouseDown(MouseEvent),
     /// Called when a mouse button is released.
@@ -133,8 +140,6 @@ pub enum Event {
 /// [`Event`]: enum.Event.html
 #[derive(Debug, Clone)]
 pub enum InternalEvent {
-    /// Sent to the root widget when the window size changes.
-    Size(Size),
     /// Sent in some cases when the mouse has left the window.
     ///
     /// This is used in cases when the platform no longer sends mouse events,

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -56,17 +56,6 @@ pub enum Event {
     ///
     /// [`LifeCycle::WidgetAdded`]: enum.LifeCycle.html#variant.WidgetAdded
     WindowConnected,
-    /// Called on the root widget when the window size changes.
-    ///
-    /// Discussion: it's not obvious this should be propagated to user
-    /// widgets. It *is* propagated through the RootWidget and handled
-    /// in the WindowPod, but after that it might be considered better
-    /// to just handle it in `layout`.
-    ///
-    /// The propagation logic of "just the root" requires a little bit
-    /// of complexity and state in EventCtx, so if it's not useful it
-    /// should be removed.
-    Size(Size),
     /// Called when a mouse button is pressed.
     MouseDown(MouseEvent),
     /// Called when a mouse button is released.
@@ -84,10 +73,6 @@ pub enum Event {
     ///
     /// [`set_cursor`]: struct.EventCtx.html#method.set_cursor
     MouseMove(MouseEvent),
-    /// Called when the mouse has left the window.
-    ///
-    /// The `MouseLeave` event is propagated to both active and hot widgets.
-    MouseLeave,
     /// Called when a key is pressed.
     ///
     /// Note: the intent is for each physical key press to correspond to
@@ -131,9 +116,31 @@ pub enum Event {
     /// [`Widget`]: trait.Widget.html
     /// [`EventCtx::submit_command`]: struct.EventCtx.html#method.submit_command
     Command(Command),
-    /// A command still in the process of being dispatched. This is an internal
-    /// event and should generally not be handled directly by widgets, but is
-    /// important for containers to dispatch to their children.
+    /// Internal druid event.
+    ///
+    /// This should always be passed down to descendant [`WidgetPod`]s.
+    ///
+    /// [`WidgetPod`]: struct.WidgetPod.html
+    Internal(InternalEvent),
+}
+
+/// Internal events used by druid inside [`WidgetPod`].
+///
+/// These events are translated into regular [`Event`]s
+/// and should not be used directly.
+///
+/// [`WidgetPod`]: struct.WidgetPod.html
+/// [`Event`]: enum.Event.html
+#[derive(Debug, Clone)]
+pub enum InternalEvent {
+    /// Sent to the root widget when the window size changes.
+    Size(Size),
+    /// Sent in some cases when the mouse has left the window.
+    ///
+    /// This is used in cases when the platform no longer sends mouse events,
+    /// but we know that we've stopped receiving the mouse events.
+    MouseLeave,
+    /// A command still in the process of being dispatched.
     TargetedCommand(Target, Command),
 }
 
@@ -164,8 +171,6 @@ pub enum LifeCycle {
     /// [`WidgetPod`]: struct.WidgetPod.html
     /// [`LifeCycleCtx::register_for_focus`]: struct.LifeCycleCtx.html#method.register_for_focus
     WidgetAdded,
-    /// Used internally by the framework to route WidgetAdded to the required widgets.
-    RouteWidgetAdded,
     /// Called at the beginning of a new animation frame.
     ///
     /// On the first frame when transitioning from idle to animating, `interval`
@@ -181,13 +186,6 @@ pub enum LifeCycle {
     /// See [`is_hot`](struct.EventCtx.html#method.is_hot) for
     /// discussion about the hot status.
     HotChanged(bool),
-    /// Internal: used by the framework to route the `FocusChanged` event.
-    RouteFocusChanged {
-        /// the widget that is losing focus, if any
-        old: Option<WidgetId>,
-        /// the widget that is gaining focus, if any
-        new: Option<WidgetId>,
-    },
     /// Called when the focus status changes.
     ///
     /// This will always be called immediately after a new widget gains focus.
@@ -198,6 +196,32 @@ pub enum LifeCycle {
     ///
     /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
     FocusChanged(bool),
+    /// Internal druid lifecycle event.
+    ///
+    /// This should always be passed down to descendant [`WidgetPod`]s.
+    ///
+    /// [`WidgetPod`]: struct.WidgetPod.html
+    Internal(InternalLifeCycle),
+}
+
+/// Internal lifecycle events used by druid inside [`WidgetPod`].
+///
+/// These events are translated into regular [`LifeCycle`] events
+/// and should not be used directly.
+///
+/// [`WidgetPod`]: struct.WidgetPod.html
+/// [`LifeCycle`]: enum.LifeCycle.html
+#[derive(Debug, Clone)]
+pub enum InternalLifeCycle {
+    /// Used to route the `WidgetAdded` event to the required widgets.
+    RouteWidgetAdded,
+    /// Used to route the `FocusChanged` event.
+    RouteFocusChanged {
+        /// the widget that is losing focus, if any
+        old: Option<WidgetId>,
+        /// the widget that is gaining focus, if any
+        new: Option<WidgetId>,
+    },
     /// Testing only: request the `BaseState` of a specific widget.
     ///
     /// During testing, you may wish to verify that the state of a widget

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -151,7 +151,7 @@ pub use command::{sys as commands, Command, Selector, Target};
 pub use contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, Region, UpdateCtx};
 pub use data::Data;
 pub use env::{Env, Key, KeyOrValue, Value, ValueType};
-pub use event::{Event, LifeCycle, WheelEvent};
+pub use event::{Event, InternalEvent, InternalLifeCycle, LifeCycle, WheelEvent};
 pub use ext_event::{ExtEventError, ExtEventSink};
 pub use lens::{Lens, LensExt, LensWrap};
 pub use localization::LocalizedString;

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -122,7 +122,10 @@ impl<T: Data> Harness<'_, T> {
     pub(crate) fn try_get_state(&mut self, widget: WidgetId) -> Option<BaseState> {
         let cell = StateCell::default();
         let state_cell = cell.clone();
-        self.lifecycle(LifeCycle::DebugRequestState { widget, state_cell });
+        self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugRequestState {
+            widget,
+            state_cell,
+        }));
         cell.take()
     }
 
@@ -131,13 +134,15 @@ impl<T: Data> Harness<'_, T> {
     /// The provided closure will be called on each widget.
     pub(crate) fn inspect_state(&mut self, f: impl Fn(&BaseState) + 'static) {
         let checkfn = StateCheckFn::new(f);
-        self.lifecycle(LifeCycle::DebugInspectState(checkfn))
+        self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugInspectState(
+            checkfn,
+        )))
     }
 
     /// Send a command to a target.
     pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
         let target = target.into().unwrap_or_else(|| self.inner.window.id.into());
-        let event = Event::TargetedCommand(target, cmd.into());
+        let event = Event::Internal(InternalEvent::TargetedCommand(target, cmd.into()));
         self.event(event);
     }
 
@@ -145,7 +150,7 @@ impl<T: Data> Harness<'_, T> {
     // should we do this automatically? Also these will change regularly?
     pub fn send_initial_events(&mut self) {
         self.event(Event::WindowConnected);
-        self.event(Event::Size(self.window_size));
+        self.event(Event::Internal(InternalEvent::Size(self.window_size)));
     }
 
     /// Send an event to the widget.
@@ -164,7 +169,9 @@ impl<T: Data> Harness<'_, T> {
         loop {
             let cmd = self.inner.cmds.pop_front();
             match cmd {
-                Some((target, cmd)) => self.event(Event::TargetedCommand(target, cmd)),
+                Some((target, cmd)) => {
+                    self.event(Event::Internal(InternalEvent::TargetedCommand(target, cmd)))
+                }
                 None => break,
             }
         }

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -150,7 +150,7 @@ impl<T: Data> Harness<'_, T> {
     // should we do this automatically? Also these will change regularly?
     pub fn send_initial_events(&mut self) {
         self.event(Event::WindowConnected);
-        self.event(Event::Internal(InternalEvent::Size(self.window_size)));
+        self.event(Event::WindowSize(self.window_size));
     }
 
     /// Send an event to the widget.

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -275,8 +275,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         let should_record = match event {
-            LifeCycle::DebugRequestState { .. } => false,
-            LifeCycle::DebugInspectState(_) => false,
+            LifeCycle::Internal(InternalLifeCycle::DebugRequestState { .. }) => false,
+            LifeCycle::Internal(InternalLifeCycle::DebugInspectState(_)) => false,
             _ => true,
         };
 

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -181,7 +181,10 @@ fn simple_lifecyle() {
         harness.send_initial_events();
         assert_matches!(record.next(), Record::L(LifeCycle::WidgetAdded));
         assert_matches!(record.next(), Record::E(Event::WindowConnected));
-        assert_matches!(record.next(), Record::E(Event::Size(_)));
+        assert_matches!(
+            record.next(),
+            Record::E(Event::Internal(InternalEvent::Size(_)))
+        );
         assert!(record.is_empty());
     })
 }

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -181,10 +181,7 @@ fn simple_lifecyle() {
         harness.send_initial_events();
         assert_matches!(record.next(), Record::L(LifeCycle::WidgetAdded));
         assert_matches!(record.next(), Record::E(Event::WindowConnected));
-        assert_matches!(
-            record.next(),
-            Record::E(Event::Internal(InternalEvent::Size(_)))
-        );
+        assert_matches!(record.next(), Record::E(Event::WindowSize(_)));
         assert!(record.is_empty());
     })
 }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -388,8 +388,6 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                         self.reset_scrollbar_fade(ctx, &env);
                     }
                 }
-                // Show the scrollbars any time our size changes
-                Event::Size(_) => self.reset_scrollbar_fade(ctx, &env),
                 Event::Timer(id) if *id == self.scrollbars.timer_id => {
                     // Schedule scroll bars animation
                     ctx.request_anim_frame();

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -616,10 +616,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
     }
 
     fn size(&mut self, width: u32, height: u32) {
-        let event = Event::Internal(InternalEvent::Size(Size::new(
-            f64::from(width),
-            f64::from(height),
-        )));
+        let event = Event::WindowSize(Size::new(f64::from(width), f64::from(height)));
         self.app_state.do_window_event(event, self.window_id);
     }
 

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -31,8 +31,8 @@ use crate::ext_event::ExtEventHost;
 use crate::menu::ContextMenu;
 use crate::window::Window;
 use crate::{
-    Command, Data, Env, Event, KeyEvent, KeyModifiers, MenuDesc, Target, TimerToken, WheelEvent,
-    WindowDesc, WindowId,
+    Command, Data, Env, Event, InternalEvent, KeyEvent, KeyModifiers, MenuDesc, Target, TimerToken,
+    WheelEvent, WindowDesc, WindowId,
 };
 
 use crate::command::sys as sys_cmd;
@@ -300,7 +300,8 @@ impl<T: Data> Inner<T> {
             // this widget, breaking if the event is handled.
             Target::Widget(id) => {
                 for w in self.windows.iter_mut().filter(|w| w.may_contain_widget(id)) {
-                    let event = Event::TargetedCommand(id.into(), cmd.clone());
+                    let event =
+                        Event::Internal(InternalEvent::TargetedCommand(id.into(), cmd.clone()));
                     if w.event(&mut self.command_queue, event, &mut self.data, &self.env) {
                         break;
                     }
@@ -319,7 +320,7 @@ impl<T: Data> Inner<T> {
 
     fn do_window_event(&mut self, source_id: WindowId, event: Event) -> bool {
         match event {
-            Event::Command(..) | Event::TargetedCommand(..) => {
+            Event::Command(..) | Event::Internal(InternalEvent::TargetedCommand(..)) => {
                 panic!("commands should be dispatched via dispatch_cmd");
             }
             _ => (),
@@ -615,7 +616,10 @@ impl<T: Data> WinHandler for DruidHandler<T> {
     }
 
     fn size(&mut self, width: u32, height: u32) {
-        let event = Event::Size(Size::new(f64::from(width), f64::from(height)));
+        let event = Event::Internal(InternalEvent::Size(Size::new(
+            f64::from(width),
+            f64::from(height),
+        )));
         self.app_state.do_window_event(event, self.window_id);
     }
 
@@ -641,7 +645,7 @@ impl<T: Data> WinHandler for DruidHandler<T> {
 
     fn mouse_leave(&mut self) {
         self.app_state
-            .do_window_event(Event::MouseLeave, self.window_id);
+            .do_window_event(Event::Internal(InternalEvent::MouseLeave), self.window_id);
     }
 
     fn key_down(&mut self, event: KeyEvent) -> bool {

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -24,8 +24,9 @@ use crate::shell::{Counter, Cursor, WindowHandle};
 use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
-    BoxConstraints, Command, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
-    LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget, WidgetId, WidgetPod, WindowDesc,
+    BoxConstraints, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
+    LayoutCtx, LifeCycle, LifeCycleCtx, LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget,
+    WidgetId, WidgetPod, WindowDesc,
 };
 
 /// A unique identifier for a window.
@@ -120,17 +121,22 @@ impl<T: Data> Window<T> {
         };
 
         let event = match event {
-            Event::Size(size) => {
+            Event::Internal(InternalEvent::Size(size)) => {
                 let dpi = f64::from(self.handle.get_dpi());
                 let scale = 96.0 / dpi;
                 self.size = Size::new(size.width * scale, size.height * scale);
-                Event::Size(self.size)
+                Event::Internal(InternalEvent::Size(self.size))
             }
             other => other,
         };
 
         if let Event::WindowConnected = event {
-            self.lifecycle(queue, &LifeCycle::RouteWidgetAdded, data, env);
+            self.lifecycle(
+                queue,
+                &LifeCycle::Internal(InternalLifeCycle::RouteWidgetAdded),
+                data,
+                env,
+            );
         }
 
         let mut base_state = BaseState::new(self.root.id());
@@ -154,7 +160,7 @@ impl<T: Data> Window<T> {
         if let Some(focus_req) = base_state.request_focus.take() {
             let old = self.focus;
             let new = self.widget_for_focus_request(focus_req);
-            let event = LifeCycle::RouteFocusChanged { old, new };
+            let event = LifeCycle::Internal(InternalLifeCycle::RouteFocusChanged { old, new });
             self.lifecycle(queue, &event, data, env);
             self.focus = new;
         }
@@ -166,7 +172,12 @@ impl<T: Data> Window<T> {
         // If children are changed during the handling of an event,
         // we need to send RouteWidgetAdded now, so that they are ready for update/layout.
         if base_state.children_changed {
-            self.lifecycle(queue, &LifeCycle::RouteWidgetAdded, data, env);
+            self.lifecycle(
+                queue,
+                &LifeCycle::Internal(InternalLifeCycle::RouteWidgetAdded),
+                data,
+                env,
+            );
         }
 
         is_handled
@@ -230,7 +241,12 @@ impl<T: Data> Window<T> {
         env: &Env,
     ) {
         if self.root.state().children_changed {
-            self.lifecycle(queue, &LifeCycle::RouteWidgetAdded, data, env);
+            self.lifecycle(
+                queue,
+                &LifeCycle::Internal(InternalLifeCycle::RouteWidgetAdded),
+                data,
+                env,
+            );
         }
         if self.root.state().needs_inval {
             self.handle.invalidate();

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -24,9 +24,9 @@ use crate::shell::{Counter, Cursor, WindowHandle};
 use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
-    BoxConstraints, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
-    LayoutCtx, LifeCycle, LifeCycleCtx, LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget,
-    WidgetId, WidgetPod, WindowDesc,
+    BoxConstraints, Command, Data, Env, Event, EventCtx, InternalLifeCycle, LayoutCtx, LifeCycle,
+    LifeCycleCtx, LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget, WidgetId, WidgetPod,
+    WindowDesc,
 };
 
 /// A unique identifier for a window.
@@ -121,11 +121,11 @@ impl<T: Data> Window<T> {
         };
 
         let event = match event {
-            Event::Internal(InternalEvent::Size(size)) => {
+            Event::WindowSize(size) => {
                 let dpi = f64::from(self.handle.get_dpi());
                 let scale = 96.0 / dpi;
                 self.size = Size::new(size.width * scale, size.height * scale);
-                Event::Internal(InternalEvent::Size(self.size))
+                Event::WindowSize(self.size)
             }
             other => other,
         };


### PR DESCRIPTION
As discussed in #826 this PR does the following:
* Moves all internal `Event` variants into a `InternalEvent` enum and adds the `Event::Internal(InternalEvent)` variant.
* Moves all internal `LifeCycle` variants into a `InternalLifeCycle` enum and adds the `LifeCycle::Internal(InternalLifeCycle)` variant.

Closes #826