### PR TITLE
Keep hot state consistent with mouse position.

### DIFF
--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -111,9 +111,9 @@ impl Widget<u32> for SimpleBox {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &u32, env: &Env) {
         let mut background = if ctx.is_hot() {
-            BackgroundBrush::Color(Color::rgb(255, 0, 0))
+            BackgroundBrush::Color(Color::rgb8(200, 55, 55))
         } else {
-            BackgroundBrush::Color(Color::rgb(0, 255, 255))
+            BackgroundBrush::Color(Color::rgb8(30, 210, 170))
         };
         background.paint(ctx, data, env);
     }

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -16,63 +16,117 @@
 
 use std::time::{Duration, Instant};
 
-use druid::kurbo::Line;
 use druid::widget::prelude::*;
-use druid::{AppLauncher, Color, LocalizedString, TimerToken, WindowDesc};
+use druid::widget::BackgroundBrush;
+use druid::{AppLauncher, Color, LocalizedString, Point, Rect, TimerToken, WidgetPod, WindowDesc};
+
+static TIMER_INTERVAL: u64 = 10;
 
 struct TimerWidget {
     timer_id: TimerToken,
-    on: bool,
+    simple_box: WidgetPod<u32, SimpleBox>,
+    pos: Point,
+}
+
+impl TimerWidget {
+    /// Move the box towards the right, until it reaches the edge,
+    /// then reset it to the left but move it to another row.
+    fn adjust_box_pos(&mut self, container_size: Size) {
+        let box_size = self.simple_box.layout_rect().size();
+        self.pos.x += 2.;
+        if self.pos.x + box_size.width > container_size.width {
+            self.pos.x = 0.;
+            self.pos.y += box_size.height;
+            if self.pos.y + box_size.height > container_size.height {
+                self.pos.y = 0.;
+            }
+        }
+    }
 }
 
 impl Widget<u32> for TimerWidget {
-    fn event(&mut self, ctx: &mut EventCtx, event: &Event, _data: &mut u32, _env: &Env) {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut u32, env: &Env) {
         match event {
-            Event::MouseDown(_) => {
-                self.on = !self.on;
-                ctx.request_paint();
-                let deadline = Instant::now() + Duration::from_millis(500);
+            Event::WindowConnected => {
+                // Start the timer when the application launches
+                let deadline = Instant::now() + Duration::from_millis(TIMER_INTERVAL);
                 self.timer_id = ctx.request_timer(deadline);
             }
             Event::Timer(id) => {
                 if *id == self.timer_id {
-                    self.on = !self.on;
-                    ctx.request_paint();
-                    let deadline = Instant::now() + Duration::from_millis(500);
+                    self.adjust_box_pos(ctx.size());
+                    ctx.request_layout();
+                    let deadline = Instant::now() + Duration::from_millis(TIMER_INTERVAL);
                     self.timer_id = ctx.request_timer(deadline);
                 }
             }
             _ => (),
         }
+        self.simple_box.event(ctx, event, data, env);
     }
 
-    fn lifecycle(&mut self, _ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {}
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &u32, env: &Env) {
+        self.simple_box.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, _old_data: &u32, data: &u32, env: &Env) {
+        self.simple_box.update(ctx, data, env);
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &u32, env: &Env) -> Size {
+        let size = self.simple_box.layout(ctx, &bc.loosen(), data, env);
+        let rect = Rect::from_origin_size(self.pos, size);
+        self.simple_box.set_layout_rect(ctx, data, env, rect);
+        bc.constrain((500.0, 500.0))
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &u32, env: &Env) {
+        self.simple_box.paint_with_offset(ctx, data, env);
+    }
+}
+
+struct SimpleBox;
+
+impl Widget<u32> for SimpleBox {
+    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut u32, _env: &Env) {}
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {
+        match _event {
+            LifeCycle::HotChanged(_) => ctx.request_paint(),
+            _ => (),
+        }
+    }
 
     fn update(&mut self, _ctx: &mut UpdateCtx, _old_data: &u32, _data: &u32, _env: &Env) {}
 
     fn layout(
         &mut self,
-        _layout_ctx: &mut LayoutCtx,
+        _ctx: &mut LayoutCtx,
         bc: &BoxConstraints,
         _data: &u32,
         _env: &Env,
     ) -> Size {
-        bc.constrain((100.0, 100.0))
+        bc.constrain((50.0, 50.0))
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx, _data: &u32, _env: &Env) {
-        if self.on {
-            ctx.stroke(Line::new((10.0, 10.0), (10.0, 50.0)), &Color::WHITE, 1.0);
-        }
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &u32, env: &Env) {
+        let mut background = if ctx.is_hot() {
+            BackgroundBrush::Color(Color::rgb(255, 0, 0))
+        } else {
+            BackgroundBrush::Color(Color::rgb(0, 255, 255))
+        };
+        background.paint(ctx, data, env);
     }
 }
 
 fn main() {
     let window = WindowDesc::new(|| TimerWidget {
         timer_id: TimerToken::INVALID,
-        on: false,
+        simple_box: WidgetPod::new(SimpleBox),
+        pos: Point::ZERO,
     })
-    .title(LocalizedString::new("timer-demo-window-title").with_placeholder("Tick Tock"));
+    .with_min_size((200., 200.))
+    .title(LocalizedString::new("timer-demo-window-title").with_placeholder("Look at it go!"));
 
     AppLauncher::with_window(window)
         .use_simple_logger()

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -23,8 +23,8 @@ use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::piet::Piet;
 use crate::piet::RenderContext;
 use crate::{
-    Affine, Command, Cursor, Insets, Rect, Size, Target, Text, TimerToken, WidgetId, WindowHandle,
-    WindowId,
+    Affine, Command, Cursor, Insets, Point, Rect, Size, Target, Text, TimerToken, WidgetId,
+    WindowHandle, WindowId,
 };
 
 /// A mutable context provided to event handling methods of widgets.
@@ -85,9 +85,11 @@ pub struct UpdateCtx<'a> {
 /// creating text layout objects, which are likely to be useful
 /// during widget layout.
 pub struct LayoutCtx<'a, 'b: 'a> {
+    pub(crate) command_queue: &'a mut CommandQueue,
+    pub(crate) base_state: &'a mut BaseState,
     pub(crate) text_factory: &'a mut Text<'b>,
-    pub(crate) paint_insets: Insets,
     pub(crate) window_id: WindowId,
+    pub(crate) mouse_pos: Option<Point>,
 }
 
 /// Z-order paint operations with transformations.
