### PR TITLE
Use dev profile for wasm-pack in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
           args: --manifest-path=druid/examples/wasm/Cargo.toml --target wasm32-unknown-unknown -- -D warnings
 
       - name: wasm-pack build examples
-        run: wasm-pack build --target web druid/examples/wasm
+        run: wasm-pack build --dev --target web druid/examples/wasm
 
   test-nightly:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I've just found out that `wasm-pack` [runs in release mode by default](https://rustwasm.github.io/wasm-pack/book/commands/build.html#profile).
This changes the CI command to use the `dev` profile, which has optimizations turned off.
Thus it will run `cargo build` in debug mode and skip running `wasm-opt`.