### PR TITLE
Add a Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Highlights
+
+- Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
+
 ### Added
 
 - `TextBox` can receive `EditAction` commands. ([#814] by [@cmyr])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `TextBox` can receive `EditAction` commands ([#814] by [@cmyr])
+- `TextBox` can receive `EditAction` commands. ([#814] by [@cmyr])
+
+- Added `Split::min_splitter_area(f64)` to add padding around the split bar. ([#738] by [@xStorm])
+
+- The `druid::text` module is public now. ([#816] by [@cmyr])
+
+- Basic X11 backend for druid-shell. ([#599] by [@crsarcco])
 
 ### Changed
 
-- `Split` constructors are now `Split::rows` and `columns`. ([#738] by [@xStorm])
+- `Split` constructors are now called `Split::rows` and `columns`. ([#738] by [@xStorm])
+
+- `Split::splitter_size` no longer includes padding. ([#738] by [@xStorm])
+
+- `Event::MouseMoved` has been renamed to `MouseMove`. ([#825] by [@teddemunnik])
 
 ### Deprecated
 
 ### Removed
+
+- The optional GTK feature for non-Linux platforms. ([#611] by [@pyroxymat])
 
 ### Fixed
 
@@ -27,12 +39,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GTK windows get actually closed. ([#797] by [@finnerale])
 
+- Windows now respects the minimum window size. ([#727] by [@teddemunnik])
+
+- Windows now respects resizability. ([#712] by [@teddemunnik])
+
+- Mouse capturing on Windows. ([#695] by [@teddemunnik])
+
 ### Visual
 - Improved `Split` accuracy. ([#738] by [@xStorm])
 
 ### Docs
 
 - `Env` got a new example and usage hints. ([#796] by [@finnerale])
+
+- Usage of boom filters got documented. ([#818] by @xStorm)]
 
 ### Cleanups
 
@@ -42,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A new project using druid: [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
 
+[#599]: https://github.com/xi-editor/druid/pull/599
+[#611]: https://github.com/xi-editor/druid/pull/611
+[#695]: https://github.com/xi-editor/druid/pull/695
+[#712]: https://github.com/xi-editor/druid/pull/712
+[#727]: https://github.com/xi-editor/druid/pull/727
 [#738]: https://github.com/xi-editor/druid/pull/738
 [#782]: https://github.com/xi-editor/druid/pull/782
 [#796]: https://github.com/xi-editor/druid/pull/796
@@ -49,11 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#798]: https://github.com/xi-editor/druid/pull/798
 [#808]: https://github.com/xi-editor/druid/pull/808
 [#814]: https://github.com/xi-editor/druid/pull/814
+[#816]: https://github.com/xi-editor/druid/pull/816
+[#818]: https://github.com/xi-editor/druid/pull/818
+[#825]: https://github.com/xi-editor/druid/pull/825
 
 ## [0.5] - 2020-04-01
 
 Last release without a changelog :(
 
+
+[@pyroxymat]: https://github.com/pyroxymat
+
+[@crsaracco]: https://github.com/crsaracco
+
+[@teddemunnik]: https://github.com/teddemunnik
 
 [@xStorm]: https://github.com/xStorm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - `Env` got a new example and usage hints. ([#796] by [@finnerale])
 
-- Usage of bloom filters got documented. ([#818] by @xStorm)]
+- Usage of bloom filters got documented. ([#818] by [@xStorm])
 
 ### Cleanups
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 
 ### Deprecated
 
+- Nothing
+
 ### Removed
 
 - The optional GTK feature for non-Linux platforms. ([#611] by [@pyroxymat])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Last release without a changelog :(
 [@elrnv]: https://github.com/elrnv
 [@tedsta]: https://github.com/tedsta
 [@kindlychung]: https://github.com/kindlychung
+[@jneem]: https://github.com/jneem
 [@fishrockz]: https://github.com/fishrockz
 [@thecodewarrior]: https://github.com/thecodewarrior
 [@sjoshid]: https://github.com/sjoshid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reduce the flashing in ext_event and identity examples [#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul]
+- Reduce the flashing in ext_event and identity examples ([#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul])
 
 ## [0.5] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased 0.6]
+
+### Added
+
+### Changed
+
+### Depricated
+
+### Removed
+
+### Fixed
+
+- Reduce the flashing in ext_event and identity examples [#782](https://github.com/xi-editor/druid/pull/782) by @futurepaul
+
+## [0.5] - 2020-04-01
+
+Last release without a changelog :(
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,8 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 ### Outside News
 
 - There are two new projects using druid:
-    - [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
-    - [jack-mixer](https://github.com/derekdreery/jack-mixer) A jack client that provides mixing, levels and a 3-band eq.
-
+  - [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
+  - [jack-mixer](https://github.com/derekdreery/jack-mixer) A jack client that provides mixing, levels and a 3-band eq.
 
 [#599]: https://github.com/xi-editor/druid/pull/599
 [#611]: https://github.com/xi-editor/druid/pull/611
@@ -138,7 +137,6 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 ## [0.5] - 2020-04-01
 
 Last release without a changelog :(
-
 
 [@futurepaul]: https://github.com/futurepaul
 [@finnerale]: https://github.com/finnerale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `TextBox` can receive `EditAction` commands ([#814](https://github.com/xi-editor/druid/pull/814) by [@cmyr])
+- `TextBox` can receive `EditAction` commands
+  ([#814](https://github.com/xi-editor/druid/pull/814) by [@cmyr])
 
 ### Changed
 
 - `Split` constructors are now `Split::rows` and `columns`.
-  `Split` is now more accurate. ([#738](https://github.com/xi-editor/druid/pull/738) by [@xStorm])
+  `Split` is more accurate as well.
+  ([#738](https://github.com/xi-editor/druid/pull/738) by [@xStorm])
 
 ### Deprecated
 
@@ -22,19 +24,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reduce the flashing in ext_event and identity examples. ([#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul])
+- Reduce the flashing in ext_event and identity examples.
+  ([#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul])
 
-- GTK uses the system locale. ([#798](https://github.com/xi-editor/druid/pull/798) by [@finnerale])
+- GTK uses the system locale.
+  ([#798](https://github.com/xi-editor/druid/pull/798) by [@finnerale])
 
-- GTK windows get actually closed. ([#797](https://github.com/xi-editor/druid/pull/797) by [@finnerale])
+- GTK windows get actually closed.
+  ([#797](https://github.com/xi-editor/druid/pull/797) by [@finnerale])
 
 ### Docs
 
-- `Env` got a new example and usage hints. ([#796](https://github.com/xi-editor/druid/pull/796) by [@finnerale])
+- `Env` got a new example and usage hints.
+  ([#796](https://github.com/xi-editor/druid/pull/796) by [@finnerale])
 
 ### Cleanups
 
-- Replace `#[macro_use]` with normal `use`. ([#808](https://github.com/xi-editor/druid/pull/808) by [@totsteps])
+- Replace `#[macro_use]` with normal `use`.
+  ([#808](https://github.com/xi-editor/druid/pull/808) by [@totsteps])
 
 ### Outside News
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `request_paint_rect` for partial invalidation. ([#817] by [@jneem])
 - Window title can be any `LabelText` (such as a simple `String`). ([#869] by [@cmyr])
 - `Label::with_font` and `set_font`. ([#785] by [@thecodewarrior])
+- `InternalEvent::RouteTimer` to route timer events. ([#831] by [@sjoshid])
 
 ### Changed
 
@@ -54,6 +55,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - GTK: Actually close windows ([#797] by [@finnerale])
 - Windows: Respect the minimum window size. ([#727] by [@teddemunnik])
 - Windows: Respect resizability. ([#712] by [@teddemunnik])
+- `Event::HotChanged(false)` will be emitted when the cursor leaves the window. ([#821] by [@teddemunnik])
 - Windows: Capture mouse for drag actions. ([#695] by [@teddemunnik])
 - Start focus cycling from non-registered-for-focus widgets. ([#819] by [@xStrom])
 - Propagate `Event::FocusChanged` to focus gaining widgets as well. ([#819] by [@xStrom])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `druid::text` module is public now. ([#816] by [@cmyr])
 
-- Basic X11 backend for druid-shell. ([#599] by [@crsarcco])
+- Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,17 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 #### Mostly complete Wasm backend for druid-shell. ([#759])
 
-[@elrnv] continued the work of [@tedsta] and implemented a mostly complete Wasm backend and enabled all druid example to [run in the browser](https://elrnv.github.io/druid-wasm-examples/).
+[@elrnv] continued the work of [@tedsta] and implemented a mostly complete Wasm backend and enabled all druid examples to [run in the browser](https://elrnv.github.io/druid-wasm-examples/).
 
 While some features like the clipboard, menus or file dialogs are not yet available, all fundamental features are there.
 
 ### Added
 
 - `TextBox` can receive `EditAction` commands. ([#814] by [@cmyr])
-- `Split::min_splitter_area(f64)` to add padding around the split bar. ([#738] by [@xStrom])
+- `Split::min_splitter_area(f64)` to add padding around the splitter bar. ([#738] by [@xStrom])
 - Published `druid::text` module. ([#816] by [@cmyr])
-- Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
-- `InternalEvent::MouseLeave` signalling the cursor leaved the window. ([#821] by [@teddemunnik])
+- `InternalEvent::MouseLeave` signalling the cursor left the window. ([#821] by [@teddemunnik])
 - `children_changed` now always includes layout and paint request. ([#839] by [@xStrom])
-- Mostly complete Wasm backend for druid-shell. ([#759] by [@elrnv])
 - `UpdateCtx::submit_command`. ([#855] by [@cmyr])
 - `request_paint_rect` for partial invalidation. ([#817] by [@jneem])
 - Window title can be any `LabelText` (such as a simple `String`). ([#869] by [@cmyr])
@@ -39,6 +37,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `Event::Internal(InternalEvent)` now bundles all internal events. ([#833] by [@xStrom])
 - `WidgetPod::set_layout_rect` now requires `LayoutCtx`, data and `Env`. ([#841] by [@xStrom])
 - `request_timer` now uses `Duration` instead of `Instant`. ([#847] by [@finnerale])
+- Global `Application` associated functions are now instance methods instead, e.g. `Application::global().quit()` instead of the old `Application::quit()`. ([#763] by [@xStrom])
 
 ### Deprecated
 
@@ -58,15 +57,16 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Start focus cycling from non-registered-for-focus widgets. ([#819] by [@xStrom])
 - Propagate `Event::FocusChanged` to focus gaining widgets as well. ([#819] by [@xStrom])
 - GTK: Prevent crashing on pop-ups. ([#837] by [@finnerale])
-- Keep hot state  consistent with mouse position. ([#841] by [@xStrom])
+- Keep hot state consistent with mouse position. ([#841] by [@xStrom])
 - Open file menu item works again. ([#851] by [@kindlychung])
 - Supply correct `LifeCycleCtx` to `Event::FocusChanged`. ([#878] by [@cmyr])
 - Windows: Termiate app when all windows have closed. ([#763] by [@xStrom])
+- macOS: `Application::quit` now quits the run loop instead of killing the process. ([#763] by [@xStrom])
 
 ### Visual
 
 - Improved `Split` accuracy. ([#738] by [@xStrom])
-- Build-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
+- Built-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
 
 ### Docs
 
@@ -83,7 +83,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Added rendering tests. ([#784] by [@fishrockz])
 - CI testing has been revamped. ([#857] by [@xStrom])
 - Associate timers with widget ids. ([#831] by [@sjoshid])
-- Add a changelog. ([#889] by [@finnerale])
+- Added a changelog containing development since the 0.5 release. ([#889] by [@finnerale])
 
 ### Outside News
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - `Env` got a new example and usage hints. ([#796] by [@finnerale])
 
-- Usage of boom filters got documented. ([#818] by @xStorm)]
+- Usage of bloom filters got documented. ([#818] by @xStorm)]
 
 ### Cleanups
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 While still incomplete this lays the foundation for running druid on Linux without relying on GTK.
 
+#### Mostly complete Wasm backend for druid-shell. ([#759])
+
+[@elrnv] continued the work of [@tedsta] and implemented a mostly complete Wasm backend and enabled all druid example to [run in the browser](https://elrnv.github.io/druid-wasm-examples/).
+
+While some features like the clipboard, menus or file dialogs are not yet available, all fundamental features are there.
+
 ### Added
 
 - `TextBox` can receive `EditAction` commands. ([#814] by [@cmyr])
@@ -24,6 +30,20 @@ While still incomplete this lays the foundation for running druid on Linux witho
 - Published `druid::text` module. ([#816] by [@cmyr])
 
 - Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
+
+- `InternalEvent::MouseLeave` signalling the cursor leaved the window. ([#821] by [@teddemunnik])
+
+- `children_changed` now always includes layout and paint request. ([#839] by [@xStorm])
+
+- Mostly complete Wasm backend for druid-shell. ([#759] by [@elrnv])
+
+- `UpdateCtx::submit_command`. ([#855] by [@cmyr])
+
+- `request_paint_rect` for partial invalidation. ([#817] by [@jneem])
+
+- Window title can be any `LabelText` (such as a simple `String`). ([#869] by [@cmyr])
+
+- `Label::with_font` and `set_font`. ([#785] by [@thecodewarrior])
 
 ### Changed
 
@@ -35,6 +55,12 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - `has_focus` no longer returns false positives. ([#819] by [@xStorm])
 
+- `Event::Internal(InternalEvent)` now bundles all internal events. ([#833] by [@xStorm])
+
+- `WidgetPod::set_layout_rect` now requires `LayoutCtx`, data and `Env`. ([#841] by [@xStorm])
+
+- `request_timer` now uses `Duration` instead of `Instant`. ([#847] by [@finnerale])
+
 ### Deprecated
 
 ### Removed
@@ -42,8 +68,6 @@ While still incomplete this lays the foundation for running druid on Linux witho
 - The optional GTK feature for non-Linux platforms. ([#611] by [@pyroxymat])
 
 ### Fixed
-
-- Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
 
 - GTK: Use the system locale. ([#798] by [@finnerale])
 
@@ -59,65 +83,110 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - Propagate `Event::FocusChanged` to focus gaining widgets as well. ([#819] by [@xStorm])
 
+- GTK: Prevent crashing on pop-ups. ([#837] by [@finnerale])
+
+- Keep hot state  consistent with mouse position. ([#841] by [@xStorm])
+
+- Open file menu item works again. ([#851] by [@kindlychung])
+
+- Supply correct `LifeCycleCtx` to `Event::FocusChanged`. ([#878] by [@cmyr])
+
+- Windows: Termiate app when all windows have closed. ([#763] by [@xStorm])
+
 ### Visual
+
 - Improved `Split` accuracy. ([#738] by [@xStorm])
 
+- Build-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
+
 ### Docs
+
+- Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
 
 - `Env` got a new example and usage hints. ([#796] by [@finnerale])
 
 - Usage of bloom filters got documented. ([#818] by [@xStorm])
 
+- Book chapters about `Painter` and `Controller` were added. ([#832] by [@cmyr])
+
+- Added hot glow option to multiwin example. ([#845] by [@xStorm])
+
 ### Cleanups
 
 - Replace `#[macro_use]` with normal `use`. ([#808] by [@totsteps])
 
+- Clippy checks are now enabled for all targets. ([#850] by [@xStorm])
+
+- Added rendering tests. ([#784] by [@fishrockz])
+
+- CI testing has been revamped. ([#857] by [@xStorm])
+
+- Associate timers with widget ids. ([#831] by [@sjoshid])
+
 ### Outside News
 
-- A new project using druid: [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
+- Two new projects using druid:
+    - [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
+    - [jack-mixer](https://github.com/derekdreery/jack-mixer) A jack client that provides mixing, levels and a 3-band eq.
 
-[#819]: https://github.com/xi-editor/druid/pull/819
 [#599]: https://github.com/xi-editor/druid/pull/599
 [#611]: https://github.com/xi-editor/druid/pull/611
 [#695]: https://github.com/xi-editor/druid/pull/695
 [#712]: https://github.com/xi-editor/druid/pull/712
 [#727]: https://github.com/xi-editor/druid/pull/727
 [#738]: https://github.com/xi-editor/druid/pull/738
+[#759]: https://github.com/xi-editor/druid/pull/759
+[#763]: https://github.com/xi-editor/druid/pull/763
 [#782]: https://github.com/xi-editor/druid/pull/782
+[#784]: https://github.com/xi-editor/druid/pull/784
+[#785]: https://github.com/xi-editor/druid/pull/785
 [#796]: https://github.com/xi-editor/druid/pull/796
 [#797]: https://github.com/xi-editor/druid/pull/797
 [#798]: https://github.com/xi-editor/druid/pull/798
 [#808]: https://github.com/xi-editor/druid/pull/808
 [#814]: https://github.com/xi-editor/druid/pull/814
 [#816]: https://github.com/xi-editor/druid/pull/816
+[#817]: https://github.com/xi-editor/druid/pull/817
 [#818]: https://github.com/xi-editor/druid/pull/818
+[#819]: https://github.com/xi-editor/druid/pull/819
+[#821]: https://github.com/xi-editor/druid/pull/821
 [#825]: https://github.com/xi-editor/druid/pull/825
+[#831]: https://github.com/xi-editor/druid/pull/831
+[#832]: https://github.com/xi-editor/druid/pull/832
+[#833]: https://github.com/xi-editor/druid/pull/833
+[#837]: https://github.com/xi-editor/druid/pull/837
+[#839]: https://github.com/xi-editor/druid/pull/839
+[#841]: https://github.com/xi-editor/druid/pull/841
+[#845]: https://github.com/xi-editor/druid/pull/845
+[#847]: https://github.com/xi-editor/druid/pull/847
+[#850]: https://github.com/xi-editor/druid/pull/850
+[#851]: https://github.com/xi-editor/druid/pull/851
+[#855]: https://github.com/xi-editor/druid/pull/855
+[#861]: https://github.com/xi-editor/druid/pull/861
+[#869]: https://github.com/xi-editor/druid/pull/869
+[#878]: https://github.com/xi-editor/druid/pull/878
 
 ## [0.5] - 2020-04-01
 
 Last release without a changelog :(
 
 
-[@pyroxymat]: https://github.com/pyroxymat
-
-[@crsaracco]: https://github.com/crsaracco
-
-[@teddemunnik]: https://github.com/teddemunnik
-
-[@xStorm]: https://github.com/xStorm
-
-[@cmyr]: https://github.com/cmyr
-
-[@totsteps]: https://github.com/totsteps
-
-[@finnerale]: https://github.com/finnerale
-
 [@futurepaul]: https://github.com/futurepaul
-
-
+[@finnerale]: https://github.com/finnerale
+[@totsteps]: https://github.com/totsteps
+[@cmyr]: https://github.com/cmyr
+[@xStorm]: https://github.com/xStorm
+[@teddemunnik]: https://github.com/teddemunnik
+[@crsaracco]: https://github.com/crsaracco
+[@pyroxymat]: https://github.com/pyroxymat
+[@elrnv]: https://github.com/elrnv
+[@tedsta]: https://github.com/tedsta
+[@kindlychung]: https://github.com/kindlychung
+[@fishrockz]: https://github.com/fishrockz
+[@thecodewarrior]: https://github.com/thecodewarrior
+[@sjoshid]: https://github.com/sjoshid
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
-
 [0.5]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - `Event::MouseMoved` has been renamed to `MouseMove`. ([#825] by [@teddemunnik])
 
+- `has_focus` no longer returns false positives. ([#819] by [@xStorm])
+
 ### Deprecated
 
 ### Removed
@@ -53,6 +55,10 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - Mouse capturing on Windows. ([#695] by [@teddemunnik])
 
+- Focus cycling now works even starting from non-registered-for-focus widgets. ([#819] by [@xStorm])
+
+- `Event::FocusChanged` gets propagated to focus gaining widgets. ([#819] by [@xStorm])
+
 ### Visual
 - Improved `Split` accuracy. ([#738] by [@xStorm])
 
@@ -70,6 +76,7 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - A new project using druid: [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
 
+[#819]: https://github.com/xi-editor/druid/pull/819
 [#599]: https://github.com/xi-editor/druid/pull/599
 [#611]: https://github.com/xi-editor/druid/pull/611
 [#695]: https://github.com/xi-editor/druid/pull/695

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `WidgetPod::set_layout_rect` now requires `LayoutCtx`, data and `Env`. ([#841] by [@xStrom])
 - `request_timer` now uses `Duration` instead of `Instant`. ([#847] by [@finnerale])
 - Global `Application` associated functions are now instance methods instead, e.g. `Application::global().quit()` instead of the old `Application::quit()`. ([#763] by [@xStrom])
+- Timer events will only be delivered to the widgets that requested them. ([#831] by [@sjoshid])
 
 ### Deprecated
 
@@ -71,20 +72,19 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 ### Docs
 
 - Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
-- `Env` got a new example and usage hints. ([#796] by [@finnerale])
-- Usage of bloom filters got documented. ([#818] by [@xStrom])
-- Book chapters about `Painter` and `Controller` were added. ([#832] by [@cmyr])
+- Added example and usage hints to `Env`. ([#796] by [@finnerale])
+- Added documentation about the usage of bloom filters. ([#818] by [@xStrom])
+- Added Book chapters about `Painter` and `Controller`. ([#832] by [@cmyr])
 - Added hot glow option to multiwin example. ([#845] by [@xStrom])
 - Added new example for blocking functions. ([#840] by [@mastfissh])
 - Added a changelog containing development since the 0.5 release. ([#889] by [@finnerale])
 
 ### Maintenance
 
-- Replace `#[macro_use]` with normal `use`. ([#808] by [@totsteps])
-- Clippy checks are now enabled for all targets. ([#850] by [@xStrom])
+- Replaced `#[macro_use]` with normal `use`. ([#808] by [@totsteps])
+- Enabled Clippy checks for all targets. ([#850] by [@xStrom])
 - Added rendering tests. ([#784] by [@fishrockz])
-- CI testing has been revamped. ([#857] by [@xStrom])
-- Associate timers with widget ids. ([#831] by [@sjoshid])
+- Revamped CI testing to optimize coverage and speed. ([#857] by [@xStrom])
 
 ### Outside News
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Highlights
 
-- Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
+#### Basic X11 backend for druid-shell. ([#599])
+
+[@crsaracco] has implemented basic support to run druid on bare-metal X11!
+
+While still incomplete this lays the foundation for running druid on Linux without relying on GTK.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,9 +134,16 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#878]: https://github.com/xi-editor/druid/pull/878
 [#889]: https://github.com/xi-editor/druid/pull/899
 
-## [0.5] - 2020-04-01
+## [0.5.0] - 2020-04-01
 
 Last release without a changelog :(
+
+## [0.4.0] - 2019-12-28
+## [0.3.2] - 2019-11-05
+## [0.3.1] - 2019-11-04
+## 0.3.0 - 2019-11-02
+## 0.1.1 - 2018-11-02
+## 0.1.0 - 2018-11-02
 
 [@futurepaul]: https://github.com/futurepaul
 [@finnerale]: https://github.com/finnerale
@@ -156,4 +163,7 @@ Last release without a changelog :(
 [@mastfissh]: https://github.com/mastfissh
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
-[0.5]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0
+[0.5.0]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/xi-editor/druid/compare/v0.3.2...v0.4.0
+[0.3.2]: https://github.com/xi-editor/druid/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/xi-editor/druid/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased 0.6]
+## [Unreleased]
 
 ### Added
 
+- `TextBox` can receive `EditAction` commands ([#814](https://github.com/xi-editor/druid/pull/814) by [@cmyr])
+
 ### Changed
 
-### Depricated
+- `Split` constructors are now `Split::rows` and `columns`.
+  `Split` is now more accurate. ([#738](https://github.com/xi-editor/druid/pull/738) by [@xStorm])
+
+### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- Reduce the flashing in ext_event and identity examples ([#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul])
+- Reduce the flashing in ext_event and identity examples. ([#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul])
+
+- GTK uses the system locale. ([#798](https://github.com/xi-editor/druid/pull/798) by [@finnerale])
+
+- GTK windows get actually closed. ([#797](https://github.com/xi-editor/druid/pull/797) by [@finnerale])
+
+### Docs
+
+- `Env` got a new example and usage hints. ([#796](https://github.com/xi-editor/druid/pull/796) by [@finnerale])
+
+### Cleanups
+
+- Replace `#[macro_use]` with normal `use`. ([#808](https://github.com/xi-editor/druid/pull/808) by [@totsteps])
+
+### Outside News
+
+- A new project using druid: [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
 
 ## [0.5] - 2020-04-01
 
 Last release without a changelog :(
 
+
+[@xStorm]: https://github.com/xStorm
+
+[@cmyr]: https://github.com/cmyr
+
+[@totsteps]: https://github.com/totsteps
+
+[@finnerale]: https://github.com/finnerale
+
 [@futurepaul]: https://github.com/futurepaul
+
+
+
+[Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
+
+[0.5]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 ### Added
 
 - `TextBox` can receive `EditAction` commands. ([#814] by [@cmyr])
-- `Split::min_splitter_area(f64)` to add padding around the split bar. ([#738] by [@xStorm])
+- `Split::min_splitter_area(f64)` to add padding around the split bar. ([#738] by [@xStrom])
 - Published `druid::text` module. ([#816] by [@cmyr])
 - Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
 - `InternalEvent::MouseLeave` signalling the cursor leaved the window. ([#821] by [@teddemunnik])
-- `children_changed` now always includes layout and paint request. ([#839] by [@xStorm])
+- `children_changed` now always includes layout and paint request. ([#839] by [@xStrom])
 - Mostly complete Wasm backend for druid-shell. ([#759] by [@elrnv])
 - `UpdateCtx::submit_command`. ([#855] by [@cmyr])
 - `request_paint_rect` for partial invalidation. ([#817] by [@jneem])
@@ -37,12 +37,12 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 
 ### Changed
 
-- Renamed `Split` constructors to `Split::rows` and `columns`. ([#738] by [@xStorm])
-- `Split::splitter_size` no longer includes padding. ([#738] by [@xStorm])
+- Renamed `Split` constructors to `Split::rows` and `columns`. ([#738] by [@xStrom])
+- `Split::splitter_size` no longer includes padding. ([#738] by [@xStrom])
 - Renamed `Event::MouseMoved` to `MouseMove`. ([#825] by [@teddemunnik])
-- `has_focus` no longer returns false positives. ([#819] by [@xStorm])
-- `Event::Internal(InternalEvent)` now bundles all internal events. ([#833] by [@xStorm])
-- `WidgetPod::set_layout_rect` now requires `LayoutCtx`, data and `Env`. ([#841] by [@xStorm])
+- `has_focus` no longer returns false positives. ([#819] by [@xStrom])
+- `Event::Internal(InternalEvent)` now bundles all internal events. ([#833] by [@xStrom])
+- `WidgetPod::set_layout_rect` now requires `LayoutCtx`, data and `Env`. ([#841] by [@xStrom])
 - `request_timer` now uses `Duration` instead of `Instant`. ([#847] by [@finnerale])
 
 ### Deprecated
@@ -60,33 +60,33 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Windows: Respect the minimum window size. ([#727] by [@teddemunnik])
 - Windows: Respect resizability. ([#712] by [@teddemunnik])
 - Windows: Capture mouse for drag actions. ([#695] by [@teddemunnik])
-- Start focus cycling from non-registered-for-focus widgets. ([#819] by [@xStorm])
-- Propagate `Event::FocusChanged` to focus gaining widgets as well. ([#819] by [@xStorm])
+- Start focus cycling from non-registered-for-focus widgets. ([#819] by [@xStrom])
+- Propagate `Event::FocusChanged` to focus gaining widgets as well. ([#819] by [@xStrom])
 - GTK: Prevent crashing on pop-ups. ([#837] by [@finnerale])
-- Keep hot state  consistent with mouse position. ([#841] by [@xStorm])
+- Keep hot state  consistent with mouse position. ([#841] by [@xStrom])
 - Open file menu item works again. ([#851] by [@kindlychung])
 - Supply correct `LifeCycleCtx` to `Event::FocusChanged`. ([#878] by [@cmyr])
-- Windows: Termiate app when all windows have closed. ([#763] by [@xStorm])
+- Windows: Termiate app when all windows have closed. ([#763] by [@xStrom])
 
 ### Visual
 
-- Improved `Split` accuracy. ([#738] by [@xStorm])
+- Improved `Split` accuracy. ([#738] by [@xStrom])
 - Build-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
 
 ### Docs
 
 - Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
 - `Env` got a new example and usage hints. ([#796] by [@finnerale])
-- Usage of bloom filters got documented. ([#818] by [@xStorm])
+- Usage of bloom filters got documented. ([#818] by [@xStrom])
 - Book chapters about `Painter` and `Controller` were added. ([#832] by [@cmyr])
-- Added hot glow option to multiwin example. ([#845] by [@xStorm])
+- Added hot glow option to multiwin example. ([#845] by [@xStrom])
 
 ### Maintenance
 
 - Replace `#[macro_use]` with normal `use`. ([#808] by [@totsteps])
-- Clippy checks are now enabled for all targets. ([#850] by [@xStorm])
+- Clippy checks are now enabled for all targets. ([#850] by [@xStrom])
 - Added rendering tests. ([#784] by [@fishrockz])
-- CI testing has been revamped. ([#857] by [@xStorm])
+- CI testing has been revamped. ([#857] by [@xStrom])
 - Associate timers with widget ids. ([#831] by [@sjoshid])
 - Add a changelog. ([#889] by [@finnerale])
 
@@ -144,7 +144,7 @@ Last release without a changelog :(
 [@finnerale]: https://github.com/finnerale
 [@totsteps]: https://github.com/totsteps
 [@cmyr]: https://github.com/cmyr
-[@xStorm]: https://github.com/xStorm
+[@xStrom]: https://github.com/xStrom
 [@teddemunnik]: https://github.com/teddemunnik
 [@crsaracco]: https://github.com/crsaracco
 [@pyroxymat]: https://github.com/pyroxymat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,41 +24,25 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 ### Added
 
 - `TextBox` can receive `EditAction` commands. ([#814] by [@cmyr])
-
 - `Split::min_splitter_area(f64)` to add padding around the split bar. ([#738] by [@xStorm])
-
 - Published `druid::text` module. ([#816] by [@cmyr])
-
 - Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
-
 - `InternalEvent::MouseLeave` signalling the cursor leaved the window. ([#821] by [@teddemunnik])
-
 - `children_changed` now always includes layout and paint request. ([#839] by [@xStorm])
-
 - Mostly complete Wasm backend for druid-shell. ([#759] by [@elrnv])
-
 - `UpdateCtx::submit_command`. ([#855] by [@cmyr])
-
 - `request_paint_rect` for partial invalidation. ([#817] by [@jneem])
-
 - Window title can be any `LabelText` (such as a simple `String`). ([#869] by [@cmyr])
-
 - `Label::with_font` and `set_font`. ([#785] by [@thecodewarrior])
 
 ### Changed
 
 - Renamed `Split` constructors to `Split::rows` and `columns`. ([#738] by [@xStorm])
-
 - `Split::splitter_size` no longer includes padding. ([#738] by [@xStorm])
-
 - Renamed `Event::MouseMoved` to `MouseMove`. ([#825] by [@teddemunnik])
-
 - `has_focus` no longer returns false positives. ([#819] by [@xStorm])
-
 - `Event::Internal(InternalEvent)` now bundles all internal events. ([#833] by [@xStorm])
-
 - `WidgetPod::set_layout_rect` now requires `LayoutCtx`, data and `Env`. ([#841] by [@xStorm])
-
 - `request_timer` now uses `Duration` instead of `Instant`. ([#847] by [@finnerale])
 
 ### Deprecated
@@ -72,59 +56,38 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 ### Fixed
 
 - GTK: Use the system locale. ([#798] by [@finnerale])
-
 - GTK: Actually close windows ([#797] by [@finnerale])
-
 - Windows: Respect the minimum window size. ([#727] by [@teddemunnik])
-
 - Windows: Respect resizability. ([#712] by [@teddemunnik])
-
 - Windows: Capture mouse for drag actions. ([#695] by [@teddemunnik])
-
 - Start focus cycling from non-registered-for-focus widgets. ([#819] by [@xStorm])
-
 - Propagate `Event::FocusChanged` to focus gaining widgets as well. ([#819] by [@xStorm])
-
 - GTK: Prevent crashing on pop-ups. ([#837] by [@finnerale])
-
 - Keep hot state  consistent with mouse position. ([#841] by [@xStorm])
-
 - Open file menu item works again. ([#851] by [@kindlychung])
-
 - Supply correct `LifeCycleCtx` to `Event::FocusChanged`. ([#878] by [@cmyr])
-
 - Windows: Termiate app when all windows have closed. ([#763] by [@xStorm])
 
 ### Visual
 
 - Improved `Split` accuracy. ([#738] by [@xStorm])
-
 - Build-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
 
 ### Docs
 
 - Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
-
 - `Env` got a new example and usage hints. ([#796] by [@finnerale])
-
 - Usage of bloom filters got documented. ([#818] by [@xStorm])
-
 - Book chapters about `Painter` and `Controller` were added. ([#832] by [@cmyr])
-
 - Added hot glow option to multiwin example. ([#845] by [@xStorm])
 
 ### Maintenance
 
 - Replace `#[macro_use]` with normal `use`. ([#808] by [@totsteps])
-
 - Clippy checks are now enabled for all targets. ([#850] by [@xStorm])
-
 - Added rendering tests. ([#784] by [@fishrockz])
-
 - CI testing has been revamped. ([#857] by [@xStorm])
-
 - Associate timers with widget ids. ([#831] by [@sjoshid])
-
 - Add a changelog. ([#889] by [@finnerale])
 
 ### Outside News

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Usage of bloom filters got documented. ([#818] by [@xStrom])
 - Book chapters about `Painter` and `Controller` were added. ([#832] by [@cmyr])
 - Added hot glow option to multiwin example. ([#845] by [@xStrom])
+- Added new example for blocking functions. ([#840] by [@mastfissh])
+- Added a changelog containing development since the 0.5 release. ([#889] by [@finnerale])
 
 ### Maintenance
 
@@ -83,13 +85,13 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Added rendering tests. ([#784] by [@fishrockz])
 - CI testing has been revamped. ([#857] by [@xStrom])
 - Associate timers with widget ids. ([#831] by [@sjoshid])
-- Added a changelog containing development since the 0.5 release. ([#889] by [@finnerale])
 
 ### Outside News
 
 - There are two new projects using druid:
     - [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
     - [jack-mixer](https://github.com/derekdreery/jack-mixer) A jack client that provides mixing, levels and a 3-band eq.
+
 
 [#599]: https://github.com/xi-editor/druid/pull/599
 [#611]: https://github.com/xi-editor/druid/pull/611
@@ -118,6 +120,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#833]: https://github.com/xi-editor/druid/pull/833
 [#837]: https://github.com/xi-editor/druid/pull/837
 [#839]: https://github.com/xi-editor/druid/pull/839
+[#840]: https://github.com/xi-editor/druid/pull/840
 [#841]: https://github.com/xi-editor/druid/pull/841
 [#845]: https://github.com/xi-editor/druid/pull/845
 [#847]: https://github.com/xi-editor/druid/pull/847
@@ -150,8 +153,7 @@ Last release without a changelog :(
 [@fishrockz]: https://github.com/fishrockz
 [@thecodewarrior]: https://github.com/thecodewarrior
 [@sjoshid]: https://github.com/sjoshid
+[@mastfissh]: https://github.com/mastfissh
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
 [0.5]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,10 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `Split::splitter_size` no longer includes padding. ([#738] by [@xStrom])
 - Renamed `Event::MouseMoved` to `MouseMove`. ([#825] by [@teddemunnik])
 - `has_focus` no longer returns false positives. ([#819] by [@xStrom])
-- `Event::Internal(InternalEvent)` now bundles all internal events. ([#833] by [@xStrom])
+- `Event::Internal(InternalEvent)` bundles all internal events. ([#833] by [@xStrom])
 - `WidgetPod::set_layout_rect` now requires `LayoutCtx`, data and `Env`. ([#841] by [@xStrom])
-- `request_timer` now uses `Duration` instead of `Instant`. ([#847] by [@finnerale])
-- Global `Application` associated functions are now instance methods instead, e.g. `Application::global().quit()` instead of the old `Application::quit()`. ([#763] by [@xStrom])
+- `request_timer` uses `Duration` instead of `Instant`. ([#847] by [@finnerale])
+- Global `Application` associated functions are instance methods instead, e.g. `Application::global().quit()` instead of the old `Application::quit()`. ([#763] by [@xStrom])
 - Timer events will only be delivered to the widgets that requested them. ([#831] by [@sjoshid])
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#850]: https://github.com/xi-editor/druid/pull/850
 [#851]: https://github.com/xi-editor/druid/pull/851
 [#855]: https://github.com/xi-editor/druid/pull/855
+[#857]: https://github.com/xi-editor/druid/pull/857
 [#861]: https://github.com/xi-editor/druid/pull/861
 [#869]: https://github.com/xi-editor/druid/pull/869
 [#878]: https://github.com/xi-editor/druid/pull/878

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 
 - Added hot glow option to multiwin example. ([#845] by [@xStorm])
 
-### Cleanups
+### Maintenance
 
 - Replace `#[macro_use]` with normal `use`. ([#808] by [@totsteps])
 
@@ -127,7 +127,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 
 ### Outside News
 
-- Two new projects using druid:
+- There are two new projects using druid:
     - [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
     - [jack-mixer](https://github.com/derekdreery/jack-mixer) A jack client that provides mixing, levels and a 3-band eq.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `TextBox` can receive `EditAction` commands
-  ([#814](https://github.com/xi-editor/druid/pull/814) by [@cmyr])
+- `TextBox` can receive `EditAction` commands ([#814] by [@cmyr])
 
 ### Changed
 
-- `Split` constructors are now `Split::rows` and `columns`.
-  `Split` is more accurate as well.
-  ([#738](https://github.com/xi-editor/druid/pull/738) by [@xStorm])
+- `Split` constructors are now `Split::rows` and `columns`. ([#738] by [@xStorm])
 
 ### Deprecated
 
@@ -24,28 +21,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reduce the flashing in ext_event and identity examples.
-  ([#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul])
+- Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
 
-- GTK uses the system locale.
-  ([#798](https://github.com/xi-editor/druid/pull/798) by [@finnerale])
+- GTK uses the system locale. ([#798] by [@finnerale])
 
-- GTK windows get actually closed.
-  ([#797](https://github.com/xi-editor/druid/pull/797) by [@finnerale])
+- GTK windows get actually closed. ([#797] by [@finnerale])
+
+### Visual
+- Improved `Split` accuracy. ([#738] by [@xStorm])
 
 ### Docs
 
-- `Env` got a new example and usage hints.
-  ([#796](https://github.com/xi-editor/druid/pull/796) by [@finnerale])
+- `Env` got a new example and usage hints. ([#796] by [@finnerale])
 
 ### Cleanups
 
-- Replace `#[macro_use]` with normal `use`.
-  ([#808](https://github.com/xi-editor/druid/pull/808) by [@totsteps])
+- Replace `#[macro_use]` with normal `use`. ([#808] by [@totsteps])
 
 ### Outside News
 
 - A new project using druid: [Kondo](https://github.com/tbillington/kondo) Save disk space by cleaning unneeded files from software projects.
+
+[#738]: https://github.com/xi-editor/druid/pull/738
+[#782]: https://github.com/xi-editor/druid/pull/782
+[#796]: https://github.com/xi-editor/druid/pull/796
+[#797]: https://github.com/xi-editor/druid/pull/797
+[#798]: https://github.com/xi-editor/druid/pull/798
+[#808]: https://github.com/xi-editor/druid/pull/808
+[#814]: https://github.com/xi-editor/druid/pull/814
 
 ## [0.5] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reduce the flashing in ext_event and identity examples [#782](https://github.com/xi-editor/druid/pull/782) by @futurepaul
+- Reduce the flashing in ext_event and identity examples [#782](https://github.com/xi-editor/druid/pull/782) by [@futurepaul]
 
 ## [0.5] - 2020-04-01
 
 Last release without a changelog :(
+
+[@futurepaul]: https://github.com/futurepaul
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,19 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - `TextBox` can receive `EditAction` commands. ([#814] by [@cmyr])
 
-- Added `Split::min_splitter_area(f64)` to add padding around the split bar. ([#738] by [@xStorm])
+- `Split::min_splitter_area(f64)` to add padding around the split bar. ([#738] by [@xStorm])
 
-- The `druid::text` module is public now. ([#816] by [@cmyr])
+- Published `druid::text` module. ([#816] by [@cmyr])
 
 - Basic X11 backend for druid-shell. ([#599] by [@crsaracco])
 
 ### Changed
 
-- `Split` constructors are now called `Split::rows` and `columns`. ([#738] by [@xStorm])
+- Renamed `Split` constructors to `Split::rows` and `columns`. ([#738] by [@xStorm])
 
 - `Split::splitter_size` no longer includes padding. ([#738] by [@xStorm])
 
-- `Event::MouseMoved` has been renamed to `MouseMove`. ([#825] by [@teddemunnik])
+- Renamed `Event::MouseMoved` to `MouseMove`. ([#825] by [@teddemunnik])
 
 - `has_focus` no longer returns false positives. ([#819] by [@xStorm])
 
@@ -45,19 +45,19 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 - Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
 
-- GTK uses the system locale. ([#798] by [@finnerale])
+- GTK: Use the system locale. ([#798] by [@finnerale])
 
-- GTK windows get actually closed. ([#797] by [@finnerale])
+- GTK: Actually close windows ([#797] by [@finnerale])
 
-- Windows now respects the minimum window size. ([#727] by [@teddemunnik])
+- Windows: Respect the minimum window size. ([#727] by [@teddemunnik])
 
-- Windows now respects resizability. ([#712] by [@teddemunnik])
+- Windows: Respect resizability. ([#712] by [@teddemunnik])
 
-- Mouse capturing on Windows. ([#695] by [@teddemunnik])
+- Windows: Capture mouse for drag actions. ([#695] by [@teddemunnik])
 
-- Focus cycling now works even starting from non-registered-for-focus widgets. ([#819] by [@xStorm])
+- Start focus cycling from non-registered-for-focus widgets. ([#819] by [@xStorm])
 
-- `Event::FocusChanged` gets propagated to focus gaining widgets. ([#819] by [@xStorm])
+- Propagate `Event::FocusChanged` to focus gaining widgets as well. ([#819] by [@xStorm])
 
 ### Visual
 - Improved `Split` accuracy. ([#738] by [@xStorm])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 
 - Associate timers with widget ids. ([#831] by [@sjoshid])
 
+- Add a changelog. ([#889] by [@finnerale])
+
 ### Outside News
 
 - There are two new projects using druid:
@@ -168,6 +170,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#861]: https://github.com/xi-editor/druid/pull/861
 [#869]: https://github.com/xi-editor/druid/pull/869
 [#878]: https://github.com/xi-editor/druid/pull/878
+[#889]: https://github.com/xi-editor/druid/pull/899
 
 ## [0.5] - 2020-04-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,15 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult [GitHub Help] for more
 information on using pull requests.
 
+Every pull request should document all changes made in the [changelog].
+- The format is always `- [what changed]. ([#pr-number] by [@username])`.
+- The number can be guessed or added after creating the pull request.
+- Links to all pull requests are recorded at the bottom of the unreleased section.
+- If you are a new contributor, please add your name to the others at the bottom of the CHANGELOG.md.
+
 If your name does not already appear in the [AUTHORS] file, please feel free to
 add it as part of your patch.
 
 [GitHub Help]: https://help.github.com/articles/about-pull-requests/
 [AUTHORS]: AUTHORS
+[changelog]: CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Druid's current development is largely driven by its use in [Runebender], a new
 font editor.
 
 We have been doing periodic releases of druid on crates.io, but it is under
-active development and its API might change.
+active development and its API might change. All changes are documented
+in [the changelog](https://github.com/xi-editor/druid/blob/master/CHANGELOG.md).
 
 For an overview of some key concepts, see the (work in progress) [druid book].
 


### PR DESCRIPTION
This introduces an in-tree changelog base on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

Whenever a new PR ist created it should contain changelog entries for everything it changes, thus keeping the changelog always in sync with `master`.

Every changelog entry is annotated with the PR that introduced it and the author for attribution.

The attribution is also the reason why the `Maintenance` section exists, even though entries in it have no *direct* impact on users.

Annotating entries with a link to the introducing PR causes a chicken-and-egg problem tho.
When creating the PR you wont know the number yet, which you need to refer to it.
Having a quick link to the related PR seems very useful however as it provides much more information about the change than the changelog ever could.

See [Zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Bookkeeping.20about.20breaking.20changes) for previous discussion.