### PR TITLE
Fix layout warnings with timers.

### DIFF
--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -451,15 +451,21 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
 
         // log if we seem not to be laid out when we should be
-        if !matches!(event, Event::WindowConnected | Event::WindowSize(_))
-            && self.state.layout_rect.is_none()
-        {
-            log::warn!(
-                "Widget '{}' received an event ({:?}) without having been laid out. \
-                This likely indicates a missed call to set_layout_rect.",
-                self.inner.type_name(),
-                event,
-            );
+        if self.state.layout_rect.is_none() {
+            match event {
+                Event::Internal(_) => (),
+                Event::Timer(_) => (),
+                Event::WindowConnected => (),
+                Event::WindowSize(_) => (),
+                _ => {
+                    log::warn!(
+                        "Widget '{}' received an event ({:?}) without having been laid out. \
+                        This likely indicates a missed call to set_layout_rect.",
+                        self.inner.type_name(),
+                        event,
+                    );
+                }
+            }
         }
 
         // TODO: factor as much logic as possible into monomorphic functions.


### PR DESCRIPTION
Timers can fire real early when requested from handling `WindowConnected`. That results in faulty warnings. This PR solves that.