### PR TITLE
Fix for RouteFocusChanged and focusable descendants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - X11: Support `Application::quit`. ([#900] by [@xStrom])
 - GTK: Support file filters in open/save dialogs. ([#903] by [@jneem])
 - X11: Support key and mouse button state. ([#920] by [@jneem])
+- Routing `Event::FocusChanged` for descendant widgets. ([#925] by [@yrns])
 
 ### Visual
 
@@ -165,6 +166,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#909]: https://github.com/xi-editor/druid/pull/909
 [#917]: https://github.com/xi-editor/druid/pull/917
 [#920]: https://github.com/xi-editor/druid/pull/920
+[#925]: https://github.com/xi-editor/druid/pull/925
 
 ## [0.5.0] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - X11: Support `Application::quit`. ([#900] by [@xStrom])
 - GTK: Support file filters in open/save dialogs. ([#903] by [@jneem])
 - X11: Support key and mouse button state. ([#920] by [@jneem])
-- Routing `Event::FocusChanged` for descendant widgets. ([#925] by [@yrns])
+- Routing `LifeCycle::FocusChanged` to descendant widgets. ([#925] by [@yrns])
 
 ### Visual
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ Last release without a changelog :(
 [@sjoshid]: https://github.com/sjoshid
 [@mastfissh]: https://github.com/mastfissh
 [@Zarenor]: https://github.com/Zarenor
+[@yrns]: https://github.com/yrns
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
 [0.5.0]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -699,8 +699,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
 
     pub fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
         // in the case of an internal routing event, if we are at our target
-        // we may replace the routing event with the actual event
-        let mut substitute_event = None;
+        // we may send an extra event after the actual event
+        let mut extra_event = None;
 
         let recurse = match event {
             LifeCycle::Internal(internal) => match internal {
@@ -735,7 +735,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                         // Only send FocusChanged in case there's actual change
                         if old != new {
                             self.state.has_focus = change;
-                            substitute_event = Some(LifeCycle::FocusChanged(change));
+                            extra_event = Some(LifeCycle::FocusChanged(change));
                         }
                     } else {
                         self.state.has_focus = false;
@@ -798,7 +798,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             self.inner.lifecycle(&mut child_ctx, event, data, env);
         }
 
-        if let Some(event) = substitute_event.as_ref() {
+        if let Some(event) = extra_event.as_ref() {
             self.inner.lifecycle(&mut child_ctx, event, data, env);
         }
 

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -213,9 +213,7 @@ fn focus_changed() {
                     if cmd.selector == TAKE_FOCUS {
                         ctx.request_focus();
                         // Stop propagating this command so children
-                        // aren't requesting focus too. The extra
-                        // focus requests would be lost when merged
-                        // up, anyway.
+                        // aren't requesting focus too.
                         ctx.set_handled();
                     }
                 }

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -203,6 +203,89 @@ fn take_focus() {
 }
 
 #[test]
+fn focus_changed() {
+    const TAKE_FOCUS: Selector = Selector::new("druid-tests.take-focus");
+
+    fn make_focus_container(children: Vec<WidgetPod<(), Box<dyn Widget<()>>>>) -> impl Widget<()> {
+        ModularWidget::new(children)
+            .event_fn(|children, ctx, event, data, env| {
+                if let Event::Command(cmd) = event {
+                    if cmd.selector == TAKE_FOCUS {
+                        ctx.request_focus();
+                        // Stop propagating this command so children
+                        // aren't requesting focus too. The extra
+                        // focus requests would be lost when merged
+                        // up, anyway.
+                        ctx.set_handled();
+                    }
+                }
+                children
+                    .iter_mut()
+                    .for_each(|a| a.event(ctx, event, data, env));
+            })
+            .lifecycle_fn(|children, ctx, event, data, env| {
+                children
+                    .iter_mut()
+                    .for_each(|a| a.lifecycle(ctx, event, data, env));
+            })
+    }
+
+    let a_rec = Recording::default();
+    let b_rec = Recording::default();
+    let c_rec = Recording::default();
+
+    let (id_a, id_b, id_c) = widget_id3();
+
+    // a contains b which contains c
+    let c = make_focus_container(vec![]).record(&c_rec).with_id(id_c);
+    let b = make_focus_container(vec![WidgetPod::new(c).boxed()])
+        .record(&b_rec)
+        .with_id(id_b);
+    let a = make_focus_container(vec![WidgetPod::new(b).boxed()])
+        .record(&a_rec)
+        .with_id(id_a);
+
+    let f = |a| match a {
+        Record::L(LifeCycle::FocusChanged(c)) => Some(c),
+        _ => None,
+    };
+    let no_change = |a: &Recording| a.drain().filter_map(f).count() == 0;
+    let changed = |a: &Recording, b| a.drain().filter_map(f).eq(std::iter::once(b));
+
+    Harness::create_simple((), a, |harness| {
+        harness.send_initial_events();
+
+        // focus none -> a
+        harness.submit_command(TAKE_FOCUS, id_a);
+        assert_eq!(harness.window().focus, Some(id_a));
+        assert!(changed(&a_rec, true));
+        assert!(no_change(&b_rec));
+        assert!(no_change(&c_rec));
+
+        // focus a -> b
+        harness.submit_command(TAKE_FOCUS, id_b);
+        assert_eq!(harness.window().focus, Some(id_b));
+        assert!(changed(&a_rec, false));
+        assert!(changed(&b_rec, true));
+        assert!(no_change(&c_rec));
+
+        // focus b -> c
+        harness.submit_command(TAKE_FOCUS, id_c);
+        assert_eq!(harness.window().focus, Some(id_c));
+        assert!(no_change(&a_rec));
+        assert!(changed(&b_rec, false));
+        assert!(changed(&c_rec, true));
+
+        // focus c -> a
+        harness.submit_command(TAKE_FOCUS, id_a);
+        assert_eq!(harness.window().focus, Some(id_a));
+        assert!(changed(&a_rec, true));
+        assert!(no_change(&b_rec));
+        assert!(changed(&c_rec, false));
+    })
+}
+
+#[test]
 fn simple_lifecyle() {
     let record = Recording::default();
     let widget = SizedBox::empty().record(&record);


### PR DESCRIPTION
My project uses a hierarchy of focusable widgets and I ran into some problems which I've attempted to fix here.

* Route RouteFocusChanged all the way down since a focusable widget
may contain descendants which can also have focus

* Instead of replacing RouteFocusChanged with FocusChanged, send it
after the former is completely routed, so request_focus is cleared

* Added a new test case to demonstrate cases that would previously
fail, along with some test harness fixes/additions