### PR TITLE
Clean up cargo manifests and generate more docs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,11 +320,38 @@ jobs:
           profile: minimal
           override: true
 
-      - name: check docs in druid/
+      # Doc packages in deeper-to-higher dependency order
+      - name: cargo doc druid-shell
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --document-private-items
+          args: --manifest-path=druid-shell/Cargo.toml --document-private-items
+
+      - name: cargo doc druid
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=druid/Cargo.toml --features=svg,image,im --document-private-items
+
+      - name: cargo doc druid-derive
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=druid-derive/Cargo.toml --document-private-items
+
+      - name: cargo doc book examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=docs/book_examples/Cargo.toml --document-private-items
+
+      # On Linux also attempt docs for X11.
+      - name: cargo doc druid-shell (X11)
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=druid-shell/Cargo.toml --features=x11 --document-private-items
+        if: contains(matrix.os, 'ubuntu')
 
   mdbook-build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - GTK: Refactored `Application` to use the new structure. ([#892] by [@xStrom])
 - X11: Refactored `Application` to use the new structure. ([#894] by [@xStrom])
 - X11: Refactored `Window` to support some reentrancy and invalidation. ([#894] by [@xStrom])
-- Added docs generation testing for all features. ([#941] by [@xStrom])
+- Added docs generation testing for all features. ([#942] by [@xStrom])
 
 ### Outside News
 
@@ -174,7 +174,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#925]: https://github.com/xi-editor/druid/pull/925
 [#928]: https://github.com/xi-editor/druid/pull/928
 [#940]: https://github.com/xi-editor/druid/pull/940
-[#941]: https://github.com/xi-editor/druid/pull/941
+[#942]: https://github.com/xi-editor/druid/pull/942
 
 ## [0.5.0] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - GTK: Refactored `Application` to use the new structure. ([#892] by [@xStrom])
 - X11: Refactored `Application` to use the new structure. ([#894] by [@xStrom])
 - X11: Refactored `Window` to support some reentrancy and invalidation. ([#894] by [@xStrom])
+- Added docs generation testing for all features. ([#941] by [@xStrom])
 
 ### Outside News
 
@@ -173,6 +174,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#925]: https://github.com/xi-editor/druid/pull/925
 [#928]: https://github.com/xi-editor/druid/pull/928
 [#940]: https://github.com/xi-editor/druid/pull/940
+[#941]: https://github.com/xi-editor/druid/pull/941
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -16,5 +16,6 @@ quote = "1.0.3"
 proc-macro2 = "1.0.9"
 
 [dev-dependencies]
-druid = { path = "../druid", version = "0.6.0" }
+druid = { version = "0.6.0", path = "../druid" }
+
 float-cmp = { version = "0.6.0", default-features = false }

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -16,17 +16,19 @@ x11 = ["xcb", "cairo-sys-rs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
+# NOTE: When changing the piet or kurbo versions, ensure that
+#       the kurbo version included in piet is compatible with the kurbo version specified here.
 piet-common = "0.1.0"
+kurbo = "0.6.0"
+
 log = "0.4.8"
 lazy_static = "1.0"
 time = "0.2.7"
 cfg-if = "0.1.10"
-# NOTE: if changing, ensure version is compatible with the version in piet
-kurbo = "0.6.0"
-# NOTE: This defaults to mimicking std::time on non-wasm targets
-instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
-cairo-rs = {  version = "0.8.1", default_features = false, optional = true }
+# Optional dependencies
+cairo-rs = { version = "0.8.1", default_features = false, optional = true }
 cairo-sys-rs = { version = "0.9.2", default_features = false, optional = true }
 gio = { version = "0.8.1", optional = true }
 gdk = { version = "0.12.1", optional = true }
@@ -37,15 +39,14 @@ glib-sys = { version = "0.9.0", optional = true }
 gtk-sys = { version = "0.9.0", optional = true }
 xcb = { version = "0.9.0", features = ["thread", "xlib_xcb", "randr"], optional = true }
 
-[dev-dependencies]
-piet-common = {version = "0.1.0", features = ["png"]}
-
 [target.'cfg(target_os="windows")'.dependencies]
 wio = "0.2"
 
 [target.'cfg(target_os="windows")'.dependencies.winapi]
 version = "0.3.6"
-features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp", "d3d11", "dwmapi", "wincon", "fileapi", "processenv", "winbase", "handleapi"]
+features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser",
+            "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp",
+            "d3d11", "dwmapi", "wincon", "fileapi", "processenv", "winbase", "handleapi"]
 
 [target.'cfg(target_os="macos")'.dependencies]
 cocoa = "0.20.0"
@@ -55,19 +56,22 @@ foreign-types = "0.3.2"
 
 # TODO(x11/dependencies): only use feature "xcb" if using XCB
 [target.'cfg(target_os="linux")'.dependencies]
-cairo-rs = {  version = "0.8.1", default_features = false, features = ["xcb"] }
+cairo-rs = { version = "0.8.1", default_features = false, features = ["xcb"] }
 gio = "0.8.1"
 gdk = "0.12.1"
 gdk-sys = "0.9.0"
 glib = "0.9.3"
 glib-sys = "0.9.0"
 gtk-sys = "0.9.0"
-
-[target.'cfg(target_os="linux")'.dependencies.gtk]
-version = "0.8.1"
-features = ["v3_20"]
+gtk = { version = "0.8.1", features = ["v3_20"] }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 wasm-bindgen = "0.2.59"
 js-sys = "0.3.36"
-web-sys = { version = "0.3.36", features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent"] }
+
+[target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
+version = "0.3.36"
+features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent"]
+
+[dev-dependencies]
+piet-common = { version = "0.1.0", features = ["png"] }

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -11,40 +11,36 @@ keywords = ["gui", "ui", "toolkit"]
 edition = "2018"
 
 [package.metadata.docs.rs]
+# The "svg" and "image" features have doc clashes that cause undefined output in docs.
+# See https://github.com/rust-lang/cargo/issues/6313 for more information.
+# Once cargo doc becomes smart enough to handle multiple versions of the same crate,
+# the "svg" and "image" features should be enabled for the docs.rs output.
+features = ["im"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]
 x11 = ["druid-shell/x11"]
 svg = ["usvg"]
 
-[badges]
-travis-ci = { repository = "xi-editor/druid" }
-
 [dependencies]
+druid-shell = { version = "0.6.0", path = "../druid-shell" }
+druid-derive = { version = "0.4.0", path = "../druid-derive" }
+
+log = "0.4.8"
+simple_logger = { version = "1.6.0", default-features = false }
 fluent-bundle = "0.11.0"
 fluent-langneg = "0.12.1"
 fluent-syntax = "0.9.1"
 unic-langid = "0.8.0"
 unicode-segmentation = "1.6.0"
-log = "0.4.8"
-usvg = {version = "0.9.0", optional = true}
-fnv = "1.0.3"
 xi-unicode = "0.2.0"
-image = {version = "0.23.2", optional = true}
-instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+fnv = "1.0.3"
+instant = { version = "0.1", features = ["wasm-bindgen"] }
+
+# Optional dependencies
 im = { version = "14.0", optional = true }
-
-[dependencies.simple_logger]
-version = "1.6.0"
-default-features = false
-
-[dependencies.druid-shell]
-path = "../druid-shell"
-version = "0.6.0"
-
-[dependencies.druid-derive]
-path = "../druid-derive"
-version = "0.4.0"
+usvg = { version = "0.9.0", optional = true }
+image = { version = "0.23.2", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 console_log = "0.1.2"
@@ -52,4 +48,4 @@ console_log = "0.1.2"
 [dev-dependencies]
 float-cmp = { version = "0.6.0", default-features = false }
 tempfile = "3.1.0"
-piet-common = {version = "0.1.0", features = ["png"]}
+piet-common = { version = "0.1.0", features = ["png"] }

--- a/druid/examples/wasm/Cargo.toml
+++ b/druid/examples/wasm/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-druid = { path="../.."}
+druid = { path="../.." }
 wasm-bindgen = "0.2.60"
 console_error_panic_hook = { version = "0.1.6" }
 log = "0.4.8"
-instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 simple_logger = { version = "1.6.0", default-features = false }


### PR DESCRIPTION
This PR does the following:
* Enables the `im` feature for [docs.rs/druid](https://docs.rs/druid/).
  The `svg` and `image` features run into cargo bugs unfortunately and will have to wait.
* Adds CI docs generation for all the crates with their features.
* Cleans up the `Cargo.toml` files so that they follow a unified style.