### PR TITLE
Statically typed selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Timer events will only be delivered to the widgets that requested them. ([#831] by [@sjoshid])
 - `Event::Wheel` now contains a `MouseEvent` structure. ([#895] by [@teddemunnik])
 - `AppDelegate::command` now receives a `Target` instead of a `&Target`. ([#909] by [@xStrom])
+- `SHOW_WINDOW` and `OPEN_WINDOW` no longer require a `WindowId` as payload, but they must `Target` the correct window. ([#???] by [@finnerale])
 
 ### Deprecated
 

--- a/docs/book_examples/src/custom_widgets_md.rs
+++ b/docs/book_examples/src/custom_widgets_md.rs
@@ -36,7 +36,7 @@ fn background_label() -> impl Widget<Color> {
 // ANCHOR_END: background_label
 
 // ANCHOR: annoying_textbox
-const ACTION: Selector<()> = Selector::new("hello.textbox-action");
+const ACTION: Selector = Selector::new("hello.textbox-action");
 const DELAY: Duration = Duration::from_millis(300);
 
 struct TextBoxActionController {

--- a/docs/book_examples/src/custom_widgets_md.rs
+++ b/docs/book_examples/src/custom_widgets_md.rs
@@ -36,7 +36,7 @@ fn background_label() -> impl Widget<Color> {
 // ANCHOR_END: background_label
 
 // ANCHOR: annoying_textbox
-const ACTION: Selector = Selector::new("hello.textbox-action");
+const ACTION: Selector<()> = Selector::new("hello.textbox-action");
 const DELAY: Duration = Duration::from_millis(300);
 
 struct TextBoxActionController {

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -61,20 +61,15 @@ impl AppDelegate<AppState> for Delegate {
         data: &mut AppState,
         _env: &Env,
     ) -> bool {
-        match () {
-            _ if cmd.is(START_SLOW_FUNCTION) => {
-                data.processing = true;
-                wrapped_slow_function(self.eventsink.clone(), data.value);
-                true
-            }
-            _ if cmd.is(FINISH_SLOW_FUNCTION) => {
-                data.processing = false;
-                let number = cmd.get(FINISH_SLOW_FUNCTION).unwrap();
-                data.value = *number;
-                true
-            }
-            _ => true,
+        if cmd.is(START_SLOW_FUNCTION) {
+            data.processing = true;
+            wrapped_slow_function(self.eventsink.clone(), data.value);
         }
+        if let Ok(number) = cmd.get(FINISH_SLOW_FUNCTION) {
+            data.processing = false;
+            data.value = *number;
+        }
+        true
     }
 }
 

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -65,7 +65,7 @@ impl AppDelegate<AppState> for Delegate {
             data.processing = true;
             wrapped_slow_function(self.eventsink.clone(), data.value);
         }
-        if let Ok(number) = cmd.get(FINISH_SLOW_FUNCTION) {
+        if let Some(number) = cmd.get(FINISH_SLOW_FUNCTION) {
             data.processing = false;
             data.value = *number;
         }

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -23,9 +23,9 @@ use druid::{
 
 use druid::widget::{Button, Either, Flex, Label};
 
-const START_SLOW_FUNCTION: Selector = Selector::new("start_slow_function");
+const START_SLOW_FUNCTION: Selector<u32> = Selector::new("start_slow_function");
 
-const FINISH_SLOW_FUNCTION: Selector = Selector::new("finish_slow_function");
+const FINISH_SLOW_FUNCTION: Selector<u32> = Selector::new("finish_slow_function");
 
 struct Delegate {
     eventsink: ExtEventSink,
@@ -61,15 +61,15 @@ impl AppDelegate<AppState> for Delegate {
         data: &mut AppState,
         _env: &Env,
     ) -> bool {
-        match cmd.selector {
-            START_SLOW_FUNCTION => {
+        match () {
+            _ if cmd.is(START_SLOW_FUNCTION) => {
                 data.processing = true;
                 wrapped_slow_function(self.eventsink.clone(), data.value);
                 true
             }
-            FINISH_SLOW_FUNCTION => {
+            _ if cmd.is(FINISH_SLOW_FUNCTION) => {
                 data.processing = false;
-                let number = cmd.get_object::<u32>().expect("api violation");
+                let number = cmd.get(FINISH_SLOW_FUNCTION).unwrap();
                 data.value = *number;
                 true
             }

--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -22,7 +22,7 @@ use druid::kurbo::RoundedRect;
 use druid::widget::prelude::*;
 use druid::{AppLauncher, Color, Data, LocalizedString, Rect, Selector, WidgetExt, WindowDesc};
 
-const SET_COLOR: Selector = Selector::new("event-example.set-color");
+const SET_COLOR: Selector<Color> = Selector::new("event-example.set-color");
 
 /// A widget that displays a color.
 struct ColorWell;
@@ -53,8 +53,8 @@ impl ColorWell {
 impl Widget<MyColor> for ColorWell {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut MyColor, _env: &Env) {
         match event {
-            Event::Command(cmd) if cmd.selector == SET_COLOR => {
-                data.0 = cmd.get_object::<Color>().unwrap().clone();
+            Event::Command(cmd) if cmd.is(SET_COLOR) => {
+                data.0 = cmd.get(SET_COLOR).unwrap().clone();
                 ctx.request_paint();
             }
             _ => (),

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -40,8 +40,8 @@ use druid::{
 
 const CYCLE_DURATION: Duration = Duration::from_millis(100);
 
-const FREEZE_COLOR: Selector = Selector::new("identity-example.freeze-color");
-const UNFREEZE_COLOR: Selector = Selector::new("identity-example.unfreeze-color");
+const FREEZE_COLOR: Selector<Color> = Selector::new("identity-example.freeze-color");
+const UNFREEZE_COLOR: Selector<()> = Selector::new("identity-example.unfreeze-color");
 
 /// Honestly: it's just a color in fancy clothing.
 #[derive(Debug, Clone, Data, Lens)]
@@ -114,15 +114,10 @@ impl Widget<OurData> for ColorWell {
                 self.token = ctx.request_timer(CYCLE_DURATION);
             }
 
-            Event::Command(cmd) if cmd.selector == FREEZE_COLOR => {
-                self.frozen = cmd
-                    .get_object::<Color>()
-                    .ok()
-                    .cloned()
-                    .expect("payload is always a Color")
-                    .into();
+            Event::Command(cmd) if cmd.is(FREEZE_COLOR) => {
+                self.frozen = cmd.get(FREEZE_COLOR).ok().cloned();
             }
-            Event::Command(cmd) if cmd.selector == UNFREEZE_COLOR => self.frozen = None,
+            Event::Command(cmd) if cmd.is(UNFREEZE_COLOR) => self.frozen = None,
             _ => (),
         }
     }

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -115,7 +115,7 @@ impl Widget<OurData> for ColorWell {
             }
 
             Event::Command(cmd) if cmd.is(FREEZE_COLOR) => {
-                self.frozen = cmd.get(FREEZE_COLOR).ok().cloned();
+                self.frozen = cmd.get(FREEZE_COLOR).cloned();
             }
             Event::Command(cmd) if cmd.is(UNFREEZE_COLOR) => self.frozen = None,
             _ => (),

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -41,7 +41,7 @@ use druid::{
 const CYCLE_DURATION: Duration = Duration::from_millis(100);
 
 const FREEZE_COLOR: Selector<Color> = Selector::new("identity-example.freeze-color");
-const UNFREEZE_COLOR: Selector<()> = Selector::new("identity-example.unfreeze-color");
+const UNFREEZE_COLOR: Selector = Selector::new("identity-example.unfreeze-color");
 
 /// Honestly: it's just a color in fancy clothing.
 #[derive(Debug, Clone, Data, Lens)]

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -24,9 +24,9 @@ use druid::{
 use log::info;
 
 const MENU_COUNT_ACTION: Selector<usize> = Selector::new("menu-count-action");
-const MENU_INCREMENT_ACTION: Selector<()> = Selector::new("menu-increment-action");
-const MENU_DECREMENT_ACTION: Selector<()> = Selector::new("menu-decrement-action");
-const MENU_SWITCH_GLOW_ACTION: Selector<()> = Selector::new("menu-switch-glow");
+const MENU_INCREMENT_ACTION: Selector = Selector::new("menu-increment-action");
+const MENU_DECREMENT_ACTION: Selector = Selector::new("menu-decrement-action");
+const MENU_SWITCH_GLOW_ACTION: Selector = Selector::new("menu-switch-glow");
 
 #[derive(Debug, Clone, Default, Data)]
 struct State {

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -187,7 +187,7 @@ impl AppDelegate<State> for Delegate {
             Target::Window(id) if cmd.is(MENU_COUNT_ACTION) => {
                 data.selected = *cmd.get(MENU_COUNT_ACTION).unwrap();
                 let menu = make_menu::<State>(data);
-                let cmd = Command::new(druid::commands::SET_MENU, menu.into_app_state_menu_desc());
+                let cmd = Command::new(sys_cmds::SET_MENU, menu.into_app_state_menu_desc());
                 ctx.submit_command(cmd, id);
                 false
             }
@@ -196,14 +196,14 @@ impl AppDelegate<State> for Delegate {
             Target::Window(id) if cmd.is(MENU_INCREMENT_ACTION) => {
                 data.menu_count += 1;
                 let menu = make_menu::<State>(data);
-                let cmd = Command::new(druid::commands::SET_MENU, menu.into_app_state_menu_desc());
+                let cmd = Command::new(sys_cmds::SET_MENU, menu.into_app_state_menu_desc());
                 ctx.submit_command(cmd, id);
                 false
             }
             Target::Window(id) if cmd.is(MENU_DECREMENT_ACTION) => {
                 data.menu_count = data.menu_count.saturating_sub(1);
                 let menu = make_menu::<State>(data);
-                let cmd = Command::new(druid::commands::SET_MENU, menu.into_app_state_menu_desc());
+                let cmd = Command::new(sys_cmds::SET_MENU, menu.into_app_state_menu_desc());
                 ctx.submit_command(cmd, id);
                 false
             }

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -66,7 +66,7 @@ pub struct AppStateWindowDesc {
     type_name: &'static str,
 }
 
-impl<T: 'static> WindowDesc<T> {
+impl<T: Any> WindowDesc<T> {
     /// This turns a typed `WindowDesc<T>` into an untyped `AppStateWindowDesc`.
     /// Doing so allows sending `WindowDesc` through `Command`s.
     /// It is up to you, to ensure that this `T` represents your application
@@ -80,7 +80,7 @@ impl<T: 'static> WindowDesc<T> {
 }
 
 impl AppStateWindowDesc {
-    pub(crate) fn realize<T: 'static>(self) -> Result<WindowDesc<T>, AppStateTypeError> {
+    pub(crate) fn realize<T: Any>(self) -> Result<WindowDesc<T>, AppStateTypeError> {
         let inner: Result<Box<WindowDesc<T>>, _> = self.inner.downcast();
         if let Ok(inner) = inner {
             Ok(*inner)

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -82,7 +82,7 @@ impl<T: 'static> WindowDesc<T> {
 impl AppStateWindowDesc {
     pub(crate) fn realize<T: 'static>(self) -> Result<WindowDesc<T>, AppStateTypeError> {
         let inner: Result<Box<WindowDesc<T>>, _> = self.inner.downcast();
-        if let Some(inner) = inner.ok() {
+        if let Ok(inner) = inner {
             Ok(*inner)
         } else {
             Err(AppStateTypeError::new(

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -31,8 +31,17 @@ pub type SelectorSymbol = &'static str;
 /// [`druid::commands`] module.
 ///
 /// [`druid::commands`]: commands/index.html
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Selector<T>(SelectorSymbol, PhantomData<T>);
+
+// This has do be done explicitly, to avoid the Copy bound on `T`.
+// See https://doc.rust-lang.org/std/marker/trait.Copy.html#how-can-i-implement-copy .
+impl<T> Copy for Selector<T> {}
+impl<T> Clone for Selector<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 /// An arbitrary command.
 ///
@@ -415,7 +424,7 @@ mod tests {
         let sel: Selector<Vec<i32>> = Selector::new("my-selector");
         let objs = vec![0, 1, 2];
         // TODO: find out why this now wants a `.clone()` even tho `Selector` implements `Copy`.
-        let command = Command::new(sel.clone(), objs);
+        let command = Command::new(sel, objs);
         assert_eq!(command.get(sel), Ok(&vec![0, 1, 2]));
     }
 }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -122,7 +122,7 @@ enum Arg {
     OneShot(Arc<Mutex<Option<Box<dyn Any>>>>),
 }
 
-/// Errors that can occur when attempting to retrieve the a `OneShotCommand`s argument.
+/// Errors that can occur when attempting to retrieve the `OneShotCommand`s argument.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ArgumentError {
     /// The command represented a different selector.

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -33,7 +33,7 @@ pub type SelectorSymbol = &'static str;
 ///
 /// [`druid::commands`]: commands/index.html
 #[derive(Debug, PartialEq, Eq)]
-pub struct Selector<T>(SelectorSymbol, PhantomData<*const T>);
+pub struct Selector<T = ()>(SelectorSymbol, PhantomData<*const T>);
 
 // This has do be done explicitly, to avoid the Copy bound on `T`.
 // See https://doc.rust-lang.org/std/marker/trait.Copy.html#how-can-i-implement-copy .
@@ -184,13 +184,13 @@ pub mod sys {
     };
 
     /// Quit the running application. This command is handled by the druid library.
-    pub const QUIT_APP: Selector<()> = Selector::new("druid-builtin.quit-app");
+    pub const QUIT_APP: Selector = Selector::new("druid-builtin.quit-app");
 
     /// Hide the application. (mac only?)
-    pub const HIDE_APPLICATION: Selector<()> = Selector::new("druid-builtin.menu-hide-application");
+    pub const HIDE_APPLICATION: Selector = Selector::new("druid-builtin.menu-hide-application");
 
     /// Hide all other applications. (mac only?)
-    pub const HIDE_OTHERS: Selector<()> = Selector::new("druid-builtin.menu-hide-others");
+    pub const HIDE_OTHERS: Selector = Selector::new("druid-builtin.menu-hide-others");
 
     /// The selector for a command to create a new window.
     pub const NEW_WINDOW: OneShotSelector<AppStateWindowDesc> =
@@ -201,17 +201,17 @@ pub mod sys {
     /// The command must target a specific window.
     /// When calling `submit_command` on a `Widget`s context, passing `None` as target
     /// will automatically target the window containing the widget.
-    pub const CLOSE_WINDOW: Selector<()> = Selector::new("druid-builtin.close-window");
+    pub const CLOSE_WINDOW: Selector = Selector::new("druid-builtin.close-window");
 
     /// Close all windows.
-    pub const CLOSE_ALL_WINDOWS: Selector<()> = Selector::new("druid-builtin.close-all-windows");
+    pub const CLOSE_ALL_WINDOWS: Selector = Selector::new("druid-builtin.close-all-windows");
 
     /// The selector for a command to bring a window to the front, and give it focus.
     ///
     /// The command must target a specific window.
     /// When calling `submit_command` on a `Widget`s context, passing `None` as target
     /// will automatically target the window containing the widget.
-    pub const SHOW_WINDOW: Selector<()> = Selector::new("druid-builtin.show-window");
+    pub const SHOW_WINDOW: Selector = Selector::new("druid-builtin.show-window");
 
     /// Display a context (right-click) menu.
     /// An `AppStateContextMenu` can be obtained using `ContextMenu::into_app_state_context_menu`.
@@ -227,16 +227,16 @@ pub mod sys {
     pub const SET_MENU: Selector<AppStateMenuDesc> = Selector::new("druid-builtin.set-menu");
 
     /// Show the application preferences.
-    pub const SHOW_PREFERENCES: Selector<()> = Selector::new("druid-builtin.menu-show-preferences");
+    pub const SHOW_PREFERENCES: Selector = Selector::new("druid-builtin.menu-show-preferences");
 
     /// Show the application about window.
-    pub const SHOW_ABOUT: Selector<()> = Selector::new("druid-builtin.menu-show-about");
+    pub const SHOW_ABOUT: Selector = Selector::new("druid-builtin.menu-show-about");
 
     /// Show all applications.
-    pub const SHOW_ALL: Selector<()> = Selector::new("druid-builtin.menu-show-all");
+    pub const SHOW_ALL: Selector = Selector::new("druid-builtin.menu-show-all");
 
     /// Show the new file dialog.
-    pub const NEW_FILE: Selector<()> = Selector::new("druid-builtin.menu-file-new");
+    pub const NEW_FILE: Selector = Selector::new("druid-builtin.menu-file-new");
 
     /// System command. A file picker dialog will be shown to the user, and an
     /// [`OPEN_FILE`] command will be sent if a file is chosen.
@@ -269,28 +269,28 @@ pub mod sys {
     pub const SAVE_FILE: Selector<Option<FileInfo>> = Selector::new("druid-builtin.menu-file-save");
 
     /// Show the print-setup window.
-    pub const PRINT_SETUP: Selector<()> = Selector::new("druid-builtin.menu-file-print-setup");
+    pub const PRINT_SETUP: Selector = Selector::new("druid-builtin.menu-file-print-setup");
 
     /// Show the print dialog.
-    pub const PRINT: Selector<()> = Selector::new("druid-builtin.menu-file-print");
+    pub const PRINT: Selector = Selector::new("druid-builtin.menu-file-print");
 
     /// Show the print preview.
-    pub const PRINT_PREVIEW: Selector<()> = Selector::new("druid-builtin.menu-file-print");
+    pub const PRINT_PREVIEW: Selector = Selector::new("druid-builtin.menu-file-print");
 
     /// Cut the current selection.
-    pub const CUT: Selector<()> = Selector::new("druid-builtin.menu-cut");
+    pub const CUT: Selector = Selector::new("druid-builtin.menu-cut");
 
     /// Copy the current selection.
-    pub const COPY: Selector<()> = Selector::new("druid-builtin.menu-copy");
+    pub const COPY: Selector = Selector::new("druid-builtin.menu-copy");
 
     /// Paste.
-    pub const PASTE: Selector<()> = Selector::new("druid-builtin.menu-paste");
+    pub const PASTE: Selector = Selector::new("druid-builtin.menu-paste");
 
     /// Undo.
-    pub const UNDO: Selector<()> = Selector::new("druid-builtin.menu-undo");
+    pub const UNDO: Selector = Selector::new("druid-builtin.menu-undo");
 
     /// Redo.
-    pub const REDO: Selector<()> = Selector::new("druid-builtin.menu-redo");
+    pub const REDO: Selector = Selector::new("druid-builtin.menu-redo");
 }
 
 impl<T> Selector<T> {

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -280,7 +280,7 @@ impl<T> Selector<T> {
 impl Command {
     /// Create a new `Command` with an argument. If you do not need
     /// an argument, `Selector` implements `Into<Command>`.
-    pub fn new<T: 'static>(selector: Selector<T>, arg: T) -> Self {
+    pub fn new<T: Any>(selector: Selector<T>, arg: T) -> Self {
         Command {
             selector: selector.symbol(),
             object: Arg::Reusable(Arc::new(arg)),
@@ -294,7 +294,7 @@ impl Command {
     /// [`take_object`].
     ///
     /// [`take_object`]: #method.take_object
-    pub fn one_shot<T: 'static>(selector: Selector<T>, arg: T) -> Self {
+    pub fn one_shot<T: Any>(selector: Selector<T>, arg: T) -> Self {
         Command {
             selector: selector.symbol(),
             object: Arg::OneShot(Arc::new(Mutex::new(Some(Box::new(arg))))),
@@ -318,7 +318,7 @@ impl Command {
     /// created with [`one_shot`].
     ///
     /// [`one_shot`]: #method.one_shot
-    pub fn get<T: 'static>(&self, selector: Selector<T>) -> Result<&T, ArgumentError> {
+    pub fn get<T: Any>(&self, selector: Selector<T>) -> Result<&T, ArgumentError> {
         if self.selector != selector.symbol() {
             return Err(ArgumentError::WrongSelector);
         }
@@ -331,7 +331,7 @@ impl Command {
     /// Attempt to take the object of a [`one-shot`] command.
     ///
     /// [`one-shot`]: #method.one_shot
-    pub fn take<T: 'static>(&self, selector: Selector<T>) -> Result<Box<T>, ArgumentError> {
+    pub fn take<T: Any>(&self, selector: Selector<T>) -> Result<Box<T>, ArgumentError> {
         if self.selector != selector.symbol() {
             return Err(ArgumentError::WrongSelector);
         }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -386,6 +386,7 @@ impl Command {
                     .unwrap()
                     .take()
                     .ok_or(ArgumentError::Consumed)?;
+                #[allow(clippy::match_wild_err_arm)]
                 match obj.downcast::<T>() {
                     Ok(obj) => Ok(obj),
                     Err(_) => {

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -131,7 +131,7 @@ pub enum ArgumentError {
     Consumed,
 }
 
-/// This error can occure when wrongly promising that a type ereased
+/// This error can occur when wrongly promising that a type erased
 /// variant of some generic item represents the application state.
 /// Examples are `MenuDesc<T>` and `AppStateMenuDesc`.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -263,9 +263,7 @@ pub mod sys {
     /// Commands to save a file, must be handled by the application.
     ///
     /// If it carries `Some`, then the application should save to that file and store the `FileInfo` for future use.
-    /// If it carries `None`, the appliaction should have recieved `Some` before and use the stored `FileInfo`.
-    ///
-    /// The argument, if present, should be the path where the file should be saved.
+    /// If it carries `None`, the application should have received `Some` before and use the stored `FileInfo`.
     pub const SAVE_FILE: Selector<Option<FileInfo>> = Selector::new("druid-builtin.menu-file-save");
 
     /// Show the print-setup window.

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -68,7 +68,7 @@ impl<T> Clone for Selector<T> {
 /// let rows = vec![1, 3, 10, 12];
 /// let command = Command::new(selector, rows);
 ///
-/// assert_eq!(command.get_object(), Ok(&vec![1, 3, 10, 12]));
+/// assert_eq!(command.get(selector), Ok(&vec![1, 3, 10, 12]));
 /// ```
 ///
 /// [`Command::new`]: #method.new

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -271,7 +271,7 @@ impl<T> Selector<T> {
         Selector(s, PhantomData)
     }
 
-    pub(crate) const fn symbol(&self) -> SelectorSymbol {
+    pub(crate) const fn symbol(self) -> SelectorSymbol {
         self.0
     }
 }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -22,6 +22,7 @@ use std::{
 
 use crate::{WidgetId, WindowId};
 
+/// An untyped identifier for a `Selector`.
 pub type SelectorSymbol = &'static str;
 
 /// An identifier for a particular command.
@@ -99,6 +100,9 @@ pub enum ArgumentError {
     Consumed,
 }
 
+/// This error can occure when wrongly promising that a type ereased
+/// variant of some generic item represents the application state.
+/// Examples are `MenuDesc<T>` and `AppStateMenuDesc`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AppStateTypeError {
     expected: &'static str,
@@ -106,7 +110,7 @@ pub struct AppStateTypeError {
 }
 
 impl AppStateTypeError {
-    pub fn new(expected: &'static str, found: &'static str) -> Self {
+    pub(crate) fn new(expected: &'static str, found: &'static str) -> Self {
         Self { expected, found }
     }
 }
@@ -177,15 +181,15 @@ pub mod sys {
     /// will automatically target the window containing the widget.
     pub const SHOW_WINDOW: Selector<()> = Selector::new("druid-builtin.show-window");
 
-    /// Display a context (right-click) menu. The argument must be the [`ContextMenu`].
-    /// object to be displayed.
+    /// Display a context (right-click) menu.
+    /// An `AppStateContextMenu` can be obtained using `ContextMenu::into_app_state_context_menu`.
     ///
     /// [`ContextMenu`]: ../struct.ContextMenu.html
     pub const SHOW_CONTEXT_MENU: Selector<AppStateContextMenu> =
         Selector::new("druid-builtin.show-context-menu");
 
-    /// The selector for a command to set the window's menu. The argument should
-    /// be a [`MenuDesc`] object.
+    /// The selector for a command to set the window's menu.
+    /// An `AppStateMenuDesc` can be obtained using `MenuDesc::into_app_state_menu_desc`.
     ///
     /// [`MenuDesc`]: ../struct.MenuDesc.html
     pub const SET_MENU: Selector<AppStateMenuDesc> = Selector::new("druid-builtin.set-menu");
@@ -205,32 +209,29 @@ pub mod sys {
     /// System command. A file picker dialog will be shown to the user, and an
     /// [`OPEN_FILE`] command will be sent if a file is chosen.
     ///
-    /// The argument should be a [`FileDialogOptions`] struct.
-    ///
     /// [`OPEN_FILE`]: constant.OPEN_FILE.html
     /// [`FileDialogOptions`]: ../struct.FileDialogOptions.html
     pub const SHOW_OPEN_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-open");
 
-    /// Open a file.
-    ///
-    /// The argument must be a [`FileInfo`] object for the file to be opened.
+    /// Commands to open a file, must be handled by the application.
     ///
     /// [`FileInfo`]: ../struct.FileInfo.html
     pub const OPEN_FILE: Selector<FileInfo> = Selector::new("druid-builtin.open-file-path");
 
-    /// Special command. When issued, the system will show the 'save as' panel,
+    /// Special command. When issued by the application, the system will show the 'save as' panel,
     /// and if a path is selected the system will issue a [`SAVE_FILE`] command
     /// with the selected path as the argument.
-    ///
-    /// The argument should be a [`FileDialogOptions`] object.
     ///
     /// [`SAVE_FILE`]: constant.SAVE_FILE.html
     /// [`FileDialogOptions`]: ../struct.FileDialogOptions.html
     pub const SHOW_SAVE_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-save-as");
 
-    /// Save the current file.
+    /// Commands to save a file, must be handled by the application.
+    ///
+    /// If it carries `Some`, then the application should save to that file and store the `FileInfo` for future use.
+    /// If it carries `None`, the appliaction should have recieved `Some` before and use the stored `FileInfo`.
     ///
     /// The argument, if present, should be the path where the file should be saved.
     pub const SAVE_FILE: Selector<Option<FileInfo>> = Selector::new("druid-builtin.menu-file-save");

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -32,7 +32,7 @@ pub type SelectorSymbol = &'static str;
 ///
 /// [`druid::commands`]: commands/index.html
 #[derive(Debug, PartialEq, Eq)]
-pub struct Selector<T>(SelectorSymbol, PhantomData<T>);
+pub struct Selector<T>(SelectorSymbol, PhantomData<*const T>);
 
 // This has do be done explicitly, to avoid the Copy bound on `T`.
 // See https://doc.rust-lang.org/std/marker/trait.Copy.html#how-can-i-implement-copy .

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -101,7 +101,7 @@ impl ExtEventSink {
     ///
     /// [`Command`]: struct.Command.html
     /// [`Selector`]: struct.Selector.html
-    pub fn submit_command<T: Send + 'static>(
+    pub fn submit_command<T: Any + Send>(
         &self,
         sel: Selector<T>,
         obj: T,

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -20,7 +20,10 @@ use std::sync::{Arc, Mutex};
 
 use crate::shell::IdleHandle;
 use crate::win_handler::EXT_EVENT_IDLE_TOKEN;
-use crate::{command::SelectorSymbol, Command, Selector, Target, WindowId};
+use crate::{
+    command::{AnySelector, SelectorSymbol},
+    Command, Selector, Target, WindowId,
+};
 
 pub(crate) type ExtCommand = (SelectorSymbol, Box<dyn Any + Send>, Option<Target>);
 

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::shell::IdleHandle;
 use crate::win_handler::EXT_EVENT_IDLE_TOKEN;
-use crate::{Command, Selector, Target, WindowId, command::SelectorSymbol};
+use crate::{command::SelectorSymbol, Command, Selector, Target, WindowId};
 
 pub(crate) type ExtCommand = (SelectorSymbol, Box<dyn Any + Send>, Option<Target>);
 

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -148,10 +148,9 @@ impl<T: 'static> MenuDesc<T> {
 
 impl AppStateMenuDesc {
     pub(crate) fn realize<T: 'static>(&self) -> Result<&MenuDesc<T>, AppStateTypeError> {
-        self.inner.downcast_ref().ok_or_else(|| AppStateTypeError::new(
-            any::type_name::<MenuDesc<T>>(),
-            self.type_name,
-        ))
+        self.inner
+            .downcast_ref()
+            .ok_or_else(|| AppStateTypeError::new(any::type_name::<MenuDesc<T>>(), self.type_name))
     }
 }
 
@@ -217,10 +216,9 @@ impl<T: 'static> ContextMenu<T> {
 
 impl AppStateContextMenu {
     pub(crate) fn realize<T: 'static>(&self) -> Result<&ContextMenu<T>, AppStateTypeError> {
-        self.inner.downcast_ref().ok_or_else(|| AppStateTypeError::new(
-            any::type_name::<ContextMenu<T>>(),
-            self.type_name,
-        ))
+        self.inner.downcast_ref().ok_or_else(|| {
+            AppStateTypeError::new(any::type_name::<ContextMenu<T>>(), self.type_name)
+        })
     }
 }
 

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -627,7 +627,6 @@ pub mod sys {
             }
 
             /// The 'Save...' menu item.
-            /// For windows, this is the same as 'Save'.
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -333,7 +333,7 @@ impl<T: Data> MenuDesc<T> {
     /// use druid::{Command, LocalizedString, MenuDesc, MenuItem, Selector};
     ///
     /// let num_items: usize = 4;
-    /// const MENU_COUNT_ACTION: Selector = Selector::new("menu-count-action");
+    /// const MENU_COUNT_ACTION: Selector<u32> = Selector::new("menu-count-action");
     ///
     /// let my_menu: MenuDesc<u32> = MenuDesc::empty()
     ///     .append_iter(|| (0..num_items).map(|i| {

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -133,7 +133,7 @@ pub struct AppStateMenuDesc {
     type_name: &'static str,
 }
 
-impl<T: 'static> MenuDesc<T> {
+impl<T: Any> MenuDesc<T> {
     /// This turns a typed `MenuDesc<T>` into an untyped `AppStateMenuDesc`.
     /// Doing so allows sending `MenuDesc` through `Command`s.
     /// It is up to you, to ensure that this `T` represents your application
@@ -147,7 +147,7 @@ impl<T: 'static> MenuDesc<T> {
 }
 
 impl AppStateMenuDesc {
-    pub(crate) fn realize<T: 'static>(&self) -> Result<&MenuDesc<T>, AppStateTypeError> {
+    pub(crate) fn realize<T: Any>(&self) -> Result<&MenuDesc<T>, AppStateTypeError> {
         self.inner
             .downcast_ref()
             .ok_or_else(|| AppStateTypeError::new(any::type_name::<MenuDesc<T>>(), self.type_name))
@@ -201,7 +201,7 @@ pub struct AppStateContextMenu {
     type_name: &'static str,
 }
 
-impl<T: 'static> ContextMenu<T> {
+impl<T: Any> ContextMenu<T> {
     /// This turns a typed `ContextMenu<T>` into an untyped `AppStateContextMenu`.
     /// Doing so allows sending `ContextMenu` through `Command`s.
     /// It is up to you, to ensure that this `T` represents your application
@@ -215,7 +215,7 @@ impl<T: 'static> ContextMenu<T> {
 }
 
 impl AppStateContextMenu {
-    pub(crate) fn realize<T: 'static>(&self) -> Result<&ContextMenu<T>, AppStateTypeError> {
+    pub(crate) fn realize<T: Any>(&self) -> Result<&ContextMenu<T>, AppStateTypeError> {
         self.inner.downcast_ref().ok_or_else(|| {
             AppStateTypeError::new(any::type_name::<ContextMenu<T>>(), self.type_name)
         })

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -148,7 +148,7 @@ impl<T: 'static> MenuDesc<T> {
 
 impl AppStateMenuDesc {
     pub(crate) fn realize<T: 'static>(&self) -> Result<&MenuDesc<T>, AppStateTypeError> {
-        self.inner.downcast_ref().ok_or(AppStateTypeError::new(
+        self.inner.downcast_ref().ok_or_else(|| AppStateTypeError::new(
             any::type_name::<MenuDesc<T>>(),
             self.type_name,
         ))
@@ -217,7 +217,7 @@ impl<T: 'static> ContextMenu<T> {
 
 impl AppStateContextMenu {
     pub(crate) fn realize<T: 'static>(&self) -> Result<&ContextMenu<T>, AppStateTypeError> {
-        self.inner.downcast_ref().ok_or(AppStateTypeError::new(
+        self.inner.downcast_ref().ok_or_else(|| AppStateTypeError::new(
             any::type_name::<ContextMenu<T>>(),
             self.type_name,
         ))

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -630,11 +630,10 @@ pub mod sys {
 
             /// The 'Save...' menu item.
             /// For windows, this is the same as 'Save'.
-            /// TODO: find out why this exists.
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
-                    LocalizedString::new("common-menu-file-save"),
-                    Command::new(commands::SAVE_FILE, None),
+                    LocalizedString::new("common-menu-file-save-ellipsis"),
+                    Command::new(commands::SHOW_OPEN_PANEL, Default::default()),
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -331,9 +331,9 @@ impl<T: Data> MenuDesc<T> {
     /// use druid::{Command, LocalizedString, MenuDesc, MenuItem, Selector};
     ///
     /// let num_items: usize = 4;
-    /// const MENU_COUNT_ACTION: Selector<u32> = Selector::new("menu-count-action");
+    /// const MENU_COUNT_ACTION: Selector<usize> = Selector::new("menu-count-action");
     ///
-    /// let my_menu: MenuDesc<u32> = MenuDesc::empty()
+    /// let my_menu: MenuDesc<usize> = MenuDesc::empty()
     ///     .append_iter(|| (0..num_items).map(|i| {
     ///         MenuItem::new(
     ///             LocalizedString::new("hello-counter").with_arg("count", move |_, _| i.into()),

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -39,7 +39,7 @@ pub type UpdateFn<S, T> = dyn FnMut(&mut S, &mut UpdateCtx, &T, &T, &Env);
 pub type LayoutFn<S, T> = dyn FnMut(&mut S, &mut LayoutCtx, &BoxConstraints, &T, &Env) -> Size;
 pub type PaintFn<S, T> = dyn FnMut(&mut S, &mut PaintCtx, &T, &Env);
 
-pub const REPLACE_CHILD: Selector<()> = Selector::new("druid-test.replace-child");
+pub const REPLACE_CHILD: Selector = Selector::new("druid-test.replace-child");
 
 /// A widget that can be constructed from individual functions, builder-style.
 ///

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -39,7 +39,7 @@ pub type UpdateFn<S, T> = dyn FnMut(&mut S, &mut UpdateCtx, &T, &T, &Env);
 pub type LayoutFn<S, T> = dyn FnMut(&mut S, &mut LayoutCtx, &BoxConstraints, &T, &Env) -> Size;
 pub type PaintFn<S, T> = dyn FnMut(&mut S, &mut PaintCtx, &T, &Env);
 
-pub const REPLACE_CHILD: Selector = Selector::new("druid-test.replace-child");
+pub const REPLACE_CHILD: Selector<()> = Selector::new("druid-test.replace-child");
 
 /// A widget that can be constructed from individual functions, builder-style.
 ///
@@ -214,7 +214,7 @@ impl<T: Data> ReplaceChild<T> {
 impl<T: Data> Widget<T> for ReplaceChild<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Event::Command(cmd) = event {
-            if cmd.selector == REPLACE_CHILD {
+            if cmd.is(REPLACE_CHILD) {
                 self.inner = WidgetPod::new((self.replacer)());
                 ctx.children_changed();
                 return;

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -150,7 +150,7 @@ fn propogate_hot() {
 }
 #[test]
 fn take_focus() {
-    const TAKE_FOCUS: Selector<()> = Selector::new("druid-tests.take-focus");
+    const TAKE_FOCUS: Selector = Selector::new("druid-tests.take-focus");
 
     /// A widget that takes focus when sent a particular command.
     /// The widget records focus change events into the inner cell.

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -150,7 +150,7 @@ fn propogate_hot() {
 }
 #[test]
 fn take_focus() {
-    const TAKE_FOCUS: Selector = Selector::new("druid-tests.take-focus");
+    const TAKE_FOCUS: Selector<()> = Selector::new("druid-tests.take-focus");
 
     /// A widget that takes focus when sent a particular command.
     /// The widget records focus change events into the inner cell.
@@ -158,7 +158,7 @@ fn take_focus() {
         ModularWidget::new(inner)
             .event_fn(|_, ctx, event, _data, _env| {
                 if let Event::Command(cmd) = event {
-                    if cmd.selector == TAKE_FOCUS {
+                    if cmd.is(TAKE_FOCUS) {
                         ctx.request_focus();
                     }
                 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -37,7 +37,7 @@ const PADDING_TOP: f64 = 5.;
 const PADDING_LEFT: f64 = 4.;
 
 // we send ourselves this when we want to reset blink, which must be done in event.
-const RESET_BLINK: Selector<()> = Selector::new("druid-builtin.reset-textbox-blink");
+const RESET_BLINK: Selector = Selector::new("druid-builtin.reset-textbox-blink");
 const CURSOR_BLINK_DRUATION: Duration = Duration::from_millis(500);
 
 /// A widget that allows user text input.

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -53,7 +53,8 @@ pub struct TextBox {
 
 impl TextBox {
     /// Perform an `EditAction`. The payload *must* be an `EditAction`.
-    pub const PERFORM_EDIT: Selector<EditAction> = Selector::new("druid-builtin.textbox.perform-edit");
+    pub const PERFORM_EDIT: Selector<EditAction> =
+        Selector::new("druid-builtin.textbox.perform-edit");
 
     /// Create a new TextBox widget
     pub fn new() -> TextBox {
@@ -281,8 +282,7 @@ impl Widget<String> for TextBox {
             }
             Event::Command(ref cmd)
                 if ctx.is_focused()
-                    && (cmd.is(crate::commands::COPY)
-                        || cmd.is(crate::commands::CUT)) =>
+                    && (cmd.is(crate::commands::COPY) || cmd.is(crate::commands::CUT)) =>
             {
                 if let Some(text) = data.slice(self.selection.range()) {
                     Application::global().clipboard().put_string(text);

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -367,26 +367,24 @@ impl<T: Data> Inner<T> {
 
     fn set_menu(&mut self, window_id: WindowId, cmd: &Command) {
         if let Some(win) = self.windows.get_mut(window_id) {
-            match cmd.get(sys_cmd::SET_MENU) {
-                Ok(menu) => match menu.realize() {
+            if let Some(menu) = cmd.get(sys_cmd::SET_MENU) {
+                match menu.realize() {
                     Ok(menu) => win.set_menu(menu.to_owned(), &self.data, &self.env),
                     Err(e) => log::error!("set_menu: {}", e),
-                },
-                Err(e) => log::error!("set-menu object error: '{}'", e),
+                }
             }
         }
     }
 
     fn show_context_menu(&mut self, window_id: WindowId, cmd: &Command) {
         if let Some(win) = self.windows.get_mut(window_id) {
-            match cmd.get(sys_cmd::SHOW_CONTEXT_MENU) {
-                Ok(menu) => match menu.realize() {
+            if let Some(menu) = cmd.get(sys_cmd::SHOW_CONTEXT_MENU) {
+                match menu.realize() {
                     Ok(ContextMenu { menu, location }) => {
                         win.show_context_menu(menu.to_owned(), *location, &self.data, &self.env)
                     }
                     Err(e) => log::error!("show_context_menu: {}", e),
-                },
-                Err(e) => log::error!("show_context_menu argument error: {}", e),
+                }
             }
         }
     }

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -311,12 +311,11 @@ impl<T: Data> Inner<T> {
         match target {
             Target::Window(id) => {
                 // first handle special window-level events
-                match () {
-                    _ if cmd.is(sys_cmd::SET_MENU) => return self.set_menu(id, &cmd),
-                    _ if cmd.is(sys_cmd::SHOW_CONTEXT_MENU) => {
-                        return self.show_context_menu(id, &cmd)
-                    }
-                    _ => (),
+                if cmd.is(sys_cmd::SET_MENU) {
+                    return self.set_menu(id, &cmd);
+                }
+                if cmd.is(sys_cmd::SHOW_CONTEXT_MENU) {
+                    return self.show_context_menu(id, &cmd);
                 }
                 if let Some(w) = self.windows.get_mut(id) {
                     let event = Event::Command(cmd);

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -523,31 +523,31 @@ impl<T: Data> AppState<T> {
     /// windows) have their logic here; other commands are passed to the window.
     fn handle_cmd(&mut self, target: Target, cmd: Command) {
         use Target as T;
-        match (target, &cmd.selector) {
+        match (target, cmd.selector_symbol()) {
             // these are handled the same no matter where they come from
-            (_, &sys_cmd::QUIT_APP) => self.quit(),
-            (_, &sys_cmd::HIDE_APPLICATION) => self.hide_app(),
-            (_, &sys_cmd::HIDE_OTHERS) => self.hide_others(),
-            (_, &sys_cmd::NEW_WINDOW) => {
+            (_, sys_cmd::QUIT_APP.symbol()) => self.quit(),
+            (_, sys_cmd::HIDE_APPLICATION) => self.hide_app(),
+            (_, sys_cmd::HIDE_OTHERS) => self.hide_others(),
+            (_, sys_cmd::NEW_WINDOW) => {
                 if let Err(e) = self.new_window(cmd) {
                     log::error!("failed to create window: '{}'", e);
                 }
             }
-            (_, &sys_cmd::CLOSE_ALL_WINDOWS) => self.request_close_all_windows(),
+            (_, sys_cmd::CLOSE_ALL_WINDOWS) => self.request_close_all_windows(),
             // these should come from a window
             // FIXME: we need to be able to open a file without a window handle
-            (T::Window(id), &sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
-            (T::Window(id), &sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
-            (T::Window(id), &sys_cmd::CLOSE_WINDOW) => self.request_close_window(cmd, id),
-            (T::Window(_), &sys_cmd::SHOW_WINDOW) => self.show_window(cmd),
-            (T::Window(id), &sys_cmd::PASTE) => self.do_paste(id),
+            (T::Window(id), sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
+            (T::Window(id), sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
+            (T::Window(id), sys_cmd::CLOSE_WINDOW) => self.request_close_window(cmd, id),
+            (T::Window(_), sys_cmd::SHOW_WINDOW) => self.show_window(cmd),
+            (T::Window(id), sys_cmd::PASTE) => self.do_paste(id),
             _sel => self.inner.borrow_mut().dispatch_cmd(target, cmd),
         }
     }
 
     fn show_open_panel(&mut self, cmd: Command, window_id: WindowId) {
         let options = cmd
-            .get_object::<FileDialogOptions>()
+            .get(sys_cmd::SHOW_OPEN_PANEL)
             .map(|opts| opts.to_owned())
             .unwrap_or_default();
         //FIXME: this is blocking; if we hold `borrow_mut` we are likely to cause

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -21,9 +21,7 @@ use std::rc::Rc;
 
 use crate::kurbo::{Rect, Size};
 use crate::piet::Piet;
-use crate::shell::{
-    Application, FileDialogOptions, IdleToken, MouseEvent, WinHandler, WindowHandle,
-};
+use crate::shell::{Application, IdleToken, MouseEvent, WinHandler, WindowHandle};
 
 use crate::app_delegate::{AppDelegate, DelegateCtx};
 use crate::core::CommandQueue;
@@ -313,9 +311,11 @@ impl<T: Data> Inner<T> {
         match target {
             Target::Window(id) => {
                 // first handle special window-level events
-                match cmd.selector {
-                    sys_cmd::SET_MENU => return self.set_menu(id, &cmd),
-                    sys_cmd::SHOW_CONTEXT_MENU => return self.show_context_menu(id, &cmd),
+                match () {
+                    _ if cmd.is(sys_cmd::SET_MENU) => return self.set_menu(id, &cmd),
+                    _ if cmd.is(sys_cmd::SHOW_CONTEXT_MENU) => {
+                        return self.show_context_menu(id, &cmd)
+                    }
                     _ => (),
                 }
                 if let Some(w) = self.windows.get_mut(id) {
@@ -368,20 +368,26 @@ impl<T: Data> Inner<T> {
 
     fn set_menu(&mut self, window_id: WindowId, cmd: &Command) {
         if let Some(win) = self.windows.get_mut(window_id) {
-            match cmd.get_object::<MenuDesc<T>>() {
-                Ok(menu) => win.set_menu(menu.to_owned(), &self.data, &self.env),
-                Err(e) => log::warn!("set-menu object error: '{}'", e),
+            match cmd.get(sys_cmd::SET_MENU) {
+                Ok(menu) => match menu.realize() {
+                    Ok(menu) => win.set_menu(menu.to_owned(), &self.data, &self.env),
+                    Err(e) => log::error!("set_menu: {}", e),
+                },
+                Err(e) => log::error!("set-menu object error: '{}'", e),
             }
         }
     }
 
     fn show_context_menu(&mut self, window_id: WindowId, cmd: &Command) {
         if let Some(win) = self.windows.get_mut(window_id) {
-            match cmd.get_object::<ContextMenu<T>>() {
-                Ok(ContextMenu { menu, location }) => {
-                    win.show_context_menu(menu.to_owned(), *location, &self.data, &self.env)
-                }
-                Err(e) => log::warn!("show-context-menu object error: '{}'", e),
+            match cmd.get(sys_cmd::SHOW_CONTEXT_MENU) {
+                Ok(menu) => match menu.realize() {
+                    Ok(ContextMenu { menu, location }) => {
+                        win.show_context_menu(menu.to_owned(), *location, &self.data, &self.env)
+                    }
+                    Err(e) => log::error!("show_context_menu: {}", e),
+                },
+                Err(e) => log::error!("show_context_menu argument error: {}", e),
             }
         }
     }
@@ -523,25 +529,31 @@ impl<T: Data> AppState<T> {
     /// windows) have their logic here; other commands are passed to the window.
     fn handle_cmd(&mut self, target: Target, cmd: Command) {
         use Target as T;
-        match (target, cmd.selector_symbol()) {
+        match target {
             // these are handled the same no matter where they come from
-            (_, sys_cmd::QUIT_APP.symbol()) => self.quit(),
-            (_, sys_cmd::HIDE_APPLICATION) => self.hide_app(),
-            (_, sys_cmd::HIDE_OTHERS) => self.hide_others(),
-            (_, sys_cmd::NEW_WINDOW) => {
+            _ if cmd.is(sys_cmd::QUIT_APP) => self.quit(),
+            _ if cmd.is(sys_cmd::HIDE_APPLICATION) => self.hide_app(),
+            _ if cmd.is(sys_cmd::HIDE_OTHERS) => self.hide_others(),
+            _ if cmd.is(sys_cmd::NEW_WINDOW) => {
                 if let Err(e) = self.new_window(cmd) {
                     log::error!("failed to create window: '{}'", e);
                 }
             }
-            (_, sys_cmd::CLOSE_ALL_WINDOWS) => self.request_close_all_windows(),
+            _ if cmd.is(sys_cmd::CLOSE_ALL_WINDOWS) => self.request_close_all_windows(),
             // these should come from a window
             // FIXME: we need to be able to open a file without a window handle
-            (T::Window(id), sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
-            (T::Window(id), sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
-            (T::Window(id), sys_cmd::CLOSE_WINDOW) => self.request_close_window(cmd, id),
-            (T::Window(_), sys_cmd::SHOW_WINDOW) => self.show_window(cmd),
-            (T::Window(id), sys_cmd::PASTE) => self.do_paste(id),
-            _sel => self.inner.borrow_mut().dispatch_cmd(target, cmd),
+            T::Window(id) if cmd.is(sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
+            T::Window(id) if cmd.is(sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
+            T::Window(id) if cmd.is(sys_cmd::CLOSE_WINDOW) => self.request_close_window(id),
+            T::Window(id) if cmd.is(sys_cmd::SHOW_WINDOW) => self.show_window(id),
+            T::Window(id) if cmd.is(sys_cmd::PASTE) => self.do_paste(id),
+            _ if cmd.is(sys_cmd::CLOSE_WINDOW) => {
+                log::warn!("CLOSE_WINDOW command must target a window.")
+            }
+            _ if cmd.is(sys_cmd::SHOW_WINDOW) => {
+                log::warn!("SHOW_WINDOW command must target a window.")
+            }
+            _ => self.inner.borrow_mut().dispatch_cmd(target, cmd),
         }
     }
 
@@ -569,7 +581,7 @@ impl<T: Data> AppState<T> {
 
     fn show_save_panel(&mut self, cmd: Command, window_id: WindowId) {
         let options = cmd
-            .get_object::<FileDialogOptions>()
+            .get(sys_cmd::SHOW_SAVE_PANEL)
             .map(|opts| opts.to_owned())
             .unwrap_or_default();
         let handle = self
@@ -580,32 +592,29 @@ impl<T: Data> AppState<T> {
             .map(|w| w.handle.clone());
         let result = handle.and_then(|mut handle| handle.save_as_sync(options));
         if let Some(info) = result {
-            let cmd = Command::new(sys_cmd::SAVE_FILE, info);
+            let cmd = Command::new(sys_cmd::SAVE_FILE, Some(info));
             self.inner.borrow_mut().dispatch_cmd(window_id.into(), cmd);
         }
     }
 
     fn new_window(&mut self, cmd: Command) -> Result<(), Box<dyn std::error::Error>> {
-        let desc = cmd.take_object::<WindowDesc<T>>()?;
+        let desc = cmd.take(sys_cmd::NEW_WINDOW)?;
+        let desc = desc.realize()?;
         let window = desc.build_native(self)?;
         window.show();
         Ok(())
     }
 
-    fn request_close_window(&mut self, cmd: Command, window_id: WindowId) {
-        let id = cmd.get_object().unwrap_or(&window_id);
-        self.inner.borrow_mut().request_close_window(*id);
+    fn request_close_window(&mut self, window_id: WindowId) {
+        self.inner.borrow_mut().request_close_window(window_id);
     }
 
     fn request_close_all_windows(&mut self) {
         self.inner.borrow_mut().request_close_all_windows();
     }
 
-    fn show_window(&mut self, cmd: Command) {
-        let id: WindowId = *cmd
-            .get_object()
-            .expect("show window selector missing window id");
-        self.inner.borrow_mut().show_window(id);
+    fn show_window(&mut self, window_id: WindowId) {
+        self.inner.borrow_mut().show_window(window_id);
     }
 
     fn do_paste(&mut self, window_id: WindowId) {


### PR DESCRIPTION
This changes `Selector` to `Selector<T>` where `T` is the selectors payload.

There was a [Zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/commands.20and.20'side.20effects') discussion about why `Command`s rely on purely dynamic typing while `Env` uses statically typed `Key`s.

I found myself typing 'Must have ThisType as payload` for pretty much every selector I've defined, so adding a type to it seemed like the logical consequence.

This also fixes some issues with menu items submitting wrong commands or showing wrong labels.

This still lacks in documentation and I haven't thoroughly checked if everything works, but at least for `multiwin` it does work better now.

Also I have plans to introduce `OneShotSelector<T>` for one-shot commands and I'm not sure if it should be part of this PR or go into a separate one.

I've opened this as a draft for now so that I have a better overview of the changes made and where I have to add documentation. Also I can see if there are errors on mac or windows and  if someone wants to give some feedback, that would be welcome as well.