### PR TITLE
Fix macOS mouse events with multiple windows and active states.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Supply correct `LifeCycleCtx` to `Event::FocusChanged`. ([#878] by [@cmyr])
 - Windows: Terminate app when all windows have closed. ([#763] by [@xStrom])
 - macOS: `Application::quit` now quits the run loop instead of killing the process. ([#763] by [@xStrom])
+- macOS: `Event::HotChanged` is properly generated with multiple windows. ([#907] by [@xStrom])
 - macOS/GTK/web: `MouseButton::X1` and `MouseButton::X2` clicks are now recognized. ([#843] by [@xStrom])
 - GTK: Support disabled menu items. ([#897] by [@jneem])
 - X11: Support individual window closing. ([#900] by [@xStrom])
@@ -111,7 +112,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Focus request handling is now predictable with the last request overriding earlier ones. ([#948] by [@xStrom])
 - Wheel events now properly update hot state. ([#951] by [@xStrom])
 - X11: Support mouse scrolling. ([#961] by [@jneem])
-- Painter widget not repainting on data change in Container ([#991] by [@cmyr])
+- `Painter` now properly repaints on data change in `Container`. ([#991] by [@cmyr])
 
 ### Visual
 
@@ -126,7 +127,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Reduce the flashing in ext_event and identity examples. ([#782] by [@futurepaul])
 - Added example and usage hints to `Env`. ([#796] by [@finnerale])
 - Added documentation about the usage of bloom filters. ([#818] by [@xStrom])
-- Added Book chapters about `Painter` and `Controller`. ([#832] by [@cmyr])
+- Added book chapters about `Painter` and `Controller`. ([#832] by [@cmyr])
 - Added hot glow option to multiwin example. ([#845] by [@xStrom])
 - Added new example for blocking functions. ([#840] by [@mastfissh])
 - Added a changelog containing development since the 0.5 release. ([#889] by [@finnerale])
@@ -207,6 +208,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#903]: https://github.com/xi-editor/druid/pull/903
 [#904]: https://github.com/xi-editor/druid/pull/904
 [#905]: https://github.com/xi-editor/druid/pull/905
+[#907]: https://github.com/xi-editor/druid/pull/907
 [#909]: https://github.com/xi-editor/druid/pull/909
 [#915]: https://github.com/xi-editor/druid/pull/915
 [#916]: https://github.com/xi-editor/druid/pull/916

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -54,6 +54,7 @@ cocoa = "0.20.1"
 objc = "0.2.7"
 core-graphics = "0.19.0"
 foreign-types = "0.3.2"
+bitflags = "1.2.1"
 
 # TODO(x11/dependencies): only use feature "xcb" if using XCB
 [target.'cfg(target_os="linux")'.dependencies]

--- a/druid-shell/src/platform/mac/appkit.rs
+++ b/druid-shell/src/platform/mac/appkit.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! macOS AppKit bindings.
+
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+
+use bitflags::bitflags;
+use cocoa::base::id;
+use cocoa::foundation::NSRect;
+use objc::{class, msg_send, sel, sel_impl};
+
+bitflags! {
+    pub struct NSTrackingAreaOptions: i32 {
+        const MouseEnteredAndExited = 1;
+        const MouseMoved = 1 << 1;
+        const CursorUpdate = 1 << 2;
+        // What's 1 << 3?
+        const ActiveWhenFirstResponder = 1 << 4;
+        const ActiveInKeyWindow = 1 << 5;
+        const ActiveInActiveApp = 1 << 6;
+        const ActiveAlways = 1 << 7;
+        const AssumeInside = 1 << 8;
+        const InVisibleRect = 1 << 9;
+        const EnabledDuringMouseDrag = 1 << 10;
+    }
+}
+
+pub trait NSTrackingArea: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSTrackingArea), alloc]
+    }
+
+    unsafe fn initWithRect_options_owner_userInfo(
+        self,
+        rect: NSRect,
+        options: NSTrackingAreaOptions,
+        owner: id,
+        userInfo: id,
+    ) -> id;
+}
+
+impl NSTrackingArea for id {
+    unsafe fn initWithRect_options_owner_userInfo(
+        self,
+        rect: NSRect,
+        options: NSTrackingAreaOptions,
+        owner: id,
+        userInfo: id,
+    ) -> id {
+        msg_send![self, initWithRect:rect options:options owner:owner userInfo:userInfo]
+    }
+}
+
+pub trait NSView: Sized {
+    unsafe fn addTrackingArea(self, trackingArea: id) -> id;
+}
+
+impl NSView for id {
+    unsafe fn addTrackingArea(self, trackingArea: id) -> id {
+        msg_send![self, addTrackingArea: trackingArea]
+    }
+}

--- a/druid-shell/src/platform/mac/mod.rs
+++ b/druid-shell/src/platform/mac/mod.rs
@@ -16,6 +16,7 @@
 
 #![allow(clippy::let_unit_value)]
 
+pub mod appkit;
 pub mod application;
 pub mod clipboard;
 pub mod dialog;


### PR DESCRIPTION
This PR replaces `acceptsMouseMovedEvents` with `NSTrackingArea`. This fixes a bunch of issues with not receiving mouse events in a multiple window situation.

The behavior is perhaps best testable with the `multiwin` example with the hot glow option turned on via the context menu. For example on `master` if you overlap multiple druid windows partially and then move the mouse not-too-fast over both of them, the window that's not active might get the hot status and remain stuck with it.

For another example:
- Position the two druid windows partially on top of each other.
- Press and hold a mouse button on the active window where the windows would overlap.
- `Cmd`+``` ` ``` to the bottom window so that it becomes the top window and is below the mouse cursor.
- Move the mouse a tiny bit, but not out of the area where it's on top of the new bottom window but in an obscured manner.
- Release the mouse button and move the mouse away.

On `master` the bottom window gets stuck in a hot state, while there's a custom fix for it in this PR.