### PR TITLE
Add hot glow option to multiwin example.

### DIFF
--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -14,11 +14,11 @@
 
 //! Opening and closing windows and using window and context menus.
 
-use druid::widget::{Align, Button, Flex, Label, Padding};
+use druid::widget::prelude::*;
+use druid::widget::{Align, BackgroundBrush, Button, Flex, Label, Padding};
 use druid::{
-    commands as sys_cmds, AppDelegate, AppLauncher, Command, ContextMenu, Data, DelegateCtx, Env,
-    Event, EventCtx, LocalizedString, MenuDesc, MenuItem, Selector, Target, Widget, WindowDesc,
-    WindowId,
+    commands as sys_cmds, AppDelegate, AppLauncher, Color, Command, ContextMenu, Data, DelegateCtx,
+    LocalizedString, MenuDesc, MenuItem, Selector, Target, WidgetPod, WindowDesc, WindowId,
 };
 
 use log::info;
@@ -26,11 +26,13 @@ use log::info;
 const MENU_COUNT_ACTION: Selector = Selector::new("menu-count-action");
 const MENU_INCREMENT_ACTION: Selector = Selector::new("menu-increment-action");
 const MENU_DECREMENT_ACTION: Selector = Selector::new("menu-decrement-action");
+const MENU_SWITCH_GLOW_ACTION: Selector = Selector::new("menu-switch-glow");
 
 #[derive(Debug, Clone, Default, Data)]
 struct State {
     menu_count: usize,
     selected: usize,
+    glow_hot: bool,
 }
 
 pub fn main() {
@@ -79,7 +81,58 @@ fn ui_builder() -> impl Widget<State> {
     row.add_child(Padding::new(5.0, inc_button));
     row.add_child(Padding::new(5.0, dec_button));
     col.add_flex_child(Align::centered(row), 1.0);
-    col
+    Glow::new(col)
+}
+
+struct Glow<W> {
+    inner: WidgetPod<State, W>,
+}
+
+impl<W: Widget<State>> Glow<W> {
+    pub fn new(inner: W) -> Glow<W> {
+        Glow {
+            inner: WidgetPod::new(inner),
+        }
+    }
+}
+
+impl<W: Widget<State>> Widget<State> for Glow<W> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut State, env: &Env) {
+        self.inner.event(ctx, event, data, env);
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &State, env: &Env) {
+        if let LifeCycle::HotChanged(_) = event {
+            ctx.request_paint();
+        }
+        self.inner.lifecycle(ctx, event, data, env);
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &State, data: &State, env: &Env) {
+        if old_data.glow_hot != data.glow_hot {
+            ctx.request_paint();
+        }
+        self.inner.update(ctx, data, env);
+    }
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx,
+        bc: &BoxConstraints,
+        data: &State,
+        env: &Env,
+    ) -> Size {
+        let size = self.inner.layout(ctx, bc, data, env);
+        self.inner.set_layout_rect(ctx, data, env, size.to_rect());
+        size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &State, env: &Env) {
+        if data.glow_hot && ctx.is_hot() {
+            BackgroundBrush::Color(Color::rgb8(200, 55, 55)).paint(ctx, data, env);
+        }
+        self.inner.paint(ctx, data, env);
+    }
 }
 
 struct Delegate;
@@ -144,6 +197,10 @@ impl AppDelegate<State> for Delegate {
                 ctx.submit_command(cmd, *id);
                 false
             }
+            (_, &MENU_SWITCH_GLOW_ACTION) => {
+                data.glow_hot = !data.glow_hot;
+                false
+            }
             _ => true,
         }
     }
@@ -206,5 +263,9 @@ fn make_context_menu<T: Data>() -> MenuDesc<T> {
         .append(MenuItem::new(
             LocalizedString::new("Decrement"),
             MENU_DECREMENT_ACTION,
+        ))
+        .append(MenuItem::new(
+            LocalizedString::new("Glow when hot"),
+            MENU_SWITCH_GLOW_ACTION,
         ))
 }


### PR DESCRIPTION
This PR adds an option to the context menu of the multiwin example. When enabled the background turns red when the window is hot.

I've used it successfully to test the workings of hot state and I think it can be interesting to others as well. Also it will be useful for demonstrating various hot state issues that I plan to tackle in upcoming PRs.