### PR TITLE
Correct built-in open and save menu items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - GTK: Support file filters in open/save dialogs. ([#903] by [@jneem])
 - X11: Support key and mouse button state. ([#920] by [@jneem])
 - Routing `LifeCycle::FocusChanged` to descendant widgets. ([#925] by [@yrns])
+- Built-in open and save menu items now show the correct label and submit the right commands. ([#930] by [@finnerale])
 
 ### Visual
 
@@ -171,6 +172,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#924]: https://github.com/xi-editor/druid/pull/924
 [#925]: https://github.com/xi-editor/druid/pull/925
 [#928]: https://github.com/xi-editor/druid/pull/928
+[#930]: https://github.com/xi-editor/druid/pull/930
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -519,8 +519,8 @@ pub mod sys {
                     .append(new())
                     .append(open())
                     .append(close())
-                    .append(save().disabled())
-                    .append(save_as().disabled())
+                    .append(save_ellipsis())
+                    .append(save_as())
                     // revert to saved?
                     .append(print().disabled())
                     .append(page_setup().disabled())
@@ -566,8 +566,8 @@ pub mod sys {
             /// The 'Save' menu item.
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
-                    LocalizedString::new("common-menu-file-save"),
-                    commands::SAVE_FILE,
+                    LocalizedString::new("common-menu-file-save-ellipsis"),
+                    commands::SHOW_SAVE_PANEL,
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }
@@ -742,7 +742,7 @@ pub mod sys {
             pub fn open_file<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-open"),
-                    commands::OPEN_FILE,
+                    commands::SHOW_OPEN_PANEL,
                 )
                 .hotkey(RawMods::Meta, "o")
             }
@@ -771,7 +771,7 @@ pub mod sys {
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),
-                    commands::SAVE_FILE,
+                    commands::SHOW_SAVE_PANEL,
                 )
                 .hotkey(RawMods::Meta, "s")
             }

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -563,7 +563,9 @@ pub mod sys {
                 .hotkey(RawMods::Ctrl, "s")
             }
 
-            /// The 'Save' menu item.
+            /// The 'Save...' menu item.
+            ///
+            /// This is used if we need to show a dialog to select save location.
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),


### PR DESCRIPTION
Second part of #908 .

Based on the [Zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/commands.20and.20'side.20effects'/near/196882766) discussion here.

On Windows / Linux:
- `save_ellipsis` now actually displays an ellipsis.

On mac:
- `open_file` shows the dialog instead of submitting an invalid `OPEN_FILE` command.

All:
- `save_ellipsis` shows the dialog and thus behaves like `save_as` instead of `save`.