### PR TITLE
Expose Scroll's child_size

### DIFF
--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -154,7 +154,7 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         self.child.widget_mut()
     }
 
-    /// Returns a size of the child widget.
+    /// Returns the size of the child widget.
     pub fn child_size(&self) -> Size {
         self.child_size
     }

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -154,6 +154,11 @@ impl<T, W: Widget<T>> Scroll<T, W> {
         self.child.widget_mut()
     }
 
+    /// Returns a size of the child widget.
+    pub fn child_size(&self) -> Size {
+        self.child_size
+    }
+
     /// Update the scroll.
     ///
     /// Returns `true` if the scroll has been updated.


### PR DESCRIPTION
This is useful when you want to update scroll offset from the parent widget.

I might not be doing it correctly though :) This is my code in the parent
widget. Where `inner` is a `Scroll` widget.

```rust
let offset = self.inner.offset();
let new_offset = Vec2::new(0., self.inner.child_size().height - self.size.height);
self.inner.scroll(new_offset - offset, Size::ZERO);
```