### PR TITLE
Ignore nested events in GTK shell

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -44,7 +44,6 @@ use crate::keyboard;
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 use crate::Error;
-use log::{info, warn};
 
 /// Taken from https://gtk-rs.org/docs-src/tutorial/closures
 /// It is used to reduce the boilerplate of setting up gtk callbacks
@@ -272,7 +271,7 @@ impl WindowBuilder {
                         widget.queue_draw();
                     }
                 } else {
-                    warn!("Drawing was skipped because the handler was already borrowed");
+                    log::warn!("Drawing was skipped because the handler was already borrowed");
                 }
 
             }
@@ -292,7 +291,7 @@ impl WindowBuilder {
                         },
                     );
                 } else {
-                    info!("GTK event was dropped because the handler was already borrowed");
+                    log::info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -311,7 +310,7 @@ impl WindowBuilder {
                         },
                     );
                 } else {
-                    info!("GTK event was dropped because the handler was already borrowed");
+                    log::info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -332,7 +331,7 @@ impl WindowBuilder {
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
                     handler.mouse_move(&mouse_event);
                 } else {
-                    info!("GTK event was dropped because the handler was already borrowed");
+                    log::info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -353,7 +352,7 @@ impl WindowBuilder {
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
                     handler.mouse_move(&mouse_event);
                 } else {
-                    info!("GTK event was dropped because the handler was already borrowed");
+                    log::info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -408,7 +407,7 @@ impl WindowBuilder {
                         }
                     }
                 } else {
-                    info!("GTK event was dropped because the handler was already borrowed");
+                    log::info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -426,7 +425,7 @@ impl WindowBuilder {
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
                     handler.key_down(make_key_event(key, repeat));
                 } else {
-                    info!("GTK event was dropped because the handler was already borrowed");
+                    log::info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -439,9 +438,9 @@ impl WindowBuilder {
                 *(state.current_keyval.borrow_mut()) = None;
 
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
-                    handler.key_down(make_key_event(key, false));
+                    handler.key_up(make_key_event(key, false));
                 } else {
-                    info!("GTK event was dropped because the handler was already borrowed");
+                    log::info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -499,7 +498,7 @@ impl WindowHandle {
     /// Bring this window to the front of the window stack and give it focus.
     pub fn bring_to_front_and_focus(&self) {
         //FIXME: implementation goes here
-        warn!("bring_to_front_and_focus not yet implemented for gtk");
+        log::warn!("bring_to_front_and_focus not yet implemented for gtk");
     }
 
     // Request invalidation of the entire window contents.
@@ -521,7 +520,7 @@ impl WindowHandle {
         let interval = match u32::try_from(interval) {
             Ok(iv) => iv,
             Err(_) => {
-                warn!("timer duration exceeds gtk max of 2^32 millis");
+                log::warn!("timer duration exceeds gtk max of 2^32 millis");
                 u32::max_value()
             }
         };

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -44,6 +44,7 @@ use crate::keyboard;
 use crate::mouse::{Cursor, MouseButton, MouseEvent};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 use crate::Error;
+use log::{info, warn};
 
 /// Taken from https://gtk-rs.org/docs-src/tutorial/closures
 /// It is used to reduce the boilerplate of setting up gtk callbacks
@@ -270,6 +271,8 @@ impl WindowBuilder {
                     if anim {
                         widget.queue_draw();
                     }
+                } else {
+                    warn!("Drawing was skipped because the handler was already borrowed");
                 }
 
             }
@@ -288,6 +291,8 @@ impl WindowBuilder {
                             button: get_mouse_button(button.get_button()),
                         },
                     );
+                } else {
+                    info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -305,6 +310,8 @@ impl WindowBuilder {
                             button: get_mouse_button(button.get_button()),
                         },
                     );
+                } else {
+                    info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -324,6 +331,8 @@ impl WindowBuilder {
 
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
                     handler.mouse_move(&mouse_event);
+                } else {
+                    info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -343,6 +352,8 @@ impl WindowBuilder {
 
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
                     handler.mouse_move(&mouse_event);
+                } else {
+                    info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -396,6 +407,8 @@ impl WindowBuilder {
                             );
                         }
                     }
+                } else {
+                    info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -412,6 +425,8 @@ impl WindowBuilder {
 
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
                     handler.key_down(make_key_event(key, repeat));
+                } else {
+                    info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -425,6 +440,8 @@ impl WindowBuilder {
 
                 if let Ok(mut handler) = state.handler.try_borrow_mut() {
                     handler.key_down(make_key_event(key, false));
+                } else {
+                    info!("GTK event was dropped because the handler was already borrowed");
                 }
             }
 
@@ -482,7 +499,7 @@ impl WindowHandle {
     /// Bring this window to the front of the window stack and give it focus.
     pub fn bring_to_front_and_focus(&self) {
         //FIXME: implementation goes here
-        log::warn!("bring_to_front_and_focus not yet implemented for gtk");
+        warn!("bring_to_front_and_focus not yet implemented for gtk");
     }
 
     // Request invalidation of the entire window contents.
@@ -504,7 +521,7 @@ impl WindowHandle {
         let interval = match u32::try_from(interval) {
             Ok(iv) => iv,
             Err(_) => {
-                log::warn!("timer duration exceeds gtk max of 2^32 millis");
+                warn!("timer duration exceeds gtk max of 2^32 millis");
                 u32::max_value()
             }
         };


### PR DESCRIPTION
Now the GTK shell uses `Mutex::try_borrow_mut` and thus ignores nested events. 

This Closes #735 and Closes #571 