### PR TITLE
Fix paint_with_z_index with pre-existing transforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - X11: Support `Application::quit`. ([#900] by [@xStrom])
 - GTK: Support file filters in open/save dialogs. ([#903] by [@jneem])
 - X11: Support key and mouse button state. ([#920] by [@jneem])
+- `paint_with_z_index` now respects pre-existing platform transforms. ([#923] by [@xStrom])
 
 ### Visual
 
@@ -163,6 +164,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#909]: https://github.com/xi-editor/druid/pull/909
 [#917]: https://github.com/xi-editor/druid/pull/917
 [#920]: https://github.com/xi-editor/druid/pull/920
+[#923]: https://github.com/xi-editor/druid/pull/923
 
 ## [0.5.0] - 2020-04-01
 


### PR DESCRIPTION
The transform state isn't necessarily empty when it arrives to druid. Right now it's GTK that applies a translate when there are menus or even just always in the case of Wayland, presumably for some sort of border space.

However soon enough we'll get the core-graphics backend for macOS which also has its own transforms applied. Hopefully this prepares druid for that too.

Fixes #922