### PR TITLE
Update CLOSE and SHOW _WINDOW commands to utilize Target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Timer events will only be delivered to the widgets that requested them. ([#831] by [@sjoshid])
 - `Event::Wheel` now contains a `MouseEvent` structure. ([#895] by [@teddemunnik])
 - `AppDelegate::command` now receives a `Target` instead of a `&Target`. ([#909] by [@xStrom])
+- `SHOW_WINDOW` and `CLOSE_WINDOW` commands now only use `Target` to determine the affected window. ([#928] by [@finnerale])
 
 ### Deprecated
 
@@ -167,6 +168,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#917]: https://github.com/xi-editor/druid/pull/917
 [#920]: https://github.com/xi-editor/druid/pull/920
 [#924]: https://github.com/xi-editor/druid/pull/924
+[#928]: https://github.com/xi-editor/druid/pull/928
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -118,8 +118,11 @@ pub mod sys {
     /// The selector for a command to create a new window.
     pub const NEW_WINDOW: Selector = Selector::new("druid-builtin.new-window");
 
-    /// The selector for a command to close a window. The command's argument
-    /// should be the id of the window to close.
+    /// The selector for a command to close a window.
+    ///
+    /// The command must target a specific window.
+    /// When calling `submit_command` on a `Widget`s context, passing `None` as target
+    /// will automatically target the window containing the widget.
     pub const CLOSE_WINDOW: Selector = Selector::new("druid-builtin.close-window");
 
     /// Close all windows.
@@ -127,7 +130,9 @@ pub mod sys {
 
     /// The selector for a command to bring a window to the front, and give it focus.
     ///
-    /// The command's argument should be the id of the target window.
+    /// The command must target a specific window.
+    /// When calling `submit_command` on a `Widget`s context, passing `None` as target
+    /// will automatically target the window containing the widget.
     pub const SHOW_WINDOW: Selector = Selector::new("druid-builtin.show-window");
 
     /// Display a context (right-click) menu. The argument must be the [`ContextMenu`].

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -538,10 +538,12 @@ impl<T: Data> AppState<T> {
             // FIXME: we need to be able to open a file without a window handle
             (T::Window(id), &sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
             (T::Window(id), &sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
-            (T::Window(id), &sys_cmd::CLOSE_WINDOW) => self.request_close_window(cmd, id),
-            (T::Window(_), &sys_cmd::SHOW_WINDOW) => self.show_window(cmd),
+            (T::Window(id), &sys_cmd::CLOSE_WINDOW) => self.request_close_window(id),
+            (T::Window(id), &sys_cmd::SHOW_WINDOW) => self.show_window(id),
             (T::Window(id), &sys_cmd::PASTE) => self.do_paste(id),
-            _sel => self.inner.borrow_mut().dispatch_cmd(target, cmd),
+            (_, &sys_cmd::CLOSE_WINDOW) => log::warn!("CLOSE_WINDOW command must target a window."),
+            (_, &sys_cmd::SHOW_WINDOW) => log::warn!("SHOW_WINDOW command must target a window."),
+            _ => self.inner.borrow_mut().dispatch_cmd(target, cmd),
         }
     }
 
@@ -592,19 +594,15 @@ impl<T: Data> AppState<T> {
         Ok(())
     }
 
-    fn request_close_window(&mut self, cmd: Command, window_id: WindowId) {
-        let id = cmd.get_object().unwrap_or(&window_id);
-        self.inner.borrow_mut().request_close_window(*id);
+    fn request_close_window(&mut self, id: WindowId) {
+        self.inner.borrow_mut().request_close_window(id);
     }
 
     fn request_close_all_windows(&mut self) {
         self.inner.borrow_mut().request_close_all_windows();
     }
 
-    fn show_window(&mut self, cmd: Command) {
-        let id: WindowId = *cmd
-            .get_object()
-            .expect("show window selector missing window id");
+    fn show_window(&mut self, id: WindowId) {
         self.inner.borrow_mut().show_window(id);
     }
 


### PR DESCRIPTION
This is the first part of my PR for typed selectors (#908).

Now the `CLOSE_WINDOW` and `SHOW_WINDOW` commands both use the `Target` instead of passing the `WindowId` as payload.