### PR TITLE
Optimize clippy trivially_copy_pass_by_ref for 64-bit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Global `Application` associated functions are instance methods instead, e.g. `Application::global().quit()` instead of the old `Application::quit()`. ([#763] by [@xStrom])
 - Timer events will only be delivered to the widgets that requested them. ([#831] by [@sjoshid])
 - `Event::Wheel` now contains a `MouseEvent` structure. ([#895] by [@teddemunnik])
+- `AppDelegate::command` now receives a `Target` instead of a `&Target`. ([#909] by [@xStrom])
 
 ### Deprecated
 
@@ -153,6 +154,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#897]: https://github.com/xi-editor/druid/pull/897
 [#898]: https://github.com/xi-editor/druid/pull/898
 [#900]: https://github.com/xi-editor/druid/pull/900
+[#909]: https://github.com/xi-editor/druid/pull/909
 
 ## [0.5.0] - 2020-04-01
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# The default clippy value for this is 8 bytes, which is chosen to improve performance on 32-bit.
+# Given that druid is being designed for the future and already even mobile phones have 64-bit CPUs,
+# it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
+# 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
+trivial-copy-size-limit = 16

--- a/druid-shell/src/platform/windows/dialog.rs
+++ b/druid-shell/src/platform/windows/dialog.rs
@@ -59,7 +59,7 @@ unsafe fn make_wstrs(spec: &FileSpec) -> (Vec<u16>, Vec<u16>) {
     let exts = spec
         .extensions
         .iter()
-        .map(normalize_extension)
+        .map(|s| normalize_extension(*s))
         .collect::<Vec<_>>();
     let name = format!("{} ({})", spec.name, exts.as_slice().join("; ")).to_wide();
     let extensions = exts.as_slice().join(";").to_wide();
@@ -67,7 +67,7 @@ unsafe fn make_wstrs(spec: &FileSpec) -> (Vec<u16>, Vec<u16>) {
 }
 
 /// add preceding *., trimming preceding *. that might've been included by the user.
-fn normalize_extension(ext: &&str) -> String {
+fn normalize_extension(ext: &str) -> String {
     format!("*.{}", ext.trim_start_matches('*').trim_start_matches('.'))
 }
 

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -56,7 +56,7 @@ impl AppDelegate<AppState> for Delegate {
     fn command(
         &mut self,
         _ctx: &mut DelegateCtx,
-        _target: &Target,
+        _target: Target,
         cmd: &Command,
         data: &mut AppState,
         _env: &Env,

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -166,7 +166,7 @@ impl AppDelegate<State> for Delegate {
     fn command(
         &mut self,
         ctx: &mut DelegateCtx,
-        target: &Target,
+        target: Target,
         cmd: &Command,
         data: &mut State,
         _env: &Env,
@@ -184,7 +184,7 @@ impl AppDelegate<State> for Delegate {
                 data.selected = *cmd.get_object().unwrap();
                 let menu = make_menu::<State>(data);
                 let cmd = Command::new(druid::commands::SET_MENU, menu);
-                ctx.submit_command(cmd, *id);
+                ctx.submit_command(cmd, id);
                 false
             }
             // wouldn't it be nice if a menu (like a button) could just mutate state
@@ -193,14 +193,14 @@ impl AppDelegate<State> for Delegate {
                 data.menu_count += 1;
                 let menu = make_menu::<State>(data);
                 let cmd = Command::new(druid::commands::SET_MENU, menu);
-                ctx.submit_command(cmd, *id);
+                ctx.submit_command(cmd, id);
                 false
             }
             (Target::Window(id), &MENU_DECREMENT_ACTION) => {
                 data.menu_count = data.menu_count.saturating_sub(1);
                 let menu = make_menu::<State>(data);
                 let cmd = Command::new(druid::commands::SET_MENU, menu);
-                ctx.submit_command(cmd, *id);
+                ctx.submit_command(cmd, id);
                 false
             }
             (_, &MENU_SWITCH_GLOW_ACTION) => {

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -91,7 +91,7 @@ pub trait AppDelegate<T: Data> {
     fn command(
         &mut self,
         ctx: &mut DelegateCtx,
-        target: &Target,
+        target: Target,
         cmd: &Command,
         data: &mut T,
         env: &Env,

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -204,7 +204,7 @@ impl<T: Data> Inner<T> {
         }
     }
 
-    fn delegate_cmd(&mut self, target: &Target, cmd: &Command) -> bool {
+    fn delegate_cmd(&mut self, target: Target, cmd: &Command) -> bool {
         self.with_delegate(|del, data, env, ctx| del.command(ctx, target, cmd, data, env))
             .unwrap_or(true)
     }
@@ -306,7 +306,7 @@ impl<T: Data> Inner<T> {
     }
 
     fn dispatch_cmd(&mut self, target: Target, cmd: Command) {
-        if !self.delegate_cmd(&target, &cmd) {
+        if !self.delegate_cmd(target, &cmd) {
             return;
         }
 


### PR DESCRIPTION
This PR changes `trivially_copy_pass_by_ref` to 16 bytes, which is the number of bytes that fit into two 64-bit CPU registers.

The default clippy value for this is 8 bytes, which is chosen to improve performance on 32-bit. Given that druid is being designed for the future and already even mobile phones have 64-bit CPUs, it makes sense to optimize for 64-bit and accept the performance hits on 32-bit. 

This also changes command `Target` to be passed by value. It's a breaking change, but given that commands are getting redone in #908 anyway, I think this is about as perfect of a time to change this as possible.