### PR TITLE
Add a size method to UpdateCtx and LifeCycleCtx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `MouseButtons` to `MouseEvent` to track which buttons are being held down during an event. ([#843] by [@xStrom])
 - `Env` and `Key` gained methods for inspecting an `Env` at runtime ([#880] by [@Zarenor])
 - `UpdateCtx::request_timer` and `UpdateCtx::request_anim_frame`. ([#898] by [@finnerale])
-- `UpdateCtx::size`. ([#917] by [@jneem])
+- `UpdateCtx::size` and `LifeCycleCtx::size`. ([#917] by [@jneem])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `MouseButtons` to `MouseEvent` to track which buttons are being held down during an event. ([#843] by [@xStrom])
 - `Env` and `Key` gained methods for inspecting an `Env` at runtime ([#880] by [@Zarenor])
 - `UpdateCtx::request_timer` and `UpdateCtx::request_anim_frame`. ([#898] by [@finnerale])
+- `UpdateCtx::size`. ([#917] by [@jneem])
 
 ### Changed
 
@@ -157,6 +158,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#900]: https://github.com/xi-editor/druid/pull/900
 [#903]: https://github.com/xi-editor/druid/pull/903
 [#909]: https://github.com/xi-editor/druid/pull/909
+[#917]: https://github.com/xi-editor/druid/pull/917
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -557,6 +557,19 @@ impl<'a> UpdateCtx<'a> {
         timer_token
     }
 
+    /// The layout size.
+    ///
+    /// This is the layout size as ultimately determined by the parent
+    /// container, on the previous layout pass.
+    ///
+    /// Generally it will be the same as the size returned by the child widget's
+    /// [`layout`] method.
+    ///
+    /// [`layout`]: trait.Widget.html#tymethod.layout
+    pub fn size(&self) -> Size {
+        self.base_state.size()
+    }
+
     /// Submit a [`Command`] to be run after layout and paint finish.
     ///
     /// **Note:**

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -479,6 +479,19 @@ impl<'a> LifeCycleCtx<'a> {
         self.request_paint();
     }
 
+    /// The layout size.
+    ///
+    /// This is the layout size as ultimately determined by the parent
+    /// container, on the previous layout pass.
+    ///
+    /// Generally it will be the same as the size returned by the child widget's
+    /// [`layout`] method.
+    ///
+    /// [`layout`]: trait.Widget.html#tymethod.layout
+    pub fn size(&self) -> Size {
+        self.base_state.size()
+    }
+
     /// Submit a [`Command`] to be run after this event is handled.
     ///
     /// Commands are run in the order they are submitted; all commands


### PR DESCRIPTION
I found myself needing this, for a widget that wants to update its internal state based on changes to data, but needs the size to do so (think of something like a scroll bar, whose state depends on the viewport size).

More generally, is there a rationale somewhere for which contexts have which functions? For example, I see that `LifeCycleCtx` is also missing `size`...