### PR TITLE
Make window title LabelText instead of LocalizedString

### DIFF
--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -17,6 +17,7 @@
 use crate::ext_event::{ExtEventHost, ExtEventSink};
 use crate::kurbo::Size;
 use crate::shell::{Application, Error as PlatformError, WindowBuilder, WindowHandle};
+use crate::widget::LabelText;
 use crate::win_handler::{AppHandler, AppState};
 use crate::window::WindowId;
 use crate::{
@@ -40,7 +41,7 @@ pub struct AppLauncher<T> {
 /// window properties such as the title.
 pub struct WindowDesc<T> {
     pub(crate) root: Box<dyn Widget<T>>,
-    pub(crate) title: LocalizedString<T>,
+    pub(crate) title: LabelText<T>,
     pub(crate) size: Option<Size>,
     pub(crate) min_size: Option<Size>,
     pub(crate) menu: Option<MenuDesc<T>>,
@@ -148,7 +149,7 @@ impl<T: Data> WindowDesc<T> {
         // this just makes our API slightly cleaner; callers don't need to explicitly box.
         WindowDesc {
             root: root().boxed(),
-            title: LocalizedString::new("app-name"),
+            title: LocalizedString::new("app-name").into(),
             size: None,
             min_size: None,
             menu: MenuDesc::platform_default(),
@@ -158,12 +159,14 @@ impl<T: Data> WindowDesc<T> {
         }
     }
 
-    /// Set the title for this window. This is a [`LocalizedString`] that will
-    /// be kept up to date as the application's state changes.
+    /// Set the title for this window. This is a [`LabelText`]; it can be either
+    /// a `String`, a [`LocalizedString`], or a closure that computes a string;
+    /// it that will be kept up to date as the application's state changes.
     ///
+    /// [`LabelText`]: widget/enum.LocalizedString.html
     /// [`LocalizedString`]: struct.LocalizedString.html
-    pub fn title(mut self, title: LocalizedString<T>) -> Self {
-        self.title = title;
+    pub fn title(mut self, title: impl Into<LabelText<T>>) -> Self {
+        self.title = title.into();
         self
     }
 
@@ -231,7 +234,7 @@ impl<T: Data> WindowDesc<T> {
             builder.set_min_size(min_size);
         }
 
-        builder.set_title(self.title.localized_str());
+        builder.set_title(self.title.display_text());
         if let Some(menu) = platform_menu {
             builder.set_menu(menu);
         }

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -30,7 +30,13 @@ const BASELINE_GUESS_FACTOR: f64 = 0.8;
 // added padding between the edges of the widget and the text.
 const LABEL_X_PADDING: f64 = 2.0;
 
-/// The text for the label
+/// The text for the label.
+///
+/// This can be one of three things; either a `String`, a [`LocalizedString`],
+/// or a closure with the signature, `Fn(&T, &Env) -> String`, where `T` is
+/// the `Data` at this point in the tree.
+///
+/// [`LocalizedString`]: ../struct.LocalizedString.html
 pub enum LabelText<T> {
     /// Localized string that will be resolved through `Env`.
     Localized(LocalizedString<T>),

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -24,11 +24,12 @@ use crate::piet::{Piet, RenderContext};
 use crate::shell::{Counter, Cursor, WindowHandle};
 
 use crate::core::{BaseState, CommandQueue, FocusChange};
+use crate::widget::LabelText;
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
     BoxConstraints, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
-    LayoutCtx, LifeCycle, LifeCycleCtx, LocalizedString, MenuDesc, PaintCtx, UpdateCtx, Widget,
-    WidgetId, WidgetPod, WindowDesc,
+    LayoutCtx, LifeCycle, LifeCycleCtx, MenuDesc, PaintCtx, UpdateCtx, Widget, WidgetId, WidgetPod,
+    WindowDesc,
 };
 
 /// A unique identifier for a window.
@@ -39,7 +40,7 @@ pub struct WindowId(u64);
 pub struct Window<T> {
     pub(crate) id: WindowId,
     pub(crate) root: WidgetPod<T, Box<dyn Widget<T>>>,
-    pub(crate) title: LocalizedString<T>,
+    pub(crate) title: LabelText<T>,
     size: Size,
     pub(crate) menu: Option<MenuDesc<T>>,
     pub(crate) context_menu: Option<MenuDesc<T>>,
@@ -360,7 +361,7 @@ impl<T: Data> Window<T> {
 
     pub(crate) fn update_title(&mut self, data: &T, env: &Env) {
         if self.title.resolve(data, env) {
-            self.handle.set_title(self.title.localized_str());
+            self.handle.set_title(self.title.display_text());
         }
     }
 


### PR DESCRIPTION
It isn't really possible for code outside of druid to use
LocalizedString in any reasonable way at the moment, and so
this makes it much easier to set a window title, especially
a title that is generated dynamically from the data.