### PR TITLE
Fix .with_child Error in the docs

### DIFF
--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -44,15 +44,15 @@ To see how this works we will divide our window in four. We'll have two rows and
 ```rust, noplaypen
 fn build_ui() -> impl Widget<()> {
     Flex::row()
-        .with_child(
+        .with_flex_child(
             Flex::column()
-                .with_child(Label::new("top left"), 1.0)
-                .with_child(Label::new("bottom left"), 1.0),
+                .with_flex_child(Label::new("top left"), 1.0)
+                .with_flex_child(Label::new("bottom left"), 1.0),
             1.0)
-        .with_child(
+        .with_flex_child(
             Flex::column()
-                .with_child(Label::new("top right"), 1.0)
-                .with_child(Label::new("bottom right"), 1.0),
+                .with_flex_child(Label::new("top right"), 1.0)
+                .with_flex_child(Label::new("bottom right"), 1.0),
             1.0)
 }
 ```
@@ -66,15 +66,15 @@ fn build_ui() -> impl Widget<()> {
     Padding::new(
         10.0,
         Flex::row()
-            .with_child(
+            .with_flex_child(
                 Flex::column()
-                    .with_child(Label::new("top left"), 1.0)
-                    .with_child(Align::centered(Label::new("bottom left")), 1.0),
+                    .with_flex_child(Label::new("top left"), 1.0)
+                    .with_flex_child(Align::centered(Label::new("bottom left")), 1.0),
                 1.0)
             .with_child(
                 Flex::column()
-                    .with_child(Label::new("top right"), 1.0)
-                    .with_child(Align::centered(Label::new("bottom right")), 1.0),
+                    .with_flex_child(Label::new("top right"), 1.0)
+                    .with_flex_child(Align::centered(Label::new("bottom right")), 1.0),
                 1.0))
 }
 ```


### PR DESCRIPTION
It appears that the .with_child method has changed to no longer accept a parameter.
As is I get an error "this function takes 1 parameter but 2 parameters were supplied"

I found the .with_flex_child method that works as a drop in replacement and works with the tutorial. 

It might be preferred to use .with_child in the tutorial and get rid of the size parameter, for the sake of simplicity. But it looks like that uses a default size of 0.0 which seems to result in different behavior, so I went with .with_flex_child