### PR TITLE
Fix the instructions for serving the wasm exmaples

### DIFF
--- a/druid/examples/wasm/.gitignore
+++ b/druid/examples/wasm/.gitignore
@@ -1,3 +1,4 @@
 src/examples.in
 src/examples
+index.html
 html

--- a/druid/examples/wasm/README.md
+++ b/druid/examples/wasm/README.md
@@ -24,10 +24,10 @@ This step has two main functions:
 To preview the build in a web browser, run
 
 ```
-> http -d html
+> http
 ```
 
-which should start serving the specified folder.
+which should start serving the crate root folder containing `index.html`.
 
 Finally, point your browser to the appropriate localhost url (usually http://localhost:8000) and you
 should see a list of HTML documents -- one for each example.

--- a/druid/examples/wasm/build.rs
+++ b/druid/examples/wasm/build.rs
@@ -77,7 +77,7 @@ mod examples {
             // Add an entry to the index.html file.
             let index_entry = format!(
                 "<li><a href=\"./html/{name}.html\">{name}</a></li>",
-                name = js_entry_fn_name
+                name = example_str
             );
 
             index_html.push_str(&index_entry);

--- a/druid/examples/wasm/build.rs
+++ b/druid/examples/wasm/build.rs
@@ -32,6 +32,19 @@ mod examples {
 "#
     .to_string();
 
+    let mut index_html = r#"
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Druid WASM examples - index</title>
+    </head>
+    <body>
+        <h1>Druid WASM examples</h1>
+        <ul>
+"#
+    .to_string();
+
     for entry in examples_dir.read_dir()? {
         let path = entry?.path();
         if let Some(r) = path.extension() {
@@ -61,6 +74,14 @@ mod examples {
                 example_str.to_string()
             };
 
+            // Add an entry to the index.html file.
+            let index_entry = format!(
+                "<li><a href=\"./html/{name}.html\">{name}</a></li>",
+                name = js_entry_fn_name
+            );
+
+            index_html.push_str(&index_entry);
+
             // Create an html document for each example.
             let html = format!(
                 r#"
@@ -68,7 +89,7 @@ mod examples {
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Druid WASM example - {name}</title>
+        <title>Druid WASM examples - {name}</title>
         <style>
             html, body, canvas {{
                 margin: 0px;
@@ -112,8 +133,13 @@ mod examples {
 
     examples_in.push_str("}");
 
+    index_html.push_str("</ul></body></html>");
+
     // Write out the contents of the examples.in module.
     fs::write(src_dir.join("examples.in"), examples_in)?;
+
+    // Write out the index.html file
+    fs::write(crate_dir.join("index.html"), index_html)?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR builds an `index.html` file which links to all the examples in the html folder and fixes the serving instructions in the README.md.