### PR TITLE
Improve Windows invalidation logging.

### DIFF
--- a/druid-shell/examples/invalidate.rs
+++ b/druid-shell/examples/invalidate.rs
@@ -78,6 +78,10 @@ impl WinHandler for InvalidateTest {
         }
     }
 
+    fn destroy(&mut self) {
+        Application::global().quit()
+    }
+
     fn as_any(&mut self) -> &mut dyn Any {
         self
     }

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -376,7 +376,7 @@ impl WndProc for MyWndProc {
             WM_PAINT => unsafe {
                 if let Ok(mut s) = self.state.try_borrow_mut() {
                     let mut rect: RECT = mem::zeroed();
-                    GetUpdateRect(hwnd, &mut rect, 0);
+                    GetUpdateRect(hwnd, &mut rect, FALSE);
                     let s = s.as_mut().unwrap();
                     if s.render_target.is_none() {
                         let rt = paint::create_render_target(&self.d2d_factory, hwnd);
@@ -412,8 +412,11 @@ impl WndProc for MyWndProc {
                     let s = s.as_mut().unwrap();
                     if s.dcomp_state.is_some() {
                         let mut rect: RECT = mem::zeroed();
-                        if GetClientRect(hwnd, &mut rect) == 0 {
-                            warn!("GetClientRect failed.");
+                        if GetClientRect(hwnd, &mut rect) == FALSE {
+                            log::warn!(
+                                "GetClientRect failed: {}",
+                                Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                            );
                             return None;
                         }
                         let rt = paint::create_render_target(&self.d2d_factory, hwnd);
@@ -444,8 +447,11 @@ impl WndProc for MyWndProc {
                     let s = s.as_mut().unwrap();
                     if s.dcomp_state.is_some() {
                         let mut rect: RECT = mem::zeroed();
-                        if GetClientRect(hwnd, &mut rect) == 0 {
-                            warn!("GetClientRect failed.");
+                        if GetClientRect(hwnd, &mut rect) == FALSE {
+                            log::warn!(
+                                "GetClientRect failed: {}",
+                                Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                            );
                             return None;
                         }
                         let width = (rect.right - rect.left) as u32;
@@ -1219,11 +1225,16 @@ impl WindowHandle {
     }
 
     pub fn invalidate_rect(&self, rect: Rect) {
-        let r = self.px_to_rect(rect);
+        let rect = self.px_to_rect(rect);
         if let Some(w) = self.state.upgrade() {
             let hwnd = w.hwnd.get();
             unsafe {
-                InvalidateRect(hwnd, &r as *const _, FALSE);
+                if InvalidateRect(hwnd, &rect, FALSE) == FALSE {
+                    log::warn!(
+                        "InvalidateRect failed: {}",
+                        Error::Hr(HRESULT_FROM_WIN32(GetLastError()))
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
I was reviewing the invalidation PR #817 and found room for a bit of improvement.
* More extensive logging in the Windows platform code.
* Quit the druid-shell example when the window is closed, like the other druid-shell examples.