@@ -551,7 +553,7 @@ impl<'a, 'b> LayoutCtx<'a, 'b> {
     /// [`Insets`]: struct.Insets.html
     /// [`WidgetPod::paint_insets`]: struct.WidgetPod.html#method.paint_insets
     pub fn set_paint_insets(&mut self, insets: impl Into<Insets>) {
-        self.paint_insets = insets.into().nonnegative();
+        self.base_state.paint_insets = insets.into().nonnegative();
     }
 }
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -43,7 +43,6 @@ pub struct EventCtx<'a> {
     pub(crate) window: &'a WindowHandle,
     pub(crate) base_state: &'a mut BaseState,
     pub(crate) focus_widget: Option<WidgetId>,
-    pub(crate) had_active: bool,
     pub(crate) is_handled: bool,
     pub(crate) is_root: bool,
 }
@@ -387,14 +386,6 @@ impl<'a> EventCtx<'a> {
     /// get the `WidgetId` of the current widget.
     pub fn widget_id(&self) -> WidgetId {
         self.base_state.id
-    }
-
-    pub(crate) fn make_lifecycle_ctx(&mut self) -> LifeCycleCtx {
-        LifeCycleCtx {
-            command_queue: self.command_queue,
-            base_state: self.base_state,
-            window_id: self.window_id,
-        }
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -198,7 +198,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
                 window_id: ctx.window_id,
             };
             self.inner
-                .lifecycle(&mut child_ctx, &hot_changed_event, data, &env);
+                .lifecycle(&mut child_ctx, &hot_changed_event, data, env);
             ctx.base_state.merge_up(&child_ctx.base_state);
         }
     }
@@ -285,7 +285,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             base_state: &self.state,
             focus_widget: ctx.focus_widget,
         };
-        self.inner.paint(&mut inner_ctx, data, &env);
+        self.inner.paint(&mut inner_ctx, data, env);
         ctx.z_ops.append(&mut inner_ctx.z_ops);
 
         if env.get(Env::DEBUG_PAINT) {
@@ -330,7 +330,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             let layout_origin = self.layout_rect().origin().to_vec2();
             ctx.transform(Affine::translate(layout_origin));
             let visible = ctx.region().to_rect() - layout_origin;
-            ctx.with_child_ctx(visible, |ctx| self.paint(ctx, data, &env));
+            ctx.with_child_ctx(visible, |ctx| self.paint(ctx, data, env));
         });
     }
 
@@ -360,7 +360,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             text_factory: ctx.text_factory,
             mouse_pos: child_mouse_pos,
         };
-        let size = self.inner.layout(&mut child_ctx, bc, data, &env);
+        let size = self.inner.layout(&mut child_ctx, bc, data, env);
 
         ctx.base_state.merge_up(&child_ctx.base_state);
 
@@ -523,11 +523,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             let hot_changed_event = LifeCycle::HotChanged(is_hot);
             let mut lc_ctx = child_ctx.make_lifecycle_ctx();
             self.inner
