### PR TITLE
Replace generic commands with methods on EventCtx and DelegateCtx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Timer events will only be delivered to the widgets that requested them. ([#831] by [@sjoshid])
 - `Event::Wheel` now contains a `MouseEvent` structure. ([#895] by [@teddemunnik])
 - `AppDelegate::command` now receives a `Target` instead of a `&Target`. ([#909] by [@xStrom])
+- `SHOW_WINDOW` and `CLOSE_WINDOW` commands now only use `Target` to determine the affected window. ([#928] by [@finnerale])
 
 ### Deprecated
 
@@ -169,6 +170,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#920]: https://github.com/xi-editor/druid/pull/920
 [#924]: https://github.com/xi-editor/druid/pull/924
 [#925]: https://github.com/xi-editor/druid/pull/925
+[#928]: https://github.com/xi-editor/druid/pull/928
 
 ## [0.5.0] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `Event::Wheel` now contains a `MouseEvent` structure. ([#895] by [@teddemunnik])
 - `AppDelegate::command` now receives a `Target` instead of a `&Target`. ([#909] by [@xStrom])
 - `SHOW_WINDOW` and `CLOSE_WINDOW` commands now only use `Target` to determine the affected window. ([#928] by [@finnerale])
+- Replaced `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`. ([#931] by [@finnerale])
 
 ### Deprecated
 
@@ -171,6 +172,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#924]: https://github.com/xi-editor/druid/pull/924
 [#925]: https://github.com/xi-editor/druid/pull/925
 [#928]: https://github.com/xi-editor/druid/pull/928
+[#931]: https://github.com/xi-editor/druid/pull/931
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -59,7 +59,7 @@ impl<'a> DelegateCtx<'a> {
                 Target::Global,
             );
         } else {
-            const MSG: &str = "All application windows must represent the same type of state.";
+            const MSG: &str = "WindowDesc<T> - T must match the application state.";
             if cfg!(debug_assertions) {
                 panic!(MSG);
             } else {
@@ -79,7 +79,7 @@ impl<'a> DelegateCtx<'a> {
                 Target::Window(window),
             );
         } else {
-            const MSG: &str = "Menus must represent the application state.";
+            const MSG: &str = "MenuDesc<T> - T must match the application state.";
             if cfg!(debug_assertions) {
                 panic!(MSG);
             } else {

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -49,7 +49,7 @@ impl<'a> DelegateCtx<'a> {
     }
 
     /// Create a new window.
-    /// `T` must represent the application state provided to [`AppLauncher::launch`].
+    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
@@ -68,8 +68,8 @@ impl<'a> DelegateCtx<'a> {
         }
     }
 
-    /// Set the windows menu.
-    /// `T` must represent the application state provided to [`AppLauncher::launch`].
+    /// Set the window's menu.
+    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>, window: WindowId) {

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -14,7 +14,10 @@
 
 //! Customizing application-level behaviour.
 
-use std::{any::Any, collections::VecDeque};
+use std::{
+    any::{Any, TypeId},
+    collections::VecDeque,
+};
 
 use crate::{
     commands, contexts::StateTypes, Command, Data, Env, Event, MenuDesc, Target, WindowDesc,
@@ -53,7 +56,7 @@ impl<'a> DelegateCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
-        if self.state_types.check_window_desc::<T>() {
+        if self.state_types.window_desc == TypeId::of::<WindowDesc<T>>() {
             self.submit_command(
                 Command::one_shot(commands::NEW_WINDOW, desc),
                 Target::Global,
@@ -73,7 +76,7 @@ impl<'a> DelegateCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>, window: WindowId) {
-        if self.state_types.check_menu_desc::<T>() {
+        if self.state_types.menu_desc == TypeId::of::<MenuDesc<T>>() {
             self.submit_command(
                 Command::new(commands::SET_MENU, menu),
                 Target::Window(window),

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -14,15 +14,19 @@
 
 //! Customizing application-level behaviour.
 
-use std::collections::VecDeque;
+use std::{any::Any, collections::VecDeque};
 
-use crate::{Command, Data, Env, Event, Target, WindowId};
+use crate::{
+    commands, contexts::StateTypes, Command, Data, Env, Event, MenuDesc, Target, WindowDesc,
+    WindowId,
+};
 
 /// A context passed in to [`AppDelegate`] functions.
 ///
 /// [`AppDelegate`]: trait.AppDelegate.html
 pub struct DelegateCtx<'a> {
     pub(crate) command_queue: &'a mut VecDeque<(Target, Command)>,
+    pub(crate) state_types: StateTypes,
 }
 
 impl<'a> DelegateCtx<'a> {
@@ -42,6 +46,46 @@ impl<'a> DelegateCtx<'a> {
         let command = command.into();
         let target = target.into().unwrap_or(Target::Global);
         self.command_queue.push_back((target, command))
+    }
+
+    /// Create a new window.
+    /// `T` must represent the application state provided to [`AppLauncher::launch`].
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
+        if self.state_types.check_window_desc::<T>() {
+            self.submit_command(
+                Command::one_shot(commands::NEW_WINDOW, desc),
+                Target::Global,
+            );
+        } else {
+            const MSG: &str = "All application windows must represent the same type of state.";
+            if cfg!(debug_assertions) {
+                panic!(MSG);
+            } else {
+                log::error!("DelegateCtx::new_window: {}", MSG)
+            }
+        }
+    }
+
+    /// Set the windows menu.
+    /// `T` must represent the application state provided to [`AppLauncher::launch`].
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>, window: WindowId) {
+        if self.state_types.check_menu_desc::<T>() {
+            self.submit_command(
+                Command::new(commands::SET_MENU, menu),
+                Target::Window(window),
+            );
+        } else {
+            const MSG: &str = "Menus must represent the application state.";
+            if cfg!(debug_assertions) {
+                panic!(MSG);
+            } else {
+                log::error!("DelegateCtx::set_menu: {}", MSG)
+            }
+        }
     }
 }
 

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -116,7 +116,7 @@ pub mod sys {
     pub const HIDE_OTHERS: Selector = Selector::new("druid-builtin.menu-hide-others");
 
     /// The selector for a command to create a new window.
-    pub const NEW_WINDOW: Selector = Selector::new("druid-builtin.new-window");
+    pub(crate) const NEW_WINDOW: Selector = Selector::new("druid-builtin.new-window");
 
     /// The selector for a command to close a window.
     ///
@@ -139,13 +139,13 @@ pub mod sys {
     /// object to be displayed.
     ///
     /// [`ContextMenu`]: ../struct.ContextMenu.html
-    pub const SHOW_CONTEXT_MENU: Selector = Selector::new("druid-builtin.show-context-menu");
+    pub(crate) const SHOW_CONTEXT_MENU: Selector = Selector::new("druid-builtin.show-context-menu");
 
     /// The selector for a command to set the window's menu. The argument should
     /// be a [`MenuDesc`] object.
     ///
     /// [`MenuDesc`]: ../struct.MenuDesc.html
-    pub const SET_MENU: Selector = Selector::new("druid-builtin.set-menu");
+    pub(crate) const SET_MENU: Selector = Selector::new("druid-builtin.set-menu");
 
     /// Show the application preferences.
     pub const SHOW_PREFERENCES: Selector = Selector::new("druid-builtin.menu-show-preferences");

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -118,8 +118,11 @@ pub mod sys {
     /// The selector for a command to create a new window.
     pub const NEW_WINDOW: Selector = Selector::new("druid-builtin.new-window");
 
-    /// The selector for a command to close a window. The command's argument
-    /// should be the id of the window to close.
+    /// The selector for a command to close a window.
+    ///
+    /// The command must target a specific window.
+    /// When calling `submit_command` on a `Widget`s context, passing `None` as target
+    /// will automatically target the window containing the widget.
     pub const CLOSE_WINDOW: Selector = Selector::new("druid-builtin.close-window");
 
     /// Close all windows.
@@ -127,7 +130,9 @@ pub mod sys {
 
     /// The selector for a command to bring a window to the front, and give it focus.
     ///
-    /// The command's argument should be the id of the target window.
+    /// The command must target a specific window.
+    /// When calling `submit_command` on a `Widget`s context, passing `None` as target
+    /// will automatically target the window containing the widget.
     pub const SHOW_WINDOW: Selector = Selector::new("druid-builtin.show-window");
 
     /// Display a context (right-click) menu. The argument must be the [`ContextMenu`].

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -302,7 +302,10 @@ impl<'a> EventCtx<'a> {
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
         if self.state_types.check_menu_desc::<T>() {
-            self.submit_command(Command::new(commands::SET_MENU, menu), Target::Window(self.window_id));
+            self.submit_command(
+                Command::new(commands::SET_MENU, menu),
+                Target::Window(self.window_id),
+            );
         } else {
             const MSG: &str = "MenuDesc<T> - T must match the application state.";
             if cfg!(debug_assertions) {
@@ -319,7 +322,10 @@ impl<'a> EventCtx<'a> {
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {
         if self.state_types.check_context_menu::<T>() {
-            self.submit_command(Command::new(commands::SHOW_CONTEXT_MENU, menu), Target::Window(self.window_id));
+            self.submit_command(
+                Command::new(commands::SHOW_CONTEXT_MENU, menu),
+                Target::Window(self.window_id),
+            );
         } else {
             const MSG: &str = "ContextMenu<T> - T must match the application state.";
             if cfg!(debug_assertions) {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -287,7 +287,7 @@ impl<'a> EventCtx<'a> {
                 Target::Global,
             );
         } else {
-            const MSG: &str = "All application windows must represent the same type of state.";
+            const MSG: &str = "WindowDesc<T> - T must match the application state.";
             if cfg!(debug_assertions) {
                 panic!(MSG);
             } else {
@@ -304,7 +304,7 @@ impl<'a> EventCtx<'a> {
         if self.state_types.check_menu_desc::<T>() {
             self.submit_command(Command::new(commands::SET_MENU, menu), Target::Window(self.window_id));
         } else {
-            const MSG: &str = "Menus must represent the application state.";
+            const MSG: &str = "MenuDesc<T> - T must match the application state.";
             if cfg!(debug_assertions) {
                 panic!(MSG);
             } else {
@@ -321,7 +321,7 @@ impl<'a> EventCtx<'a> {
         if self.state_types.check_context_menu::<T>() {
             self.submit_command(Command::new(commands::SHOW_CONTEXT_MENU, menu), Target::Window(self.window_id));
         } else {
-            const MSG: &str = "Context menus must represent the application state.";
+            const MSG: &str = "ContextMenu<T> - T must match the application state.";
             if cfg!(debug_assertions) {
                 panic!(MSG);
             } else {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -15,8 +15,8 @@
 //! The context types that are passed into various widget methods.
 
 use std::{
-    ops::{Deref, DerefMut},
     any::{Any, TypeId},
+    ops::{Deref, DerefMut},
     time::Duration,
 };
 
@@ -31,9 +31,9 @@ use crate::{
 /// These allow type checking new windows and menus at runtime
 #[derive(Clone, Copy)]
 pub(crate) struct StateTypes {
-    window_desc: TypeId,
-    menu_desc: TypeId,
-    context_menu: TypeId,
+    pub window_desc: TypeId,
+    pub menu_desc: TypeId,
+    pub context_menu: TypeId,
 }
 
 /// A mutable context provided to event handling methods of widgets.
@@ -146,18 +146,6 @@ impl StateTypes {
             menu_desc: TypeId::of::<MenuDesc<T>>(),
             context_menu: TypeId::of::<ContextMenu<T>>(),
         }
-    }
-
-    pub fn check_window_desc<T: Any>(&self) -> bool {
-        self.window_desc == TypeId::of::<WindowDesc<T>>()
-    }
-
-    pub fn check_menu_desc<T: Any>(&self) -> bool {
-        self.menu_desc == TypeId::of::<MenuDesc<T>>()
-    }
-
-    pub fn check_context_menu<T: Any>(&self) -> bool {
-        self.context_menu == TypeId::of::<ContextMenu<T>>()
     }
 }
 
@@ -281,7 +269,7 @@ impl<'a> EventCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
-        if self.state_types.check_window_desc::<T>() {
+        if self.state_types.window_desc == TypeId::of::<WindowDesc<T>>() {
             self.submit_command(
                 Command::one_shot(commands::NEW_WINDOW, desc),
                 Target::Global,
@@ -301,7 +289,7 @@ impl<'a> EventCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        if self.state_types.check_menu_desc::<T>() {
+        if self.state_types.menu_desc == TypeId::of::<MenuDesc<T>>() {
             self.submit_command(
                 Command::new(commands::SET_MENU, menu),
                 Target::Window(self.window_id),
@@ -321,7 +309,7 @@ impl<'a> EventCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {
-        if self.state_types.check_context_menu::<T>() {
+        if self.state_types.context_menu == TypeId::of::<ContextMenu<T>>() {
             self.submit_command(
                 Command::new(commands::SHOW_CONTEXT_MENU, menu),
                 Target::Window(self.window_id),

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -14,8 +14,8 @@
 
 //! The context types that are passed into various widget methods.
 
-use std::ops::{Deref, DerefMut};
 use std::{
+    ops::{Deref, DerefMut},
     any::{Any, TypeId},
     time::Duration,
 };
@@ -277,7 +277,7 @@ impl<'a> EventCtx<'a> {
     }
 
     /// Create a new window.
-    /// `T` must represent the application state provided to [`AppLauncher::launch`].
+    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
@@ -296,8 +296,8 @@ impl<'a> EventCtx<'a> {
         }
     }
 
-    /// Set the menu of the window containing the event handling widget.
-    /// `T` must represent the application state provided to [`AppLauncher::launch`].
+    /// Set the menu of the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
@@ -316,8 +316,8 @@ impl<'a> EventCtx<'a> {
         }
     }
 
-    /// Show the context menu in the window containing the event handling widget.
-    /// `T` must represent the application state provided to [`AppLauncher::launch`].
+    /// Show the context menu in the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -302,7 +302,7 @@ impl<'a> EventCtx<'a> {
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
         if self.state_types.check_menu_desc::<T>() {
-            self.submit_command(Command::new(commands::SET_MENU, menu), None);
+            self.submit_command(Command::new(commands::SET_MENU, menu), Target::Window(self.window_id));
         } else {
             const MSG: &str = "Menus must represent the application state.";
             if cfg!(debug_assertions) {
@@ -319,7 +319,7 @@ impl<'a> EventCtx<'a> {
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {
         if self.state_types.check_context_menu::<T>() {
-            self.submit_command(Command::new(commands::SHOW_CONTEXT_MENU, menu), None);
+            self.submit_command(Command::new(commands::SHOW_CONTEXT_MENU, menu), Target::Window(self.window_id));
         } else {
             const MSG: &str = "Context menus must represent the application state.";
             if cfg!(debug_assertions) {

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -554,6 +554,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             is_handled: false,
             is_root: false,
             focus_widget: ctx.focus_widget,
+            state_types: ctx.state_types,
         };
 
         let rect = child_ctx.base_state.layout_rect.unwrap_or_default();

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -35,7 +35,7 @@ use crate::{
     WindowId,
 };
 
-use crate::command::sys as sys_cmd;
+use crate::{command::sys as sys_cmd, contexts::StateTypes};
 
 pub(crate) const RUN_COMMANDS_TOKEN: IdleToken = IdleToken::new(1);
 
@@ -187,7 +187,10 @@ impl<T: Data> Inner<T> {
             ref env,
             ..
         } = self;
-        let mut ctx = DelegateCtx { command_queue };
+        let mut ctx = DelegateCtx {
+            command_queue,
+            state_types: StateTypes::new::<T>(),
+        };
         if let Some(delegate) = delegate {
             Some(f(delegate, data, env, &mut ctx))
         } else {

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -538,10 +538,12 @@ impl<T: Data> AppState<T> {
             // FIXME: we need to be able to open a file without a window handle
             (T::Window(id), &sys_cmd::SHOW_OPEN_PANEL) => self.show_open_panel(cmd, id),
             (T::Window(id), &sys_cmd::SHOW_SAVE_PANEL) => self.show_save_panel(cmd, id),
-            (T::Window(id), &sys_cmd::CLOSE_WINDOW) => self.request_close_window(cmd, id),
-            (T::Window(_), &sys_cmd::SHOW_WINDOW) => self.show_window(cmd),
+            (T::Window(id), &sys_cmd::CLOSE_WINDOW) => self.request_close_window(id),
+            (T::Window(id), &sys_cmd::SHOW_WINDOW) => self.show_window(id),
             (T::Window(id), &sys_cmd::PASTE) => self.do_paste(id),
-            _sel => self.inner.borrow_mut().dispatch_cmd(target, cmd),
+            (_, &sys_cmd::CLOSE_WINDOW) => log::warn!("CLOSE_WINDOW command must target a window."),
+            (_, &sys_cmd::SHOW_WINDOW) => log::warn!("SHOW_WINDOW command must target a window."),
+            _ => self.inner.borrow_mut().dispatch_cmd(target, cmd),
         }
     }
 
@@ -592,19 +594,15 @@ impl<T: Data> AppState<T> {
         Ok(())
     }
 
-    fn request_close_window(&mut self, cmd: Command, window_id: WindowId) {
-        let id = cmd.get_object().unwrap_or(&window_id);
-        self.inner.borrow_mut().request_close_window(*id);
+    fn request_close_window(&mut self, id: WindowId) {
+        self.inner.borrow_mut().request_close_window(id);
     }
 
     fn request_close_all_windows(&mut self) {
         self.inner.borrow_mut().request_close_all_windows();
     }
 
-    fn show_window(&mut self, cmd: Command) {
-        let id: WindowId = *cmd
-            .get_object()
-            .expect("show window selector missing window id");
+    fn show_window(&mut self, id: WindowId) {
         self.inner.borrow_mut().show_window(id);
     }
 

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -28,9 +28,9 @@ use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::widget::LabelText;
 use crate::win_handler::RUN_COMMANDS_TOKEN;
 use crate::{
-    BoxConstraints, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
-    LayoutCtx, LifeCycle, LifeCycleCtx, MenuDesc, PaintCtx, TimerToken, UpdateCtx, Widget,
-    WidgetId, WidgetPod, WindowDesc,
+    contexts::StateTypes, BoxConstraints, Command, Data, Env, Event, EventCtx, InternalEvent,
+    InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, MenuDesc, PaintCtx, TimerToken,
+    UpdateCtx, Widget, WidgetId, WidgetPod, WindowDesc,
 };
 
 /// A unique identifier for a window.
@@ -206,6 +206,7 @@ impl<T: Data> Window<T> {
                 window: &self.handle,
                 window_id: self.id,
                 focus_widget: self.focus,
+                state_types: StateTypes::new::<T>(),
             };
 
             self.root.event(&mut ctx, &event, data, env);


### PR DESCRIPTION
Third part of #908 .

Replaces `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`.

This will get rid of any generic commands which caused quite some trouble for typed selectors.

When calling any of the methods with the wrong data type, it will  `panic!` in debug mode and `log::error!` in a release build.

I've not added `show_context_menu` to `DelegateCtx` as I could not imagine a real world usecase.
Thus I had to change `multiwin` a bit to use a `Controller` for the context menu, which seemed to be much closer to actual usage of a context menu.