### PR TITLE
Change request_timer to work with Duration

### DIFF
--- a/docs/book_examples/src/custom_widgets_md.rs
+++ b/docs/book_examples/src/custom_widgets_md.rs
@@ -3,7 +3,7 @@ use druid::{
     Color, Env, Event, EventCtx, KeyCode, PaintCtx, RenderContext, Selector, TimerToken, Widget,
     WidgetExt,
 };
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 const CORNER_RADIUS: f64 = 4.0;
 const STROKE_WIDTH: f64 = 2.0;
@@ -63,7 +63,7 @@ impl Controller<String, TextBox> for TextBoxActionController {
                 ctx.submit_command(ACTION, None);
             }
             Event::KeyUp(k) if k.key_code != KeyCode::Return => {
-                self.timer = Some(ctx.request_timer(Instant::now() + DELAY));
+                self.timer = Some(ctx.request_timer(DELAY));
                 child.event(ctx, event, data, env);
             }
             Event::Timer(token) if Some(*token) == self.timer => {

--- a/druid-shell/examples/shello.rs
+++ b/druid-shell/examples/shello.rs
@@ -64,7 +64,7 @@ impl WinHandler for HelloState {
     }
 
     fn key_down(&mut self, event: KeyEvent) -> bool {
-        let deadline = instant::Instant::now() + std::time::Duration::from_millis(500);
+        let deadline = std::time::Duration::from_millis(500);
         let id = self.handle.request_timer(deadline);
         println!("keydown: {:?}, timer id = {:?}", event, id);
 

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -15,6 +15,7 @@
 //! Platform independent window types.
 
 use std::any::Any;
+use std::time::Duration;
 
 use crate::common_util::Counter;
 use crate::dialog::{FileDialogOptions, FileInfo};
@@ -157,8 +158,8 @@ impl WindowHandle {
     /// requiring precision.
     ///
     /// [`WinHandler::timer()`]: trait.WinHandler.html#tymethod.timer
-    pub fn request_timer(&self, deadline: instant::Instant) -> TimerToken {
-        self.0.request_timer(deadline)
+    pub fn request_timer(&self, deadline: Duration) -> TimerToken {
+        self.0.request_timer(instant::Instant::now() + deadline)
     }
 
     /// Set the cursor icon.

--- a/druid/examples/game_of_life.rs
+++ b/druid/examples/game_of_life.rs
@@ -16,7 +16,6 @@
 
 //! Game of life
 
-use instant::Instant;
 use std::ops::{Index, IndexMut};
 use std::time::Duration;
 
@@ -237,7 +236,7 @@ impl Widget<AppData> for GameOfLifeWidget {
         match event {
             Event::WindowConnected => {
                 ctx.request_paint();
-                let deadline = Instant::now() + Duration::from_millis(data.iter_interval() as u64);
+                let deadline = Duration::from_millis(data.iter_interval() as u64);
                 self.timer_id = ctx.request_timer(deadline);
             }
             Event::Timer(id) => {
@@ -246,8 +245,7 @@ impl Widget<AppData> for GameOfLifeWidget {
                         data.grid.evolve();
                         ctx.request_paint();
                     }
-                    let deadline =
-                        Instant::now() + Duration::from_millis(data.iter_interval() as u64);
+                    let deadline = Duration::from_millis(data.iter_interval() as u64);
                     self.timer_id = ctx.request_timer(deadline);
                 }
             }

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -106,12 +106,12 @@ impl Widget<OurData> for ColorWell {
                     (_, _) => Color::rgb8(r, g, b.wrapping_add(10)),
                 };
 
-                self.token = ctx.request_timer(Instant::now() + CYCLE_DURATION);
+                self.token = ctx.request_timer(CYCLE_DURATION);
                 ctx.request_paint();
             }
 
             Event::WindowConnected if self.randomize => {
-                self.token = ctx.request_timer(Instant::now() + CYCLE_DURATION);
+                self.token = ctx.request_timer(CYCLE_DURATION);
             }
 
             Event::Command(cmd) if cmd.selector == FREEZE_COLOR => {

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -14,14 +14,13 @@
 
 //! An example of a timer.
 
-use instant::Instant;
 use std::time::Duration;
 
 use druid::widget::prelude::*;
 use druid::widget::BackgroundBrush;
 use druid::{AppLauncher, Color, LocalizedString, Point, Rect, TimerToken, WidgetPod, WindowDesc};
 
-static TIMER_INTERVAL: u64 = 10;
+static TIMER_INTERVAL: Duration = Duration::from_millis(10);
 
 struct TimerWidget {
     timer_id: TimerToken,
@@ -50,15 +49,13 @@ impl Widget<u32> for TimerWidget {
         match event {
             Event::WindowConnected => {
                 // Start the timer when the application launches
-                let deadline = Instant::now() + Duration::from_millis(TIMER_INTERVAL);
-                self.timer_id = ctx.request_timer(deadline);
+                self.timer_id = ctx.request_timer(TIMER_INTERVAL);
             }
             Event::Timer(id) => {
                 if *id == self.timer_id {
                     self.adjust_box_pos(ctx.size());
                     ctx.request_layout();
-                    let deadline = Instant::now() + Duration::from_millis(TIMER_INTERVAL);
-                    self.timer_id = ctx.request_timer(deadline);
+                    self.timer_id = ctx.request_timer(TIMER_INTERVAL);
                 }
             }
             _ => (),
@@ -91,10 +88,9 @@ struct SimpleBox;
 impl Widget<u32> for SimpleBox {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut u32, _env: &Env) {}
 
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {
-        match _event {
-            LifeCycle::HotChanged(_) => ctx.request_paint(),
-            _ => (),
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {
+        if matches!(event, LifeCycle::HotChanged(_)) {
+            ctx.request_paint();
         }
     }
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -15,8 +15,7 @@
 //! The context types that are passed into various widget methods.
 
 use std::ops::{Deref, DerefMut};
-
-use instant::Instant;
+use std::time::Duration;
 
 use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::piet::Piet;
@@ -344,7 +343,7 @@ impl<'a> EventCtx<'a> {
     ///
     /// The return value is a token, which can be used to associate the
     /// request with the event.
-    pub fn request_timer(&mut self, deadline: Instant) -> TimerToken {
+    pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
         self.base_state.request_timer = true;
         self.window.request_timer(deadline)
     }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -15,8 +15,7 @@
 //! A container that scrolls its contents.
 
 use std::f64::INFINITY;
-
-use instant::{Duration, Instant};
+use std::time::Duration;
 
 use crate::kurbo::{Affine, Point, Rect, RoundedRect, Size, Vec2};
 use crate::theme;
@@ -175,7 +174,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         // Display scroll bars and schedule their disappearance
         self.scrollbars.opacity = env.get(theme::SCROLLBAR_MAX_OPACITY);
         let fade_delay = env.get(theme::SCROLLBAR_FADE_DELAY);
-        let deadline = Instant::now() + Duration::from_millis(fade_delay);
+        let deadline = Duration::from_millis(fade_delay);
         self.scrollbars.timer_id = ctx.request_timer(deadline);
     }
 

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -15,8 +15,7 @@
 //! A stepper widget.
 
 use std::f64::EPSILON;
-
-use instant::{Duration, Instant};
+use std::time::Duration;
 
 use crate::kurbo::{BezPath, Rect, RoundedRect};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
@@ -206,8 +205,7 @@ impl Widget<f64> for Stepper {
                     self.increment(data);
                 }
 
-                let delay = Instant::now() + STEPPER_REPEAT_DELAY;
-                self.timer_id = ctx.request_timer(delay);
+                self.timer_id = ctx.request_timer(STEPPER_REPEAT_DELAY);
 
                 ctx.request_paint();
             }
@@ -227,8 +225,7 @@ impl Widget<f64> for Stepper {
                 if self.decrease_active {
                     self.decrement(data);
                 }
-                let delay = Instant::now() + STEPPER_REPEAT;
-                self.timer_id = ctx.request_timer(delay);
+                self.timer_id = ctx.request_timer(STEPPER_REPEAT);
             }
             _ => (),
         }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -14,7 +14,7 @@
 
 //! A textbox widget.
 
-use instant::{Duration, Instant};
+use std::time::Duration;
 
 use crate::{
     Application, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx,
@@ -38,6 +38,7 @@ const PADDING_LEFT: f64 = 4.;
 
 // we send ourselves this when we want to reset blink, which must be done in event.
 const RESET_BLINK: Selector = Selector::new("druid-builtin.reset-textbox-blink");
+const CURSOR_BLINK_DRUATION: Duration = Duration::from_millis(500);
 
 /// A widget that allows user text input.
 #[derive(Debug, Clone)]
@@ -225,8 +226,7 @@ impl TextBox {
 
     fn reset_cursor_blink(&mut self, ctx: &mut EventCtx) {
         self.cursor_on = true;
-        let deadline = Instant::now() + Duration::from_millis(500);
-        self.cursor_timer = ctx.request_timer(deadline);
+        self.cursor_timer = ctx.request_timer(CURSOR_BLINK_DRUATION);
     }
 }
 
@@ -274,8 +274,7 @@ impl Widget<String> for TextBox {
                 if *id == self.cursor_timer {
                     self.cursor_on = !self.cursor_on;
                     ctx.request_paint();
-                    let deadline = Instant::now() + Duration::from_millis(500);
-                    self.cursor_timer = ctx.request_timer(deadline);
+                    self.cursor_timer = ctx.request_timer(CURSOR_BLINK_DRUATION);
                 }
             }
             Event::Command(ref cmd)


### PR DESCRIPTION
Since the wasm PR I've been thinking about changing `request_timer` to take `Duration` instead of `Instant`, considering that I've never seen it being called in a different way than
```rust
ctx.request_timer(Instant::now() + some_duration)
```
With this it's just
```rust
ctx.request_timer(some_duration)
```
That would allow us to get rid of Instant as part of our API and thus `instant::Instant` would not be necessary in user code when targeting wasm.

This should also fix the wasm CI