### PR TITLE
Capture first mouse event on macOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Window title can be any `LabelText` (such as a simple `String`). ([#869] by [@cmyr])
 - `Label::with_font` and `set_font`. ([#785] by [@thecodewarrior])
 - `InternalEvent::RouteTimer` to route timer events. ([#831] by [@sjoshid])
+- `MouseEvent` now has a `focus` field which is `true` with window focusing left clicks on macOS. ([#842] by [@xStrom])
 - `MouseButtons` to `MouseEvent` to track which buttons are being held down during an event. ([#843] by [@xStrom])
 - `Env` and `Key` gained methods for inspecting an `Env` at runtime ([#880] by [@Zarenor])
 - `UpdateCtx::request_timer` and `UpdateCtx::request_anim_frame`. ([#898] by [@finnerale])
@@ -135,6 +136,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#839]: https://github.com/xi-editor/druid/pull/839
 [#840]: https://github.com/xi-editor/druid/pull/840
 [#841]: https://github.com/xi-editor/druid/pull/841
+[#842]: https://github.com/xi-editor/druid/pull/842
 [#843]: https://github.com/xi-editor/druid/pull/843
 [#845]: https://github.com/xi-editor/druid/pull/845
 [#847]: https://github.com/xi-editor/druid/pull/847

--- a/druid-shell/src/mouse.rs
+++ b/druid-shell/src/mouse.rs
@@ -34,6 +34,9 @@ pub struct MouseEvent {
     /// The number of mouse clicks associated with this event. This will always
     /// be `0` for a mouse-up and mouse-move events.
     pub count: u8,
+    /// Focus is `true` on macOS when the mouse-down event (or its companion mouse-up event)
+    /// with `MouseButton::Left` was the event that caused the window to gain focus.
+    pub focus: bool,
     /// The button that was pressed down in the case of mouse-down,
     /// or the button that was released in the case of mouse-up.
     /// This will always be `MouseButton::None` in the case of mouse-move.

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -416,12 +416,13 @@ impl WindowBuilder {
                         }
                     };
 
-                    if let Some(wheel_delta) = wheel_delta{
-                        let mouse_event = MouseEvent{
+                    if let Some(wheel_delta) = wheel_delta {
+                        let mouse_event = MouseEvent {
                             pos: Point::from(scroll.get_position()),
                             buttons: get_mouse_buttons_from_modifiers(scroll.get_state()),
                             mods,
                             count: 0,
+                            focus: false,
                             button: MouseButton::None,
                             wheel_delta
                         };

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -296,6 +296,7 @@ impl WindowBuilder {
                                 buttons: get_mouse_buttons_from_modifiers(button_state).with(button),
                                 mods: get_modifiers(button_state),
                                 count: get_mouse_click_count(event.get_event_type()),
+                                focus: false,
                                 button,
                                 wheel_delta: Vec2::ZERO
                             },
@@ -320,6 +321,7 @@ impl WindowBuilder {
                                 buttons: get_mouse_buttons_from_modifiers(button_state).without(button),
                                 mods: get_modifiers(button_state),
                                 count: 0,
+                                focus: false,
                                 button,
                                 wheel_delta: Vec2::ZERO
                             },
@@ -341,6 +343,7 @@ impl WindowBuilder {
                     buttons: get_mouse_buttons_from_modifiers(motion_state),
                     mods: get_modifiers(motion_state),
                     count: 0,
+                    focus: false,
                     button: MouseButton::None,
                     wheel_delta: Vec2::ZERO
                 };
@@ -363,6 +366,7 @@ impl WindowBuilder {
                     buttons: get_mouse_buttons_from_modifiers(crossing_state),
                     mods: get_modifiers(crossing_state),
                     count: 0,
+                    focus: false,
                     button: MouseButton::None,
                     wheel_delta: Vec2::ZERO
                 };

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -232,6 +232,13 @@ lazy_static! {
         extern "C" fn acceptsFirstResponder(_this: &Object, _sel: Sel) -> BOOL {
             YES
         }
+        decl.add_method(
+            sel!(acceptsFirstMouse:),
+            acceptsFirstMouse as extern "C" fn(&Object, Sel, id) -> BOOL,
+        );
+        extern "C" fn acceptsFirstMouse(_this: &Object, _sel: Sel, _nsevent: id) -> BOOL {
+            YES
+        }
         decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
         extern "C" fn dealloc(this: &Object, _sel: Sel) {
             info!("view is dealloc'ed");

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -514,7 +514,14 @@ extern "C" fn scroll_wheel(this: &mut Object, _: Sel, nsevent: id) {
             }
         };
 
-        let event = mouse_event(nsevent, this as id, 0, MouseButton::None, Vec2::new(dx, dy));
+        let event = mouse_event(
+            nsevent,
+            this as id,
+            0,
+            false,
+            MouseButton::None,
+            Vec2::new(dx, dy),
+        );
         (*view_state).handler.wheel(&event);
     }
 }

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -104,6 +104,8 @@ struct ViewState {
     handler: Box<dyn WinHandler>,
     idle_queue: Arc<Mutex<Vec<IdleKind>>>,
     last_mods: KeyModifiers,
+    /// Tracks window focusing left clicks
+    focus_click: bool,
 }
 
 impl WindowBuilder {
@@ -232,11 +234,17 @@ lazy_static! {
         extern "C" fn acceptsFirstResponder(_this: &Object, _sel: Sel) -> BOOL {
             YES
         }
+        // acceptsFirstMouse is called when a left mouse click would focus the window
         decl.add_method(
             sel!(acceptsFirstMouse:),
             acceptsFirstMouse as extern "C" fn(&Object, Sel, id) -> BOOL,
         );
-        extern "C" fn acceptsFirstMouse(_this: &Object, _sel: Sel, _nsevent: id) -> BOOL {
+        extern "C" fn acceptsFirstMouse(this: &Object, _sel: Sel, _nsevent: id) -> BOOL {
+            unsafe {
+                let view_state: *mut c_void = *this.get_ivar("viewState");
+                let view_state = &mut *(view_state as *mut ViewState);
+                view_state.focus_click = true;
+            }
             YES
         }
         decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
@@ -346,6 +354,7 @@ fn make_view(handler: Box<dyn WinHandler>) -> (id, Weak<Mutex<Vec<IdleKind>>>) {
             handler,
             idle_queue,
             last_mods: KeyModifiers::default(),
+            focus_click: false,
         };
         let state_ptr = Box::into_raw(Box::new(state));
         (*view).set_ivar("viewState", state_ptr as *mut c_void);
@@ -371,6 +380,7 @@ fn mouse_event(
     nsevent: id,
     view: id,
     count: u8,
+    focus: bool,
     button: MouseButton,
     wheel_delta: Vec2,
 ) -> MouseEvent {
@@ -385,6 +395,7 @@ fn mouse_event(
             buttons,
             mods: modifiers,
             count,
+            focus,
             button,
             wheel_delta,
         }
@@ -443,7 +454,8 @@ fn mouse_down(this: &mut Object, nsevent: id, button: MouseButton) {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
         let count = nsevent.clickCount() as u8;
-        let event = mouse_event(nsevent, this as id, count, button, Vec2::ZERO);
+        let focus = view_state.focus_click && button == MouseButton::Left;
+        let event = mouse_event(nsevent, this as id, count, focus, button, Vec2::ZERO);
         (*view_state).handler.mouse_down(&event);
     }
 }
@@ -468,7 +480,13 @@ fn mouse_up(this: &mut Object, nsevent: id, button: MouseButton) {
     unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
-        let event = mouse_event(nsevent, this as id, 0, button, Vec2::ZERO);
+        let focus = if view_state.focus_click && button == MouseButton::Left {
+            view_state.focus_click = false;
+            true
+        } else {
+            false
+        };
+        let event = mouse_event(nsevent, this as id, 0, focus, button, Vec2::ZERO);
         (*view_state).handler.mouse_up(&event);
     }
 }
@@ -477,7 +495,7 @@ extern "C" fn mouse_move(this: &mut Object, _: Sel, nsevent: id) {
     unsafe {
         let view_state: *mut c_void = *this.get_ivar("viewState");
         let view_state = &mut *(view_state as *mut ViewState);
-        let event = mouse_event(nsevent, this as id, 0, MouseButton::None, Vec2::ZERO);
+        let event = mouse_event(nsevent, this as id, 0, false, MouseButton::None, Vec2::ZERO);
         (*view_state).handler.mouse_move(&event);
     }
 }

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -147,6 +147,7 @@ fn setup_mouse_down_callback(ws: &Rc<WindowState>) {
                 buttons,
                 mods: get_modifiers!(event),
                 count: 1,
+                focus: false,
                 button,
                 wheel_delta: Vec2::ZERO,
             };
@@ -165,6 +166,7 @@ fn setup_mouse_up_callback(ws: &Rc<WindowState>) {
                 buttons,
                 mods: get_modifiers!(event),
                 count: 0,
+                focus: false,
                 button,
                 wheel_delta: Vec2::ZERO,
             };
@@ -182,6 +184,7 @@ fn setup_mouse_move_callback(ws: &Rc<WindowState>) {
             buttons,
             mods: get_modifiers!(event),
             count: 0,
+            focus: false,
             button: MouseButton::None,
             wheel_delta: Vec2::ZERO,
         };

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -218,6 +218,7 @@ fn setup_scroll_callback(ws: &Rc<WindowState>) {
             buttons: mouse_buttons(event.buttons()),
             mods: get_modifiers!(event),
             count: 0,
+            focus: false,
             button: MouseButton::None,
             wheel_delta,
         };

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -694,11 +694,12 @@ impl WndProc for MyWndProc {
                     let buttons = get_buttons(down_state);
                     let event = MouseEvent {
                         pos,
-                        mods,
-                        button: MouseButton::None,
-                        count: 0,
-                        wheel_delta,
                         buttons,
+                        mods,
+                        count: 0,
+                        focus: false,
+                        button: MouseButton::None,
+                        wheel_delta,
                     };
                     s.handler.wheel(&event);
                 } else {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -749,6 +749,7 @@ impl WndProc for MyWndProc {
                         buttons,
                         mods,
                         count: 0,
+                        focus: false,
                         button: MouseButton::None,
                         wheel_delta: Vec2::ZERO,
                     };
@@ -816,6 +817,7 @@ impl WndProc for MyWndProc {
                             buttons,
                             mods,
                             count,
+                            focus: false,
                             button,
                             wheel_delta: Vec2::ZERO,
                         };

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -565,6 +565,7 @@ impl Window {
                 meta: false,
             },
             count: 1,
+            focus: false,
             button: MouseButton::Left,
             wheel_delta: Vec2::ZERO,
         };
@@ -598,6 +599,7 @@ impl Window {
                 meta: false,
             },
             count: 0,
+            focus: false,
             button: MouseButton::Left,
             wheel_delta: Vec2::ZERO,
         };
@@ -631,6 +633,7 @@ impl Window {
                 meta: false,
             },
             count: 0,
+            focus: false,
             button: MouseButton::None,
             wheel_delta: Vec2::ZERO,
         };

--- a/druid/src/mouse.rs
+++ b/druid/src/mouse.rs
@@ -36,6 +36,15 @@ pub struct MouseEvent {
     /// The number of mouse clicks associated with this event. This will always
     /// be `0` for a mouse-up and mouse-move events.
     pub count: u8,
+    /// Focus is `true` on macOS when the mouse-down event (or its companion mouse-up event)
+    /// with `MouseButton::Left` was the event that caused the window to gain focus.
+    ///
+    /// This is primarily used in relation to text selection.
+    /// If there is some text selected in some text widget and it receives a click
+    /// with `focus` set to `true` then the widget should gain focus (i.e. start blinking a cursor)
+    /// but it should not change the text selection. Text selection should only be changed
+    /// when the click has `focus` set to `false`.
+    pub focus: bool,
     /// The button that was pressed down in the case of mouse-down,
     /// or the button that was released in the case of mouse-up.
     /// This will always be `MouseButton::None` in the case of mouse-move.
@@ -58,6 +67,7 @@ impl From<druid_shell::MouseEvent> for MouseEvent {
             buttons,
             mods,
             count,
+            focus,
             button,
             wheel_delta,
         } = src;
@@ -67,6 +77,7 @@ impl From<druid_shell::MouseEvent> for MouseEvent {
             buttons,
             mods,
             count,
+            focus,
             button,
             wheel_delta,
         }

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -80,6 +80,7 @@ fn propogate_hot() {
             buttons: MouseButtons::default(),
             mods: KeyModifiers::default(),
             count: 0,
+            focus: false,
             button: MouseButton::None,
             wheel_delta: Vec2::ZERO,
         }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -243,12 +243,14 @@ impl Widget<String> for TextBox {
                 ctx.request_focus();
                 ctx.set_active(true);
 
-                let cursor_offset = self.offset_for_point(mouse.pos, &text_layout);
-                edit_action = Some(EditAction::Click(MouseAction {
-                    row: 0,
-                    column: cursor_offset,
-                    mods: mouse.mods,
-                }));
+                if !mouse.focus {
+                    let cursor_offset = self.offset_for_point(mouse.pos, &text_layout);
+                    edit_action = Some(EditAction::Click(MouseAction {
+                        row: 0,
+                        column: cursor_offset,
+                        mods: mouse.mods,
+                    }));
+                }
 
                 ctx.request_paint();
             }


### PR DESCRIPTION
This PR allows druid to receive the first mouse click when the click also makes the druid window active.

When you open the macOS calculator, switch to another app, then click a calculator button it will register the click even though it wasn't active. This does not work with the druid calculator example. With this PRs change applied, the druid calculator will also receive the click event.