### PR TITLE
Add im::Vector support to the List widget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - `UpdateCtx::request_timer` and `UpdateCtx::request_anim_frame`. ([#898] by [@finnerale])
 - `UpdateCtx::size` and `LifeCycleCtx::size`. ([#917] by [@jneem])
 - `WidgetExt::debug_widget_id`, for displaying widget ids on hover. ([#876] by [@cmyr])
-- `im` feature, with `Data` support for the [`im` crate](https://docs.rs/im/) collections. ([#924])
+- `im` feature, with `Data` support for the [`im` crate](https://docs.rs/im/) collections. ([#924] by [@cmyr])
+- `im::Vector` support for the `List` widget. ([#940] by [@xStrom])
 
 ### Changed
 
@@ -171,6 +172,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#924]: https://github.com/xi-editor/druid/pull/924
 [#925]: https://github.com/xi-editor/druid/pull/925
 [#928]: https://github.com/xi-editor/druid/pull/928
+[#940]: https://github.com/xi-editor/druid/pull/940
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -14,109 +14,122 @@
 
 //! Demos basic list widget and list manipulations.
 
-use std::sync::Arc;
-
-use druid::lens::{self, LensExt};
-use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll};
-use druid::{
-    AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WidgetExt, WindowDesc,
-};
-
-#[derive(Clone, Data, Lens)]
-struct AppData {
-    left: Arc<Vec<u32>>,
-    right: Arc<Vec<u32>>,
-}
-
+#[cfg(not(feature = "im"))]
 pub fn main() {
-    let main_window = WindowDesc::new(ui_builder)
-        .title(LocalizedString::new("list-demo-window-title").with_placeholder("List Demo"));
-    // Set our initial data
-    let data = AppData {
-        left: Arc::new(vec![1, 2]),
-        right: Arc::new(vec![1, 2, 3]),
-    };
-    AppLauncher::with_window(main_window)
-        .use_simple_logger()
-        .launch(data)
-        .expect("launch failed");
+    eprintln!("This examples requires the \"im\" feature to be enabled:");
+    eprintln!("cargo run --example list --features im");
 }
 
-fn ui_builder() -> impl Widget<AppData> {
-    let mut root = Flex::column();
+#[cfg(feature = "im")]
+pub fn main() {
+    example::main()
+}
 
-    // Build a button to add children to both lists
-    root.add_child(
-        Button::new("Add")
-            .on_click(|_, data: &mut AppData, _| {
-                // Add child to left list
-                let value = data.left.len() + 1;
-                Arc::make_mut(&mut data.left).push(value as u32);
+#[cfg(feature = "im")]
+mod example {
+    use druid::im::{vector, Vector};
+    use druid::lens::{self, LensExt};
+    use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll};
+    use druid::{
+        AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WidgetExt, WindowDesc,
+    };
 
-                // Add child to right list
-                let value = data.right.len() + 1;
-                Arc::make_mut(&mut data.right).push(value as u32);
-            })
-            .fix_height(30.0)
-            .expand_width(),
-    );
+    #[derive(Clone, Data, Lens)]
+    struct AppData {
+        left: Vector<u32>,
+        right: Vector<u32>,
+    }
 
-    let mut lists = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);
+    pub fn main() {
+        let main_window = WindowDesc::new(ui_builder)
+            .title(LocalizedString::new("list-demo-window-title").with_placeholder("List Demo"));
+        // Set our initial data
+        let data = AppData {
+            left: vector![1, 2],
+            right: vector![1, 2, 3],
+        };
+        AppLauncher::with_window(main_window)
+            .use_simple_logger()
+            .launch(data)
+            .expect("launch failed");
+    }
 
-    // Build a simple list
-    lists.add_flex_child(
-        Scroll::new(List::new(|| {
-            Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
-                .align_vertical(UnitPoint::LEFT)
-                .padding(10.0)
-                .expand()
-                .height(50.0)
-                .background(Color::rgb(0.5, 0.5, 0.5))
-        }))
-        .vertical()
-        .lens(AppData::left),
-        1.0,
-    );
+    fn ui_builder() -> impl Widget<AppData> {
+        let mut root = Flex::column();
 
-    // Build a list with shared data
-    lists.add_flex_child(
-        Scroll::new(List::new(|| {
-            Flex::row()
-                .with_child(
-                    Label::new(|(_, item): &(Arc<Vec<u32>>, u32), _env: &_| {
-                        format!("List item #{}", item)
-                    })
-                    .align_vertical(UnitPoint::LEFT),
-                )
-                .with_flex_spacer(1.0)
-                .with_child(
-                    Button::new("Delete")
-                        .on_click(|_ctx, (shared, item): &mut (Arc<Vec<u32>>, u32), _env| {
-                            // We have access to both child's data and shared data.
-                            // Remove element from right list.
-                            Arc::make_mut(shared).retain(|v| v != item);
+        // Build a button to add children to both lists
+        root.add_child(
+            Button::new("Add")
+                .on_click(|_, data: &mut AppData, _| {
+                    // Add child to left list
+                    let value = data.left.len() + 1;
+                    data.left.push_back(value as u32);
+
+                    // Add child to right list
+                    let value = data.right.len() + 1;
+                    data.right.push_back(value as u32);
+                })
+                .fix_height(30.0)
+                .expand_width(),
+        );
+
+        let mut lists = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);
+
+        // Build a simple list
+        lists.add_flex_child(
+            Scroll::new(List::new(|| {
+                Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
+                    .align_vertical(UnitPoint::LEFT)
+                    .padding(10.0)
+                    .expand()
+                    .height(50.0)
+                    .background(Color::rgb(0.5, 0.5, 0.5))
+            }))
+            .vertical()
+            .lens(AppData::left),
+            1.0,
+        );
+
+        // Build a list with shared data
+        lists.add_flex_child(
+            Scroll::new(List::new(|| {
+                Flex::row()
+                    .with_child(
+                        Label::new(|(_, item): &(Vector<u32>, u32), _env: &_| {
+                            format!("List item #{}", item)
                         })
-                        .fix_size(80.0, 20.0)
-                        .align_vertical(UnitPoint::CENTER),
-                )
-                .padding(10.0)
-                .background(Color::rgb(0.5, 0.0, 0.5))
-                .fix_height(50.0)
-        }))
-        .vertical()
-        .lens(lens::Id.map(
-            // Expose shared data with children data
-            |d: &AppData| (d.right.clone(), d.right.clone()),
-            |d: &mut AppData, x: (Arc<Vec<u32>>, Arc<Vec<u32>>)| {
-                // If shared data was changed reflect the changes in our AppData
-                d.right = x.0
-            },
-        )),
-        1.0,
-    );
+                        .align_vertical(UnitPoint::LEFT),
+                    )
+                    .with_flex_spacer(1.0)
+                    .with_child(
+                        Button::new("Delete")
+                            .on_click(|_ctx, (shared, item): &mut (Vector<u32>, u32), _env| {
+                                // We have access to both child's data and shared data.
+                                // Remove element from right list.
+                                shared.retain(|v| v != item);
+                            })
+                            .fix_size(80.0, 20.0)
+                            .align_vertical(UnitPoint::CENTER),
+                    )
+                    .padding(10.0)
+                    .background(Color::rgb(0.5, 0.0, 0.5))
+                    .fix_height(50.0)
+            }))
+            .vertical()
+            .lens(lens::Id.map(
+                // Expose shared data with children data
+                |d: &AppData| (d.right.clone(), d.right.clone()),
+                |d: &mut AppData, x: (Vector<u32>, Vector<u32>)| {
+                    // If shared data was changed reflect the changes in our AppData
+                    d.right = x.0
+                },
+            )),
+            1.0,
+        );
 
-    root.add_flex_child(lists, 1.0);
+        root.add_flex_child(lists, 1.0);
 
-    // Mark the widget as needing its layout rects painted
-    root.debug_paint_layout()
+        // Mark the widget as needing its layout rects painted
+        root.debug_paint_layout()
+    }
 }

--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -190,12 +190,6 @@ impl<T: Data, U: Data> Data for Result<T, U> {
     }
 }
 
-impl<D: Data> Data for Vec<D> {
-    fn same(&self, other: &Self) -> bool {
-        self.iter().zip(other.iter()).all(|(a, b)| a.same(b))
-    }
-}
-
 impl Data for () {
     fn same(&self, _other: &Self) -> bool {
         true

--- a/druid/src/data.rs
+++ b/druid/src/data.rs
@@ -452,13 +452,6 @@ mod test {
     use super::Data;
 
     #[test]
-    fn vec_data() {
-        let input = vec![1u8, 0, 0, 1, 0];
-        assert!(input.same(&vec![1u8, 0, 0, 1, 0]));
-        assert!(!input.same(&vec![1u8, 1, 0, 1, 0]));
-    }
-
-    #[test]
     fn array_data() {
         let input = [1u8, 0, 0, 1, 0];
         assert!(input.same(&[1u8, 0, 0, 1, 0]));

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -93,16 +93,17 @@ impl<T: Data> ListIter<T> for Vector<T> {
     }
 }
 
+// S == shared data type
 #[cfg(feature = "im")]
-impl<T1: Data, T: Data> ListIter<(T1, T)> for (T1, Vector<T>) {
-    fn for_each(&self, mut cb: impl FnMut(&(T1, T), usize)) {
+impl<S: Data, T: Data> ListIter<(S, T)> for (S, Vector<T>) {
+    fn for_each(&self, mut cb: impl FnMut(&(S, T), usize)) {
         for (i, item) in self.1.iter().enumerate() {
             let d = (self.0.to_owned(), item.to_owned());
             cb(&d, i);
         }
     }
 
-    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (T1, T), usize)) {
+    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (S, T), usize)) {
         for (i, item) in self.1.iter_mut().enumerate() {
             let mut d = (self.0.clone(), item.clone());
             cb(&mut d, i);
@@ -152,15 +153,16 @@ impl<T: Data> ListIter<T> for Arc<Vec<T>> {
     }
 }
 
-impl<T1: Data, T: Data> ListIter<(T1, T)> for (T1, Arc<Vec<T>>) {
-    fn for_each(&self, mut cb: impl FnMut(&(T1, T), usize)) {
+// S == shared data type
+impl<S: Data, T: Data> ListIter<(S, T)> for (S, Arc<Vec<T>>) {
+    fn for_each(&self, mut cb: impl FnMut(&(S, T), usize)) {
         for (i, item) in self.1.iter().enumerate() {
             let d = (self.0.clone(), item.to_owned());
             cb(&d, i);
         }
     }
 
-    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (T1, T), usize)) {
+    fn for_each_mut(&mut self, mut cb: impl FnMut(&mut (S, T), usize)) {
         let mut new_data = Vec::with_capacity(self.1.len());
         let mut any_shared_changed = false;
         let mut any_el_changed = false;


### PR DESCRIPTION
This PR adds `im::Vector` support for the `List` widget when the `im` feature is enabled. It seems to work real nicely with `ListIter<T>` where we can just pass references. The shared data `ListIter<(T1, T)>` implementation is less nice as we still need to clone data due to the signature. It may be worth looking into changing the signature for shared data lists in the future so that we could use just references even with shared data.

The `Vector` usage seems much more ergonomical than `Arc<Vec>`. I also updated the `list` example to use `Vector`. The real functional diff to the example looks great, with basically just removing code. However due to having to add feature guards the code diff looks a lot noisier.

I also removed an unnecessary variable from the `Arc<Vec>` implementation, which was the remnant of a previous refactoring.

This PR also reverts the `Data` implementation of `Vec<T: Data>` as discussed in #911. The implementation was broken as well.