### PR TITLE
Refactor GTK Application to make use of the new structure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Enabled Clippy checks for all targets. ([#850] by [@xStrom])
 - Added rendering tests. ([#784] by [@fishrockz])
 - Revamped CI testing to optimize coverage and speed. ([#857] by [@xStrom])
+- GTK: Refactored `Application` to use the new structure. ([#892] by [@xStrom])
 - X11: Refactored `Application` to use the new structure. ([#894] by [@xStrom])
 - X11: Refactored `Window` to support some reentrancy and invalidation. ([#894] by [@xStrom])
 
@@ -137,7 +138,8 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#861]: https://github.com/xi-editor/druid/pull/861
 [#869]: https://github.com/xi-editor/druid/pull/869
 [#878]: https://github.com/xi-editor/druid/pull/878
-[#889]: https://github.com/xi-editor/druid/pull/899
+[#889]: https://github.com/xi-editor/druid/pull/889
+[#892]: https://github.com/xi-editor/druid/pull/892
 [#894]: https://github.com/xi-editor/druid/pull/894
 
 ## [0.5.0] - 2020-04-01

--- a/druid-shell/src/platform/gtk/error.rs
+++ b/druid-shell/src/platform/gtk/error.rs
@@ -14,14 +14,26 @@
 
 //! GTK platform errors.
 
-//TODO: add a platform error for GTK
+use std::fmt;
 
+use glib::{BoolError, Error as GLibError};
+
+/// GTK platform errors.
 #[derive(Debug, Clone)]
-pub struct Error;
+pub enum Error {
+    /// Generic GTK error.
+    Error(GLibError),
+    /// GTK error that has no information provided by GTK,
+    /// but may have extra information provided by gtk-rs.
+    BoolError(BoolError),
+}
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "GTK Error")
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Error::Error(err) => write!(f, "GTK Error: {}", err),
+            Error::BoolError(err) => write!(f, "GTK BoolError: {}", err),
+        }
     }
 }
 


### PR DESCRIPTION
#763 introduced a new instance based `Application` structure. This PR refactors the GTK `Application` code to make use of it, as well as adding better error reporting and removing duplicate thread assertions.