### PR TITLE
Add UpdateCtx::request_timer and request_anim_frame.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `Label::with_font` and `set_font`. ([#785] by [@thecodewarrior])
 - `InternalEvent::RouteTimer` to route timer events. ([#831] by [@sjoshid])
 - `MouseButtons` to `MouseEvent` to track which buttons are being held down during an event. ([#843] by [@xStrom])
+- `UpdateCtx::request_timer` and `UpdateCtx::request_anim_frame`. ([#898] by [@finnerale])
 
 ### Changed
 
@@ -72,6 +73,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 
 - Improved `Split` accuracy. ([#738] by [@xStrom])
 - Built-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
+- `Switch` toggles with animation when its data changes externally. ([#898] by [@finnerale])
 
 ### Docs
 
@@ -139,6 +141,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#878]: https://github.com/xi-editor/druid/pull/878
 [#889]: https://github.com/xi-editor/druid/pull/899
 [#894]: https://github.com/xi-editor/druid/pull/894
+[#898]: https://github.com/xi-editor/druid/pull/898
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/examples/switch.rs
+++ b/druid/examples/switch.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use druid::widget::{
-    Flex, Label, MainAxisAlignment, Padding, Parse, Stepper, Switch, TextBox, WidgetExt,
+    Checkbox, Flex, Label, MainAxisAlignment, Padding, Parse, Stepper, Switch, TextBox, WidgetExt,
 };
 use druid::{AppLauncher, Data, Lens, LensExt, LensWrap, LocalizedString, Widget, WindowDesc};
 
@@ -27,10 +27,12 @@ fn build_widget() -> impl Widget<DemoState> {
     let mut col = Flex::column();
     let mut row = Flex::row();
     let switch = LensWrap::new(Switch::new(), DemoState::value);
+    let check_box = LensWrap::new(Checkbox::new(""), DemoState::value);
     let switch_label = Label::new("Setting label");
 
     row.add_child(Padding::new(5.0, switch_label));
     row.add_child(Padding::new(5.0, switch));
+    row.add_child(Padding::new(5.0, check_box));
 
     let stepper = LensWrap::new(
         Stepper::new()

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -540,6 +540,23 @@ impl<'a> UpdateCtx<'a> {
         self.request_layout();
     }
 
+    /// Request an animation frame.
+    pub fn request_anim_frame(&mut self) {
+        self.base_state.request_anim = true;
+        self.request_paint();
+    }
+
+    /// Request a timer event.
+    ///
+    /// The return value is a token, which can be used to associate the
+    /// request with the event.
+    pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
+        self.base_state.request_timer = true;
+        let timer_token = self.window.request_timer(deadline);
+        self.base_state.add_timer(timer_token);
+        timer_token
+    }
+
     /// Submit a [`Command`] to be run after layout and paint finish.
     ///
     /// **Note:**

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -181,6 +181,8 @@ impl Widget<bool> for Switch {
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &bool, data: &bool, _env: &Env) {
         if old_data != data {
             ctx.request_paint();
+            self.animation_in_progress = true;
+            ctx.request_anim_frame();
         }
     }
 

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -137,7 +137,6 @@ impl Widget<bool> for Switch {
 
                 ctx.set_active(false);
 
-                ctx.request_paint();
                 self.knob_dragged = false;
                 self.animation_in_progress = true;
                 ctx.request_anim_frame();
@@ -180,7 +179,6 @@ impl Widget<bool> for Switch {
 
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &bool, data: &bool, _env: &Env) {
         if old_data != data {
-            ctx.request_paint();
             self.animation_in_progress = true;
             ctx.request_anim_frame();
         }


### PR DESCRIPTION
This adds `UpdateCtx::request_timer` and `request_anim_frame`.
Also the `Switch` widget animates external changes of its state, the `switch` example now has a checkbox next to the `Switch` to test this.