### PR TITLE
Refactor X11 Application to make use of the new structure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Added rendering tests. ([#784] by [@fishrockz])
 - Revamped CI testing to optimize coverage and speed. ([#857] by [@xStrom])
 - X11: Refactored `Application` to use the new structure. ([#894] by [@xStrom])
+- X11: Refactored `Window` to support some reentrancy and invalidation. ([#894] by [@xStrom])
 
 ### Outside News
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Enabled Clippy checks for all targets. ([#850] by [@xStrom])
 - Added rendering tests. ([#784] by [@fishrockz])
 - Revamped CI testing to optimize coverage and speed. ([#857] by [@xStrom])
+- X11: Refactored `Application` to use the new structure. ([#894] by [@xStrom])
 
 ### Outside News
 
@@ -136,6 +137,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#869]: https://github.com/xi-editor/druid/pull/869
 [#878]: https://github.com/xi-editor/druid/pull/878
 [#889]: https://github.com/xi-editor/druid/pull/899
+[#894]: https://github.com/xi-editor/druid/pull/894
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -34,8 +34,6 @@ pub(crate) struct Application {
 }
 
 struct State {
-    // TODO: Figure out a better solution for window event passing,
-    //       because this approach has reentrancy issues with window creation etc.
     windows: HashMap<u32, Rc<Window>>,
 }
 

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -17,7 +17,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use crate::application::AppHandler;
 use crate::kurbo::{Point, Rect};
@@ -25,11 +24,11 @@ use crate::{KeyCode, KeyModifiers, MouseButton, MouseButtons, MouseEvent};
 
 use super::clipboard::Clipboard;
 use super::error::Error;
-use super::window::XWindow;
+use super::window::Window;
 
 #[derive(Clone)]
 pub(crate) struct Application {
-    connection: Arc<xcb::Connection>,
+    connection: Rc<xcb::Connection>,
     screen_num: i32, // Needs a container when no longer const
     state: Rc<RefCell<State>>,
 }
@@ -37,7 +36,7 @@ pub(crate) struct Application {
 struct State {
     // TODO: Figure out a better solution for window event passing,
     //       because this approach has reentrancy issues with window creation etc.
-    windows: HashMap<u32, XWindow>,
+    windows: HashMap<u32, Rc<Window>>,
 }
 
 impl Application {
@@ -50,23 +49,40 @@ impl Application {
             windows: HashMap::new(),
         }));
         Ok(Application {
-            connection: Arc::new(conn),
+            connection: Rc::new(conn),
             screen_num,
             state,
         })
     }
 
-    pub(crate) fn add_window(&self, id: u32, xwindow: XWindow) {
-        self.state.borrow_mut().windows.insert(id, xwindow);
+    pub(crate) fn add_window(&self, id: u32, window: Rc<Window>) {
+        if let Ok(mut state) = self.state.try_borrow_mut() {
+            state.windows.insert(id, window);
+        } else {
+            log::warn!("Application::add_window - state already borrowed");
+        }
     }
 
     #[allow(dead_code)]
     pub(crate) fn remove_window(&self, id: u32) {
-        self.state.borrow_mut().windows.remove(&id);
+        if let Ok(mut state) = self.state.try_borrow_mut() {
+            state.windows.remove(&id);
+        } else {
+            log::warn!("Application::remove_window - state already borrowed");
+        }
+    }
+
+    pub(crate) fn window(&self, id: u32) -> Option<Rc<Window>> {
+        if let Ok(state) = self.state.try_borrow() {
+            state.windows.get(&id).map(|w| w.clone())
+        } else {
+            log::warn!("Application::window - state already borrowed");
+            None
+        }
     }
 
     #[inline]
-    pub(crate) fn connection(&self) -> &Arc<xcb::Connection> {
+    pub(crate) fn connection(&self) -> &Rc<xcb::Connection> {
         &self.connection
     }
 
@@ -98,27 +114,21 @@ impl Application {
                             (expose.x() as f64, expose.y() as f64),
                             (expose.width() as f64, expose.height() as f64),
                         );
-                        if let Ok(mut state) = self.state.try_borrow_mut() {
-                            if let Some(w) = state.windows.get_mut(&window_id) {
-                                w.render(rect);
-                            }
+                        if let Some(w) = self.window(window_id) {
+                            w.render(rect);
                         } else {
-                            log::warn!("Application state already borrowed");
+                            log::warn!("EXPOSE - failed to get window");
                         }
                     }
                     xcb::KEY_PRESS => {
                         let key_press: &xcb::KeyPressEvent = unsafe { xcb::cast_event(&ev) };
                         let key: u32 = key_press.detail() as u32;
                         let key_code: KeyCode = key.into();
-
                         let window_id = key_press.event();
-                        println!("window_id {}", window_id);
-                        if let Ok(mut state) = self.state.try_borrow_mut() {
-                            if let Some(w) = state.windows.get_mut(&window_id) {
-                                w.key_down(key_code);
-                            }
+                        if let Some(w) = self.window(window_id) {
+                            w.key_down(key_code);
                         } else {
-                            log::warn!("Application state already borrowed");
+                            log::warn!("KEY_PRESS - failed to get window");
                         }
                     }
                     xcb::BUTTON_PRESS => {
@@ -140,12 +150,10 @@ impl Application {
                             count: 0,
                             button: MouseButton::Left,
                         };
-                        if let Ok(mut state) = self.state.try_borrow_mut() {
-                            if let Some(w) = state.windows.get_mut(&window_id) {
-                                w.mouse_down(&mouse_event);
-                            }
+                        if let Some(w) = self.window(window_id) {
+                            w.mouse_down(&mouse_event);
                         } else {
-                            log::warn!("Application state already borrowed");
+                            log::warn!("BUTTON_PRESS - failed to get window");
                         }
                     }
                     xcb::BUTTON_RELEASE => {
@@ -168,12 +176,10 @@ impl Application {
                             count: 0,
                             button: MouseButton::Left,
                         };
-                        if let Ok(mut state) = self.state.try_borrow_mut() {
-                            if let Some(w) = state.windows.get_mut(&window_id) {
-                                w.mouse_up(&mouse_event);
-                            }
+                        if let Some(w) = self.window(window_id) {
+                            w.mouse_up(&mouse_event);
                         } else {
-                            log::warn!("Application state already borrowed");
+                            log::warn!("BUTTON_RELEASE - failed to get window");
                         }
                     }
                     xcb::MOTION_NOTIFY => {
@@ -195,12 +201,10 @@ impl Application {
                             count: 0,
                             button: MouseButton::None,
                         };
-                        if let Ok(mut state) = self.state.try_borrow_mut() {
-                            if let Some(w) = state.windows.get_mut(&window_id) {
-                                w.mouse_move(&mouse_event);
-                            }
+                        if let Some(w) = self.window(window_id) {
+                            w.mouse_move(&mouse_event);
                         } else {
-                            log::warn!("Application state already borrowed");
+                            log::warn!("MOTION_NOTIFY - failed to get window");
                         }
                     }
                     _ => {}

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -65,10 +65,12 @@ impl Application {
         self.state.borrow_mut().windows.remove(&id);
     }
 
+    #[inline]
     pub(crate) fn connection(&self) -> &Arc<xcb::Connection> {
         &self.connection
     }
 
+    #[inline]
     pub(crate) fn screen_num(&self) -> i32 {
         self.screen_num
     }

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -72,7 +72,7 @@ impl Application {
 
     pub(crate) fn window(&self, id: u32) -> Option<Rc<Window>> {
         if let Ok(state) = self.state.try_borrow() {
-            state.windows.get(&id).map(|w| w.clone())
+            state.windows.get(&id).cloned()
         } else {
             log::warn!("Application::window - state already borrowed");
             None

--- a/druid-shell/src/platform/x11/error.rs
+++ b/druid-shell/src/platform/x11/error.rs
@@ -18,15 +18,20 @@ use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum Error {
+    // Generic error
+    Generic(String),
     // TODO: Replace String with xcb::ConnError once that gets Clone support
     ConnectionError(String),
-    // TODO(x11/errors): Add more `Error`s for X11
+    // Runtime borrow failure
+    BorrowError(String),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
+            Error::Generic(msg) => write!(f, "Error: {}", msg),
             Error::ConnectionError(err) => write!(f, "Connection error: {}", err),
+            Error::BorrowError(msg) => write!(f, "Borrow error: {}", msg),
         }
     }
 }

--- a/druid-shell/src/platform/x11/error.rs
+++ b/druid-shell/src/platform/x11/error.rs
@@ -18,14 +18,17 @@ use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum Error {
-    // TODO(x11/errors): enumerate `Error`s for X11
-    NoError,
+    // TODO: Replace String with xcb::ConnError once that gets Clone support
+    ConnectionError(String),
+    // TODO(x11/errors): Add more `Error`s for X11
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        // TODO(x11/errors): implement Error::fmt
-        log::warn!("Error::fmt is currently unimplemented for X11 platforms.");
-        write!(f, "X11 Error")
+        match self {
+            Error::ConnectionError(err) => write!(f, "Connection error: {}", err),
+        }
     }
 }
+
+impl std::error::Error for Error {}

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -235,9 +235,10 @@ impl Window {
         match self.cairo_context.try_borrow() {
             Ok(ctx) => match ctx.get_target().try_into() {
                 Ok(surface) => Ok(surface),
-                Err(err) => Err(Error::Generic(
-                    format!("try_into in Window::cairo_surface: {}", err),
-                )),
+                Err(err) => Err(Error::Generic(format!(
+                    "try_into in Window::cairo_surface: {}",
+                    err
+                ))),
             },
             Err(_) => Err(Error::BorrowError(
                 "cairo context in Window::cairo_surface".into(),

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -181,15 +181,13 @@ impl Window {
         let refresh_rate = util::refresh_rate(app.connection(), id);
         let handler = RefCell::new(handler);
         let state = RefCell::new(WindowState { size });
-        let window = Window {
+        Window {
             id,
             app,
             handler,
             refresh_rate,
             state,
-        };
-
-        window
+        }
     }
 
     pub fn connect(&self, handle: WindowHandle) {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -341,7 +341,6 @@ impl Window {
     }
 
     fn close(&self) {
-        // Hopefully there aren't any references to this window after this function is called.
         xcb::destroy_window(self.app.connection(), self.id);
     }
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -416,7 +416,6 @@ impl WindowHandle {
 
     pub fn set_cursor(&mut self, _cursor: &Cursor) {
         // TODO(x11/cursors): implement WindowHandle::set_cursor
-        //log::warn!("WindowHandle::set_cursor is currently unimplemented for X11 platforms.");
     }
 
     pub fn open_file_sync(&mut self, _options: FileDialogOptions) -> Option<FileInfo> {

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -304,14 +304,16 @@ impl Window {
         let mut anim = false;
         if let Ok(mut cairo_ctx) = self.cairo_context.try_borrow_mut() {
             let mut piet_ctx = Piet::new(&mut cairo_ctx);
+            piet_ctx.clip(invalid_rect);
             if let Ok(mut handler) = self.handler.try_borrow_mut() {
                 anim = handler.paint(&mut piet_ctx, invalid_rect);
             } else {
                 log::warn!("Window::render - handler already borrowed");
             }
             if let Err(e) = piet_ctx.finish() {
-                log::error!("piet finish failed: {}", e);
+                log::error!("Window::render - piet finish failed: {}", e);
             }
+            cairo_ctx.reset_clip();
         } else {
             log::warn!("Window::render - cairo context already borrowed");
         }

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -310,8 +310,7 @@ impl Window {
                 log::warn!("Window::render - handler already borrowed");
             }
             if let Err(e) = piet_ctx.finish() {
-                // TODO(x11/errors): hook up to error or something?
-                panic!("piet error on render: {:?}", e);
+                log::error!("piet finish failed: {}", e);
             }
         } else {
             log::warn!("Window::render - cairo context already borrowed");

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -321,6 +321,10 @@ impl Window {
             // TODO(x11/render_improvements): Sleeping is a terrible way to schedule redraws.
             //     I think I'll end up having to write a redraw scheduler or something. :|
             //     Doing it this way for now to proof-of-concept it.
+            //
+            // Eventually we also need to make sure we respect V-Sync timings.
+            // A druid-shell test utility should probably be written to verify that.
+            // Inspiration can be taken from: https://www.vsynctester.com/we
             let sleep_amount_ms = (1000.0 / self.refresh_rate.unwrap()) as u64;
             std::thread::sleep(std::time::Duration::from_millis(sleep_amount_ms));
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -153,7 +153,7 @@ impl WindowBuilder {
 
         let handler = self.handler.unwrap();
         let window = Rc::new(Window::new(window_id, self.app.clone(), handler, self.size));
-        let handle = WindowHandle::new(Rc::downgrade(&window));
+        let handle = WindowHandle::new(window_id, Rc::downgrade(&window));
         window.connect(handle.clone());
 
         self.app.add_window(window_id, window);
@@ -486,65 +486,84 @@ impl IdleHandle {
 
 #[derive(Clone, Default)]
 pub(crate) struct WindowHandle {
+    id: u32,
     window: Weak<Window>,
 }
 
 impl WindowHandle {
-    fn new(window: Weak<Window>) -> WindowHandle {
-        WindowHandle { window }
+    fn new(id: u32, window: Weak<Window>) -> WindowHandle {
+        WindowHandle { id, window }
     }
 
     pub fn show(&self) {
         if let Some(w) = self.window.upgrade() {
             w.show();
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn close(&self) {
         if let Some(w) = self.window.upgrade() {
             w.close();
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn resizable(&self, resizable: bool) {
         if let Some(w) = self.window.upgrade() {
             w.resizable(resizable);
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn show_titlebar(&self, show_titlebar: bool) {
         if let Some(w) = self.window.upgrade() {
             w.show_titlebar(show_titlebar);
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn bring_to_front_and_focus(&self) {
         if let Some(w) = self.window.upgrade() {
             w.bring_to_front_and_focus();
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn invalidate(&self) {
         if let Some(w) = self.window.upgrade() {
             w.invalidate();
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn invalidate_rect(&self, rect: Rect) {
         if let Some(w) = self.window.upgrade() {
             w.invalidate_rect(rect);
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn set_title(&self, title: &str) {
         if let Some(w) = self.window.upgrade() {
             w.set_title(title);
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
     pub fn set_menu(&self, menu: Menu) {
         if let Some(w) = self.window.upgrade() {
             w.set_menu(menu);
+        } else {
+            log::warn!("Window {} has already been dropped", self.id);
         }
     }
 
@@ -592,6 +611,7 @@ impl WindowHandle {
         if let Some(w) = self.window.upgrade() {
             w.get_dpi()
         } else {
+            log::warn!("Window {} has already been dropped", self.id);
             96.0
         }
     }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -83,6 +83,8 @@ fn ui_builder() -> impl Widget<State> {
     let mut row = Flex::row();
     row.add_child(Padding::new(5.0, inc_button));
     row.add_child(Padding::new(5.0, dec_button));
+    col.add_flex_child(Align::centered(row), 1.0);
+    let mut row = Flex::row();
     row.add_child(Padding::new(5.0, new_button));
     col.add_flex_child(Align::centered(row), 1.0);
     Glow::new(col)

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -74,12 +74,16 @@ fn ui_builder() -> impl Widget<State> {
         data.menu_count = data.menu_count.saturating_sub(1);
         ctx.set_menu(make_menu::<State>(data));
     });
+    let new_button = Button::<State>::new("New window").on_click(|ctx, _data, _env| {
+        ctx.submit_command(sys_cmds::NEW_FILE, Target::Global);
+    });
 
     let mut col = Flex::column();
     col.add_flex_child(Align::centered(Padding::new(5.0, label)), 1.0);
     let mut row = Flex::row();
     row.add_child(Padding::new(5.0, inc_button));
     row.add_child(Padding::new(5.0, dec_button));
+    row.add_child(Padding::new(5.0, new_button));
     col.add_flex_child(Align::centered(row), 1.0);
     Glow::new(col)
 }


### PR DESCRIPTION
#763 introduced a new instance based `Application` structure. This PR refactors the X11 `Application` code to make use of it, as well as adding better error reporting.

The `windows` map has reentrancy issues. Those were already there and this PR makes no attempt at solving them. I just merely refactored it to the new `Application` style.