-                .lifecycle(&mut lc_ctx, &hot_changed_event, data, &env);
+                .lifecycle(&mut lc_ctx, &hot_changed_event, data, env);
         }
         if recurse {
             child_ctx.base_state.has_active = false;
-            self.inner.event(&mut child_ctx, &child_event, data, &env);
+            self.inner.event(&mut child_ctx, &child_event, data, env);
             child_ctx.base_state.has_active |= child_ctx.base_state.is_active;
         };
 

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -205,15 +205,16 @@ impl<T: Data> Inner<T> {
 
     fn lifecycle(&mut self, event: LifeCycle) {
         self.window
-            .lifecycle(&mut self.cmds, &event, &self.data, &self.env);
+            .lifecycle(&mut self.cmds, &event, &self.data, &self.env, false);
     }
 
     fn update(&mut self) {
-        self.window.update(&self.data, &self.env);
+        self.window.update(&mut self.cmds, &self.data, &self.env);
     }
 
     fn layout(&mut self, piet: &mut Piet) {
-        self.window.just_layout(piet, &self.data, &self.env);
+        self.window
+            .just_layout(piet, &mut self.cmds, &self.data, &self.env);
     }
 
     #[allow(dead_code)]

--- a/druid/src/widget/align.rs
+++ b/druid/src/widget/align.rs
@@ -94,16 +94,10 @@ impl<T: Data> Widget<T> for Align<T> {
         self.child.update(ctx, data, env);
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Align");
 
-        let size = self.child.layout(layout_ctx, &bc.loosen(), data, env);
+        let size = self.child.layout(ctx, &bc.loosen(), data, env);
 
         log_size_warnings(size);
 
@@ -129,10 +123,10 @@ impl<T: Data> Widget<T> for Align<T> {
             .align
             .resolve(Rect::new(0., 0., extra_width, extra_height));
         self.child
-            .set_layout_rect(Rect::from_origin_size(origin, size));
+            .set_layout_rect(ctx, data, env, Rect::from_origin_size(origin, size));
 
         let my_insets = self.child.compute_parent_paint_insets(my_size);
-        layout_ctx.set_paint_insets(my_insets);
+        ctx.set_paint_insets(my_insets);
         my_size
     }
 

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -71,22 +71,20 @@ impl Widget<bool> for Checkbox {
         ctx.request_paint();
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &bool,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &bool, env: &Env) -> Size {
         bc.debug_check("Checkbox");
 
-        let label_size = self.child_label.layout(layout_ctx, &bc, data, env);
+        let label_size = self.child_label.layout(ctx, &bc, data, env);
         let padding = 8.0;
         let label_x_offset = env.get(theme::BASIC_WIDGET_HEIGHT) + padding;
         let origin = Point::new(label_x_offset, 0.0);
 
-        self.child_label
-            .set_layout_rect(Rect::from_origin_size(origin, label_size));
+        self.child_label.set_layout_rect(
+            ctx,
+            data,
+            env,
+            Rect::from_origin_size(origin, label_size),
+        );
 
         bc.constrain(Size::new(
             label_x_offset + label_size.width,

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -122,7 +122,7 @@ impl<T: Data> Widget<T> for Container<T> {
         let size = self.inner.layout(ctx, &child_bc, data, env);
         let origin = Point::new(border_width, border_width);
         self.inner
-            .set_layout_rect(Rect::from_origin_size(origin, size));
+            .set_layout_rect(ctx, data, env, Rect::from_origin_size(origin, size));
 
         let my_size = Size::new(
             size.width + 2.0 * border_width,

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -77,24 +77,26 @@ impl<T: Data> Widget<T> for Either<T> {
         }
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         if self.current {
-            let size = self.true_branch.layout(layout_ctx, bc, data, env);
-            self.true_branch
-                .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
-            layout_ctx.set_paint_insets(self.true_branch.paint_insets());
+            let size = self.true_branch.layout(ctx, bc, data, env);
+            self.true_branch.set_layout_rect(
+                ctx,
+                data,
+                env,
+                Rect::from_origin_size(Point::ORIGIN, size),
+            );
+            ctx.set_paint_insets(self.true_branch.paint_insets());
             size
         } else {
-            let size = self.false_branch.layout(layout_ctx, bc, data, env);
-            self.false_branch
-                .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
-            layout_ctx.set_paint_insets(self.true_branch.paint_insets());
+            let size = self.false_branch.layout(ctx, bc, data, env);
+            self.false_branch.set_layout_rect(
+                ctx,
+                data,
+                env,
+                Rect::from_origin_size(Point::ORIGIN, size),
+            );
+            ctx.set_paint_insets(self.true_branch.paint_insets());
             size
         }
     }

--- a/druid/src/widget/flex.rs
+++ b/druid/src/widget/flex.rs
@@ -560,7 +560,7 @@ impl<T: Data> Widget<T> for Flex<T> {
                 minor = minor.max(self.direction.minor(child_size).expand());
                 // Stash size.
                 let rect = Rect::from_origin_size(Point::ORIGIN, child_size);
-                child.widget.set_layout_rect(rect);
+                child.widget.set_layout_rect(ctx, data, env, rect);
             }
         }
 
@@ -587,7 +587,7 @@ impl<T: Data> Widget<T> for Flex<T> {
                 minor = minor.max(self.direction.minor(child_size).expand());
                 // Stash size.
                 let rect = Rect::from_origin_size(Point::ORIGIN, child_size);
-                child.widget.set_layout_rect(rect);
+                child.widget.set_layout_rect(ctx, data, env, rect);
             }
         }
 
@@ -611,7 +611,9 @@ impl<T: Data> Widget<T> for Flex<T> {
             let align_minor = alignment.align(extra_minor);
             let pos: Point = self.direction.pack(major, align_minor).into();
 
-            child.widget.set_layout_rect(rect.with_origin(pos));
+            child
+                .widget
+                .set_layout_rect(ctx, data, env, rect.with_origin(pos));
             child_paint_rect = child_paint_rect.union(child.widget.paint_rect());
             major += self.direction.major(rect.size()).expand();
             major += spacing.next().unwrap_or(0.);

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -183,13 +183,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
         }
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         let mut width = bc.min().width;
         let mut y = 0.0;
 
@@ -206,9 +200,9 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
                 Size::new(bc.min().width, 0.0),
                 Size::new(bc.max().width, std::f64::INFINITY),
             );
-            let child_size = child.layout(layout_ctx, &child_bc, child_data, env);
+            let child_size = child.layout(ctx, &child_bc, child_data, env);
             let rect = Rect::from_origin_size(Point::new(0.0, y), child_size);
-            child.set_layout_rect(rect);
+            child.set_layout_rect(ctx, child_data, env, rect);
             paint_rect = paint_rect.union(child.paint_rect());
             width = width.max(child_size.width);
             y += child_size.height;
@@ -216,7 +210,7 @@ impl<C: Data, T: ListIter<C>> Widget<T> for List<C> {
 
         let my_size = bc.constrain(Size::new(width, y));
         let insets = paint_rect - Rect::ZERO.with_size(my_size);
-        layout_ctx.set_paint_insets(insets);
+        ctx.set_paint_insets(insets);
         my_size
     }
 

--- a/druid/src/widget/padding.rs
+++ b/druid/src/widget/padding.rs
@@ -85,27 +85,21 @@ impl<T: Data> Widget<T> for Padding<T> {
         self.child.update(ctx, data, env);
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Padding");
 
         let hpad = self.left + self.right;
         let vpad = self.top + self.bottom;
 
         let child_bc = bc.shrink((hpad, vpad));
-        let size = self.child.layout(layout_ctx, &child_bc, data, env);
+        let size = self.child.layout(ctx, &child_bc, data, env);
         let origin = Point::new(self.left, self.top);
         self.child
-            .set_layout_rect(Rect::from_origin_size(origin, size));
+            .set_layout_rect(ctx, data, env, Rect::from_origin_size(origin, size));
 
         let my_size = Size::new(size.width + hpad, size.height + vpad);
         let my_insets = self.child.compute_parent_paint_insets(my_size);
-        layout_ctx.set_paint_insets(my_insets);
+        ctx.set_paint_insets(my_insets);
         my_size
     }
 

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -86,22 +86,20 @@ impl<T: Data + PartialEq> Widget<T> for Radio<T> {
         ctx.request_paint();
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         bc.debug_check("Radio");
 
-        let label_size = self.child_label.layout(layout_ctx, &bc, data, env);
+        let label_size = self.child_label.layout(ctx, &bc, data, env);
         let padding = 5.0;
         let label_x_offset = env.get(theme::BASIC_WIDGET_HEIGHT) + padding;
         let origin = Point::new(label_x_offset, 0.0);
 
-        self.child_label
-            .set_layout_rect(Rect::from_origin_size(origin, label_size));
+        self.child_label.set_layout_rect(
+            ctx,
+            data,
+            env,
+            Rect::from_origin_size(origin, label_size),
+        );
 
         bc.constrain(Size::new(
             label_x_offset + label_size.width,

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -253,7 +253,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
 
         // Vertical bar
         if viewport.height() < self.child_size.height {
-            let bounds = self.calc_vertical_bar_bounds(viewport, &env);
+            let bounds = self.calc_vertical_bar_bounds(viewport, env);
             let rect = RoundedRect::from_rect(bounds, radius);
             ctx.render_ctx.fill(rect, &brush);
             ctx.render_ctx.stroke(rect, &border_brush, edge_width);
@@ -261,7 +261,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
 
         // Horizontal bar
         if viewport.width() < self.child_size.width {
-            let bounds = self.calc_horizontal_bar_bounds(viewport, &env);
+            let bounds = self.calc_horizontal_bar_bounds(viewport, env);
             let rect = RoundedRect::from_rect(bounds, radius);
             ctx.render_ctx.fill(rect, &brush);
             ctx.render_ctx.stroke(rect, &border_brush, edge_width);
@@ -271,7 +271,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     fn point_hits_vertical_bar(&self, viewport: Rect, pos: Point, env: &Env) -> bool {
         if viewport.height() < self.child_size.height {
             // Stretch hitbox to edge of widget
-            let mut bounds = self.calc_vertical_bar_bounds(viewport, &env);
+            let mut bounds = self.calc_vertical_bar_bounds(viewport, env);
             bounds.x1 = self.scroll_offset.x + viewport.width();
             bounds.contains(pos)
         } else {
@@ -282,7 +282,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
     fn point_hits_horizontal_bar(&self, viewport: Rect, pos: Point, env: &Env) -> bool {
         if viewport.width() < self.child_size.width {
             // Stretch hitbox to edge of widget
-            let mut bounds = self.calc_horizontal_bar_bounds(viewport, &env);
+            let mut bounds = self.calc_horizontal_bar_bounds(viewport, env);
             bounds.y1 = self.scroll_offset.y + viewport.height();
             bounds.contains(pos)
         } else {
@@ -299,8 +299,8 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         let scrollbar_is_hovered = match event {
             Event::MouseMove(e) | Event::MouseUp(e) | Event::MouseDown(e) => {
                 let offset_pos = e.pos + self.scroll_offset;
-                self.point_hits_vertical_bar(viewport, offset_pos, &env)
-                    || self.point_hits_horizontal_bar(viewport, offset_pos, &env)
+                self.point_hits_vertical_bar(viewport, offset_pos, env)
+                    || self.point_hits_horizontal_bar(viewport, offset_pos, env)
             }
             _ => false,
         };
@@ -312,14 +312,14 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     match self.scrollbars.held {
                         BarHeldState::Vertical(offset) => {
                             let scale_y = viewport.height() / self.child_size.height;
-                            let bounds = self.calc_vertical_bar_bounds(viewport, &env);
+                            let bounds = self.calc_vertical_bar_bounds(viewport, env);
                             let mouse_y = event.pos.y + self.scroll_offset.y;
                             let delta = mouse_y - bounds.y0 - offset;
                             self.scroll(Vec2::new(0f64, (delta / scale_y).ceil()), size);
                         }
                         BarHeldState::Horizontal(offset) => {
                             let scale_x = viewport.width() / self.child_size.width;
-                            let bounds = self.calc_horizontal_bar_bounds(viewport, &env);
+                            let bounds = self.calc_horizontal_bar_bounds(viewport, env);
                             let mouse_x = event.pos.x + self.scroll_offset.x;
                             let delta = mouse_x - bounds.x0 - offset;
                             self.scroll(Vec2::new((delta / scale_x).ceil(), 0f64), size);
@@ -334,7 +334,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
 
                     if !scrollbar_is_hovered {
                         self.scrollbars.hovered = BarHoveredState::None;
-                        self.reset_scrollbar_fade(ctx, &env);
+                        self.reset_scrollbar_fade(ctx, env);
                     }
                 }
                 _ => (), // other events are a noop
@@ -344,7 +344,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
             match event {
                 Event::MouseMove(event) => {
                     let offset_pos = event.pos + self.scroll_offset;
-                    if self.point_hits_vertical_bar(viewport, offset_pos, &env) {
+                    if self.point_hits_vertical_bar(viewport, offset_pos, env) {
                         self.scrollbars.hovered = BarHoveredState::Vertical;
                     } else {
                         self.scrollbars.hovered = BarHoveredState::Horizontal;
@@ -357,15 +357,15 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 Event::MouseDown(event) => {
                     let pos = event.pos + self.scroll_offset;
 
-                    if self.point_hits_vertical_bar(viewport, pos, &env) {
+                    if self.point_hits_vertical_bar(viewport, pos, env) {
                         ctx.set_active(true);
                         self.scrollbars.held = BarHeldState::Vertical(
-                            pos.y - self.calc_vertical_bar_bounds(viewport, &env).y0,
+                            pos.y - self.calc_vertical_bar_bounds(viewport, env).y0,
                         );
-                    } else if self.point_hits_horizontal_bar(viewport, pos, &env) {
+                    } else if self.point_hits_horizontal_bar(viewport, pos, env) {
                         ctx.set_active(true);
                         self.scrollbars.held = BarHeldState::Horizontal(
-                            pos.x - self.calc_horizontal_bar_bounds(viewport, &env).x0,
+                            pos.x - self.calc_horizontal_bar_bounds(viewport, env).x0,
                         );
                     }
                 }
@@ -385,7 +385,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                     // if we have just stopped hovering
                     if self.scrollbars.hovered.is_hovered() && !scrollbar_is_hovered {
                         self.scrollbars.hovered = BarHoveredState::None;
-                        self.reset_scrollbar_fade(ctx, &env);
+                        self.reset_scrollbar_fade(ctx, env);
                     }
                 }
                 Event::Timer(id) if *id == self.scrollbars.timer_id => {
@@ -402,7 +402,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
                 if self.scroll(wheel.delta, size) {
                     ctx.request_paint();
                     ctx.set_handled();
-                    self.reset_scrollbar_fade(ctx, &env);
+                    self.reset_scrollbar_fade(ctx, env);
                 }
             }
         }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -436,7 +436,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Scroll<T, W> {
         log_size_warnings(size);
 
         self.child_size = size;
-        self.child.set_layout_rect(size.to_rect());
+        self.child.set_layout_rect(ctx, data, env, size.to_rect());
         let self_size = bc.constrain(self.child_size);
         let _ = self.scroll(Vec2::new(0.0, 0.0), self_size);
         self_size

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -427,8 +427,8 @@ impl<T: Data> Widget<T> for Split<T> {
                 )
             }
         };
-        self.child1.set_layout_rect(child1_rect);
-        self.child2.set_layout_rect(child2_rect);
+        self.child1.set_layout_rect(ctx, data, env, child1_rect);
+        self.child2.set_layout_rect(ctx, data, env, child2_rect);
 
         let paint_rect = self.child1.paint_rect().union(self.child2.paint_rect());
         let insets = paint_rect - Rect::ZERO.with_size(my_size);

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -86,17 +86,11 @@ impl<T: Data, U: PartialEq> Widget<T> for ViewSwitcher<T, U> {
         }
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
         match self.active_child {
             Some(ref mut child) => {
-                let size = child.layout(layout_ctx, bc, data, env);
-                child.set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+                let size = child.layout(ctx, bc, data, env);
+                child.set_layout_rect(ctx, data, env, Rect::from_origin_size(Point::ORIGIN, size));
                 size
             }
             None => bc.max(),

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -362,7 +362,7 @@ impl<T: Data> Inner<T> {
     fn do_update(&mut self) {
         // we send `update` to all windows, not just the active one:
         for window in self.windows.iter_mut() {
-            window.update(&self.data, &self.env);
+            window.update(&mut self.command_queue, &self.data, &self.env);
         }
         self.invalidate_and_finalize();
     }
@@ -373,7 +373,7 @@ impl<T: Data> Inner<T> {
     /// including for lifecycle events.
     fn invalidate_and_finalize(&mut self) {
         for win in self.windows.iter_mut() {
-            win.invalidate_and_finalize(&mut self.command_queue, &self.data, &self.env);
+            win.invalidate_and_finalize();
         }
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -149,7 +149,9 @@ impl<T: Data> Window<T> {
         env: &Env,
     ) -> bool {
         match &event {
-            Event::MouseMove(e) => self.last_mouse_pos = Some(e.pos),
+            Event::MouseDown(e) | Event::MouseUp(e) | Event::MouseMove(e) => {
+                self.last_mouse_pos = Some(e.pos)
+            }
             Event::Internal(InternalEvent::MouseLeave) => self.last_mouse_pos = None,
             _ => (),
         }
@@ -187,7 +189,6 @@ impl<T: Data> Window<T> {
                 base_state: &mut base_state,
                 is_handled: false,
                 is_root: true,
-                had_active: self.root.has_active(),
                 window: &self.handle,
                 window_id: self.id,
                 focus_widget: self.focus,

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -17,16 +17,16 @@
 use std::mem;
 use std::time::Instant;
 
-use crate::kurbo::{Insets, Point, Rect, Size};
+use crate::kurbo::{Point, Rect, Size};
 use crate::piet::{Piet, RenderContext};
 use crate::shell::{Counter, Cursor, WindowHandle};
 
 use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
-    BoxConstraints, Command, Data, Env, Event, EventCtx, InternalLifeCycle, LayoutCtx, LifeCycle,
-    LifeCycleCtx, LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget, WidgetId, WidgetPod,
-    WindowDesc,
+    BoxConstraints, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
+    LayoutCtx, LifeCycle, LifeCycleCtx, LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget,
+    WidgetId, WidgetPod, WindowDesc,
 };
 
 /// A unique identifier for a window.
@@ -42,6 +42,7 @@ pub struct Window<T> {
     pub(crate) menu: Option<MenuDesc<T>>,
     pub(crate) context_menu: Option<MenuDesc<T>>,
     pub(crate) last_anim: Option<Instant>,
+    pub(crate) last_mouse_pos: Option<Point>,
     pub(crate) focus: Option<WidgetId>,
     pub(crate) handle: WindowHandle,
     // delegate?
@@ -57,6 +58,7 @@ impl<T> Window<T> {
             menu: desc.menu,
             context_menu: None,
             last_anim: None,
+            last_mouse_pos: None,
             focus: None,
             handle,
         }
@@ -64,7 +66,7 @@ impl<T> Window<T> {
 }
 
 impl<T: Data> Window<T> {
-    /// `true` iff any child requested an animation frame during the last `AnimFrame` event.
+    /// `true` if any child requested an animation frame during the last `AnimFrame` event.
     pub(crate) fn wants_animation_frame(&self) -> bool {
         self.last_anim.is_some()
     }
@@ -108,6 +110,37 @@ impl<T: Data> Window<T> {
         }
     }
 
+    fn post_event_processing(
+        &mut self,
+        queue: &mut CommandQueue,
+        data: &T,
+        env: &Env,
+        process_commands: bool,
+    ) {
+        let base_state = self.root.state();
+        // If children are changed during the handling of an event,
+        // we need to send RouteWidgetAdded now, so that they are ready for update/layout.
+        if base_state.children_changed {
+            self.lifecycle(
+                queue,
+                &LifeCycle::Internal(InternalLifeCycle::RouteWidgetAdded),
+                data,
+                env,
+                false,
+            );
+        }
+        // If there are any commands and they should be processed
+        if process_commands && !queue.is_empty() {
+            // Ask the handler to call us back on idle
+            // so we can process them in a new event/update pass.
+            if let Some(mut handle) = self.handle.get_idle_handle() {
+                handle.schedule_idle(RUN_COMMANDS_TOKEN);
+            } else {
+                log::error!("failed to get idle handle");
+            }
+        }
+    }
+
     pub(crate) fn event(
         &mut self,
         queue: &mut CommandQueue,
@@ -115,6 +148,12 @@ impl<T: Data> Window<T> {
         data: &mut T,
         env: &Env,
     ) -> bool {
+        match &event {
+            Event::MouseMove(e) => self.last_mouse_pos = Some(e.pos),
+            Event::Internal(InternalEvent::MouseLeave) => self.last_mouse_pos = None,
+            _ => (),
+        }
+
         let mut cursor = match event {
             Event::MouseMove(..) => Some(Cursor::Arrow),
             _ => None,
@@ -136,6 +175,7 @@ impl<T: Data> Window<T> {
                 &LifeCycle::Internal(InternalLifeCycle::RouteWidgetAdded),
                 data,
                 env,
+                false,
             );
         }
 
@@ -161,7 +201,7 @@ impl<T: Data> Window<T> {
             let old = self.focus;
             let new = self.widget_for_focus_request(focus_req);
             let event = LifeCycle::Internal(InternalLifeCycle::RouteFocusChanged { old, new });
-            self.lifecycle(queue, &event, data, env);
+            self.lifecycle(queue, &event, data, env, false);
             self.focus = new;
         }
 
@@ -169,16 +209,7 @@ impl<T: Data> Window<T> {
             self.handle.set_cursor(&cursor);
         }
 
-        // If children are changed during the handling of an event,
-        // we need to send RouteWidgetAdded now, so that they are ready for update/layout.
-        if base_state.children_changed {
-            self.lifecycle(
-                queue,
-                &LifeCycle::Internal(InternalLifeCycle::RouteWidgetAdded),
-                data,
-                env,
-            );
-        }
+        self.post_event_processing(queue, data, env, false);
 
         is_handled
     }
@@ -189,6 +220,7 @@ impl<T: Data> Window<T> {
         event: &LifeCycle,
         data: &T,
         env: &Env,
+        process_commands: bool,
     ) {
         let mut base_state = BaseState::new(self.root.id());
         let mut ctx = LifeCycleCtx {
@@ -198,10 +230,12 @@ impl<T: Data> Window<T> {
         };
 
         if let LifeCycle::AnimFrame(_) = event {
-            return self.do_anim_frame(&mut ctx, data, env);
+            self.do_anim_frame(&mut ctx, data, env)
+        } else {
+            self.root.lifecycle(&mut ctx, event, data, env);
         }
 
-        self.root.lifecycle(&mut ctx, event, data, env);
+        self.post_event_processing(queue, data, env, process_commands);
     }
 
     /// AnimFrame has special logic, so we implement it separately.
@@ -221,7 +255,7 @@ impl<T: Data> Window<T> {
         }
     }
 
-    pub(crate) fn update(&mut self, data: &T, env: &Env) {
+    pub(crate) fn update(&mut self, queue: &mut CommandQueue, data: &T, env: &Env) {
         self.update_title(data, env);
 
         let mut base_state = BaseState::new(self.root.id());
@@ -232,22 +266,10 @@ impl<T: Data> Window<T> {
         };
 
         self.root.update(&mut update_ctx, data, env);
+        self.post_event_processing(queue, data, env, false);
     }
 
-    pub(crate) fn invalidate_and_finalize(
-        &mut self,
-        queue: &mut CommandQueue,
-        data: &T,
-        env: &Env,
-    ) {
-        if self.root.state().children_changed {
-            self.lifecycle(
-                queue,
-                &LifeCycle::Internal(InternalLifeCycle::RouteWidgetAdded),
-                data,
-                env,
-            );
-        }
+    pub(crate) fn invalidate_and_finalize(&mut self) {
         if self.root.state().needs_inval {
             self.handle.invalidate();
         }
@@ -263,42 +285,46 @@ impl<T: Data> Window<T> {
         env: &Env,
     ) {
         // FIXME: only do AnimFrame if root has requested_anim?
-        self.lifecycle(queue, &LifeCycle::AnimFrame(0), data, env);
+        self.lifecycle(queue, &LifeCycle::AnimFrame(0), data, env, true);
 
         if self.root.state().needs_layout {
-            self.layout(piet, data, env);
+            self.layout(piet, queue, data, env);
         }
 
         piet.clear(env.get(crate::theme::WINDOW_BACKGROUND_COLOR));
         self.paint(piet, data, env);
-
-        // If commands were submitted during anim frame, ask the handler
-        // to call us back on idle so we can process them in a new event/update pass.
-        if !queue.is_empty() {
-            if let Some(mut handle) = self.handle.get_idle_handle() {
-                handle.schedule_idle(RUN_COMMANDS_TOKEN);
-            } else {
-                log::error!("failed to get idle handle");
-            }
-        }
     }
 
-    fn layout(&mut self, piet: &mut Piet, data: &T, env: &Env) {
+    fn layout(&mut self, piet: &mut Piet, queue: &mut CommandQueue, data: &T, env: &Env) {
+        let mut base_state = BaseState::new(self.root.id());
         let mut layout_ctx = LayoutCtx {
+            command_queue: queue,
+            base_state: &mut base_state,
             text_factory: piet.text(),
             window_id: self.id,
-            paint_insets: Insets::ZERO,
+            mouse_pos: self.last_mouse_pos,
         };
         let bc = BoxConstraints::tight(self.size);
         let size = self.root.layout(&mut layout_ctx, &bc, data, env);
-        self.root
-            .set_layout_rect(Rect::from_origin_size(Point::ORIGIN, size));
+        self.root.set_layout_rect(
+            &mut layout_ctx,
+            data,
+            env,
+            Rect::from_origin_size(Point::ORIGIN, size),
+        );
+        self.post_event_processing(queue, data, env, true);
     }
 
     /// only expose `layout` for testing; normally it is called as part of `do_paint`
     #[cfg(test)]
-    pub(crate) fn just_layout(&mut self, piet: &mut Piet, data: &T, env: &Env) {
-        self.layout(piet, data, env)
+    pub(crate) fn just_layout(
+        &mut self,
+        piet: &mut Piet,
+        queue: &mut CommandQueue,
+        data: &T,
+        env: &Env,
+    ) {
+        self.layout(piet, queue, data, env)
     }
 
     fn paint(&mut self, piet: &mut Piet, data: &T, env: &Env) {

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -66,7 +66,7 @@ impl<T> Window<T> {
 }
 
 impl<T: Data> Window<T> {
-    /// `true` if any child requested an animation frame during the last `AnimFrame` event.
+    /// `true` iff any child requested an animation frame during the last `AnimFrame` event.
     pub(crate) fn wants_animation_frame(&self) -> bool {
         self.last_anim.is_some()
     }


### PR DESCRIPTION
## Background
The genesis of this PR is a discussion in [zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/significant.20latency.20in.20handling.20mouse.20move) where @kindlychung was having trouble with the hot state acting bizarrely.

In the original example (*code available in zulip, as well as a video of it in action*) there are three basic circles that you can drag around. When you really fling them around they keep flickering between black and white, representing their hot state. The reason is the order of how things are being done in druid.

## How hot state is determined
When a `MouseMove` event gets sent by the platform, with a position that is no longer on top of the circle, then druid acts as follows:
1. Calculates the hot state to be `false` and sends a `LifeCycle::HotChanged(false)` event to the circle widget.
2. Sends the `Event::MouseMove` event based on which the container widget will calculate the new position for the circle widget and request layout.
3. `layout` happens and the circle widget gets a new origin.
4. `paint` happens and the circle gets painted black because the hot state is `false`.

Indeed druid never detects the hot state to be `true` because the hot state calculation happens during `MouseMove`. No more mouse movement is guaranteed, this might have been the last one. Even if there's a new mouse movement, if the mouse is moving fast enough this new `MouseMove` position will be once again too far away for hot to be `true`. In practice the situation seems to vary, which is why the circle flickers.

## Tricky situation
One solution might be to re-send the `MouseMove` event with the same position at the beginning of the next wave of `event/update/paint`. If the `event` isn't flagged for immediate execution then this might take multiple seconds. However even if the new cycle is immediate this will still result in a single frame of incorrect hot state rendering. During a dragging operation like the example above, this will mean a lot of incorrect frames and so at best we've reduced the flickering but not removed it.

## It gets worse
While thinking about this problem I realized another hole in the current system. What if the mouse doesn't move at all? What if the widget moves instead, e.g. with a timer? Well in that case the current system will never apply the hot state to the widget.

## Easy demonstration
I updated the timer example to have a moving box which changes color based on hot state. This example can be used to create the mouse-not-moving challange. Just predict where the box is going to move to next, move your cursor in front of its path, and wait. With this PR the box changes color correctly, with a previous druid version it won't change color.

## Solution
Thus it seemed clear to me that the solution is to keep track of the mouse position and re-calculate hot state and its associated `LifeCycle::HotChanged` events after `layout` but before `paint`.

This approach means zero incorrect hot state frames. Works perfectly if you're really speeding with your mouse or even with the mouse disconnected and the widget moving.

## Details
`LayoutCtx` needs to get fatter, there's no obvious way around it. It's not just about having the mouse position, we also need to have everything required to synthesize the `LifeCycle::HotChanged` event and we need to transport back any `BaseState` changes, especially the hot state changes.

## Breaking change
```rust
// Previously
fn set_layout_rect(&mut self, layout_rect: Rect) {}
// New signature
fn set_layout_rect(&mut self, ctx: &mut LayoutCtx, data: &T, env: &Env, layout_rect: Rect)
```

## Additional changes
* Unified `event/lifecycle/update/layout` post-processing in the window. Previously this was missing for `lifecycle`, although I did find a comment for the `invalidate_and_finalize` method saying it should happen for `lifecycle`.
* Renamed a bunch of legacy `layout_ctx` variables to `ctx`.