### PR TITLE
Fix flash of white at window edge while resizing on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - X11: Support `Application::quit`. ([#900] by [@xStrom])
 - GTK: Support file filters in open/save dialogs. ([#903] by [@jneem])
 - GTK: Support DPI values other than 96. ([#904] by [@xStrom])
+- Windows: Removed flashes of white background at the edge of the window when resizing. ([#915] by [@xStrom])
 - X11: Support key and mouse button state. ([#920] by [@jneem])
 - Routing `LifeCycle::FocusChanged` to descendant widgets. ([#925] by [@yrns])
 - Built-in open and save menu items now show the correct label and submit the right commands. ([#930] by [@finnerale])
@@ -199,6 +200,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#904]: https://github.com/xi-editor/druid/pull/904
 [#905]: https://github.com/xi-editor/druid/pull/905
 [#909]: https://github.com/xi-editor/druid/pull/909
+[#915]: https://github.com/xi-editor/druid/pull/915
 [#917]: https://github.com/xi-editor/druid/pull/917
 [#920]: https://github.com/xi-editor/druid/pull/920
 [#924]: https://github.com/xi-editor/druid/pull/924

--- a/druid-shell/src/platform/windows/application.rs
+++ b/druid-shell/src/platform/windows/application.rs
@@ -26,7 +26,6 @@ use winapi::shared::windef::{HCURSOR, HWND};
 use winapi::shared::winerror::HRESULT_FROM_WIN32;
 use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::shellscalingapi::PROCESS_SYSTEM_DPI_AWARE;
-use winapi::um::wingdi::CreateSolidBrush;
 use winapi::um::winuser::{
     DispatchMessageW, GetAncestor, GetMessageW, LoadIconW, PostMessageW, PostQuitMessage,
     RegisterClassW, TranslateAcceleratorW, TranslateMessage, GA_ROOT, IDI_APPLICATION, MSG,
@@ -74,7 +73,6 @@ impl Application {
         unsafe {
             let class_name = CLASS_NAME.to_wide();
             let icon = LoadIconW(0 as HINSTANCE, IDI_APPLICATION);
-            let brush = CreateSolidBrush(0xff_ff_ff);
             let wnd = WNDCLASSW {
                 style: 0,
                 lpfnWndProc: Some(window::win_proc_dispatch),
@@ -83,7 +81,7 @@ impl Application {
                 hInstance: 0 as HINSTANCE,
                 hIcon: icon,
                 hCursor: 0 as HCURSOR,
-                hbrBackground: brush,
+                hbrBackground: ptr::null_mut(), // We control all the painting
                 lpszMenuName: 0 as LPCWSTR,
                 lpszClassName: class_name.as_ptr(),
             };


### PR DESCRIPTION
On Windows 7 when resizing there are flashes of white background, because the content resize lags behind the window resize. With this change the background coloring task is delegated to druid, which it already does.

This might also have an effect on #914 although given that the initial app opening flash is harder to reproduce, it will take time to find out whether that is solved.