### PR TITLE
Fix clippy complaint in timer example

### DIFF
--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -91,10 +91,9 @@ struct SimpleBox;
 impl Widget<u32> for SimpleBox {
     fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut u32, _env: &Env) {}
 
-    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, _event: &LifeCycle, _data: &u32, _env: &Env) {
-        match _event {
-            LifeCycle::HotChanged(_) => ctx.request_paint(),
-            _ => (),
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {
+        if let LifeCycle::HotChanged(_) = event {
+             ctx.request_paint();
         }
     }
 

--- a/druid/examples/timer.rs
+++ b/druid/examples/timer.rs
@@ -93,7 +93,7 @@ impl Widget<u32> for SimpleBox {
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, _data: &u32, _env: &Env) {
         if let LifeCycle::HotChanged(_) = event {
-             ctx.request_paint();
+            ctx.request_paint();
         }
     }
 


### PR DESCRIPTION
Fixing a break in the pipeline found in https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/druid.23759.20Wasm.20support/near/194233485:

```rust
error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
  --> druid/examples/wasm/src/examples/timer.rs:95:9
   |
95 | /         match _event {
96 | |             LifeCycle::HotChanged(_) => ctx.request_paint(),
97 | |             _ => (),
98 | |         }
   | |_________^ help: try this: `if let LifeCycle::HotChanged(_) = _event { ctx.request_paint() }`
   |
   = note: `-D clippy::single-match` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match

error: aborting due to previous error

error: could not compile `druid-wasm-examples`.
```
