### PR TITLE
Fix gtk menu shortcuts.

### DIFF
--- a/druid-shell/src/platform/gtk/menu.rs
+++ b/druid-shell/src/platform/gtk/menu.rs
@@ -127,7 +127,7 @@ impl Menu {
 }
 
 fn register_accelerator(item: &GtkMenuItem, accel_group: &AccelGroup, menu_key: HotKey) {
-    let wc = match menu_key.key {
+    let gdk_keyval = match menu_key.key {
         KeyCompare::Code(key_code) => key_code.into(),
         KeyCompare::Text(text) => text.chars().next().unwrap() as u32,
     };
@@ -135,7 +135,7 @@ fn register_accelerator(item: &GtkMenuItem, accel_group: &AccelGroup, menu_key: 
     item.add_accelerator(
         "activate",
         accel_group,
-        gdk::unicode_to_keyval(wc),
+        gdk_keyval,
         modifiers_to_gdk_modifier_type(menu_key.mods),
         gtk::AccelFlags::VISIBLE,
     );


### PR DESCRIPTION
The key code returned by `KeyCode::into()` is already a gdk keyval, not a unicode value (not every keycode even has a unicode value).

Prior to this change, hotkeys like Alt+F4 were broken in gtk.