### PR TITLE
Move HWND render target creation to WM_CREATE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - GTK: Support file filters in open/save dialogs. ([#903] by [@jneem])
 - GTK: Support DPI values other than 96. ([#904] by [@xStrom])
 - Windows: Removed flashes of white background at the edge of the window when resizing. ([#915] by [@xStrom])
+- Windows: Reduced chance of white flash when opening a new window. ([#916] by [@xStrom])
 - X11: Support key and mouse button state. ([#920] by [@jneem])
 - Routing `LifeCycle::FocusChanged` to descendant widgets. ([#925] by [@yrns])
 - Built-in open and save menu items now show the correct label and submit the right commands. ([#930] by [@finnerale])
@@ -201,6 +202,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#905]: https://github.com/xi-editor/druid/pull/905
 [#909]: https://github.com/xi-editor/druid/pull/909
 [#915]: https://github.com/xi-editor/druid/pull/915
+[#916]: https://github.com/xi-editor/druid/pull/916
 [#917]: https://github.com/xi-editor/druid/pull/917
 [#920]: https://github.com/xi-editor/druid/pull/920
 [#924]: https://github.com/xi-editor/druid/pull/924


### PR DESCRIPTION
This PR should help with the initial white flash reported in #914. On my Windows 7 desktop I measured the HWND render target creation at 39ms. This is definitely too long to lazily create in `WM_PAINT` so I moved it to `WM_CREATE`.

Even if it doesn't fully fix the white flash, it cuts down the first frame time by 39ms on my machine, so it's worth a merge regardless.

I left the check in `WM_PAINT` intact, because there are failure paths with dcomp that may need it.