### PR TITLE
Fix wasm examples not building on Windows with a standard user.

### DIFF
--- a/druid/examples/wasm/build.rs
+++ b/druid/examples/wasm/build.rs
@@ -21,7 +21,7 @@ fn link_dir(src: &std::path::Path, dst: &std::path::Path) {
     }
     // Perform platform specific linking
     #[cfg(unix)]
-    std::os::unix::fs::symlink(parent_dir, &examples_dir).expect("failed to create symlink");
+    std::os::unix::fs::symlink(src, dst).expect("failed to create symlink");
     #[cfg(windows)]
     link_dir_windows(src, dst);
     // Make sure the directory exists now

--- a/druid/examples/wasm/build.rs
+++ b/druid/examples/wasm/build.rs
@@ -8,6 +8,39 @@ const EXCEPTIONS: &[&str] = &[
     "ext_event", // WASM doesn't currently support spawning threads.
 ];
 
+#[cfg(windows)]
+fn link_dir_windows(src: &std::path::Path, dst: &std::path::Path) {
+    // Attempt to create a symlink, which will work with either
+    // * Admininstrator privileges
+    // * New enough Windows with developer mode enabled
+    if std::os::windows::fs::symlink_dir(src, dst).is_ok() {
+        return;
+    }
+    // Otherwise fall back to creating a junction instead.
+    // First we have to delete any previous junction,
+    // because a junction is an absolute path reference
+    // that becomes invalid if one of our ancestor directories gets renamed/moved.
+    let err = fs::remove_dir(dst).err();
+    match err {
+        None => (),
+        Some(err) if err.kind() == std::io::ErrorKind::NotFound => (),
+        Some(err) => panic!("Failed to remove directory: {}", err),
+    }
+    // Then use Command Prompt's inbuilt 'mklink' command to create the junction for us.
+    std::process::Command::new("cmd")
+        .arg("/C") // Run a command and exit
+        .arg("mklink")
+        .arg("/J") // Junction
+        .arg(dst.as_os_str())
+        .arg(src.as_os_str())
+        .output()
+        .expect("failed to execute process");
+    // Make sure the directory exists now
+    if !dst.exists() {
+        panic!("Failed to create a junction");
+    }
+}
+
 fn main() -> Result<()> {
     let crate_dir = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
     let src_dir = crate_dir.join("src");
@@ -17,9 +50,9 @@ fn main() -> Result<()> {
 
     // Create a symlink (platform specific) to the examples directory.
     #[cfg(unix)]
-    std::os::unix::fs::symlink(parent_dir, &examples_dir).ok();
+    std::os::unix::fs::symlink(parent_dir, &examples_dir).expect("failed to create symlink");
     #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(parent_dir, &examples_dir).ok();
+    link_dir_windows(parent_dir, &examples_dir);
 
     // Generate example module and the necessary html documents.
 

--- a/druid/examples/wasm/build.rs
+++ b/druid/examples/wasm/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::Result;
 use std::path::PathBuf;
 use std::{env, fs};


### PR DESCRIPTION
The wasm example build script used [std::os::windows::fs::symlink_dir](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html) but that requires administrator privileges to work. The one exception is that if it's a new enough Windows that also has developer mode enabled.

A fine alternative is a [junction](https://stackoverflow.com/a/48586946/138826). However there doesn't seem to be a Rust standard library way to do it. There is [std::sys::windows::fs::symlink_junction](https://github.com/rust-lang/rust/blob/ce93331e2cf21ac4b72a53854b105955919114e7/src/libstd/sys/windows/fs.rs#L886) but that is a private function that is not exposed for public use. Given that this is a test build file, I didn't bother too much and went with a somewhat hacky solution of just calling out to a shell.

So the solution is to attempt to create a symbolic link and if that fails just launch a Command Prompt shell and use it's inbuilt **mklink** command to create the junction.