### PR TITLE
Remove references to cairo on macOS.

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -10,9 +10,6 @@ jobs:
     # if it isn't an issue comment run every time, otherwise only run if the comment starts with '/bloat'
     if: (!startsWith(github.event_name, 'issue_comment') || startsWith(github.event.comment.body, '/bloat'))
     steps:
-      - name: install cairo (macOS)
-        run: brew install cairo
-
       - name: checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install cairo
-        run: brew install cairo
-        if: contains(matrix.os, 'mac')
-
       - name: install libgtk-3-dev libx11-dev
         run: |
           sudo apt update
@@ -236,10 +232,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install cairo
-        run: brew install cairo
-        if: contains(matrix.os, 'mac')
-
       - name: install libgtk-dev libx11-dev
         run: |
           sudo apt update
@@ -302,10 +294,6 @@ jobs:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-
-      - name: install cairo
-        run: brew install cairo
-        if: contains(matrix.os, 'mac')
 
       - name: install libgtk-dev
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,18 @@ While still incomplete this lays the foundation for running druid on Linux witho
 
 #### Mostly complete Wasm backend for druid-shell. ([#759])
 
-[@elrnv] continued the work of [@tedsta] and implemented a mostly complete Wasm backend and enabled all druid examples to [run in the browser](https://elrnv.github.io/druid-wasm-examples/).
+[@elrnv] continued the work of [@tedsta] and implemented a mostly complete Wasm backend and enabled
+all druid examples to [run in the browser](https://elrnv.github.io/druid-wasm-examples/).
 
-While some features like the clipboard, menus or file dialogs are not yet available, all fundamental features are there.
+While some features like the clipboard, menus or file dialogs are not yet available,
+all fundamental features are there.
+
+#### Using Core Graphics on macOS. ([#905])
+
+[@cmyr] continued the work of [@jrmuizel] and implemented Core Graphics support for piet in
+[piet#176](https://github.com/linebender/piet/pull/176).
+
+Those changes made it into druid via [#905].
 
 ### Added
 
@@ -99,6 +108,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 - Added hot glow option to multiwin example. ([#845] by [@xStrom])
 - Added new example for blocking functions. ([#840] by [@mastfissh])
 - Added a changelog containing development since the 0.5 release. ([#889] by [@finnerale])
+- Removed references to cairo on macOS. ([#943] by [@xStrom])
 
 ### Maintenance
 
@@ -167,6 +177,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#898]: https://github.com/xi-editor/druid/pull/898
 [#900]: https://github.com/xi-editor/druid/pull/900
 [#903]: https://github.com/xi-editor/druid/pull/903
+[#905]: https://github.com/xi-editor/druid/pull/905
 [#909]: https://github.com/xi-editor/druid/pull/909
 [#917]: https://github.com/xi-editor/druid/pull/917
 [#920]: https://github.com/xi-editor/druid/pull/920
@@ -175,6 +186,7 @@ While some features like the clipboard, menus or file dialogs are not yet availa
 [#928]: https://github.com/xi-editor/druid/pull/928
 [#940]: https://github.com/xi-editor/druid/pull/940
 [#942]: https://github.com/xi-editor/druid/pull/942
+[#943]: https://github.com/xi-editor/druid/pull/943
 
 ## [0.5.0] - 2020-04-01
 
@@ -205,6 +217,7 @@ Last release without a changelog :(
 [@mastfissh]: https://github.com/mastfissh
 [@Zarenor]: https://github.com/Zarenor
 [@yrns]: https://github.com/yrns
+[@jrmuizel]: https://github.com/jrmuizel
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
 [0.5.0]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ all fundamental features are there.
 [piet#176](https://github.com/linebender/piet/pull/176).
 
 Those changes made it into druid via [#905].
+This means that druid no longer requires cairo on macOS and uses Core Graphics instead.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ couple of [non-druid examples].
 
 ### piet
 
-Druid relies on the [piet library] for drawing and text layout. Piet is a 2D
-graphics abstraction with multiple backends: `piet-direct2d`, `piet-cairo`, and
-`piet-web` are currently available, and a GPU backend is planned. In terms of
-OS support, macOS and Linux use `piet-cairo`, and Windows uses `piet-direct2d`.
+Druid relies on the [piet library] for drawing and text layout. Piet is a 2D graphics
+abstraction with multiple backends: `piet-direct2d`, `piet-coregraphics`, `piet-cairo`,
+`piet-web`, and `piet-svg` are currently available, and a GPU backend is planned.
+In terms of druid platform support via piet, macOS uses `piet-coregraphics`,
+Linux uses `piet-cairo`, Windows uses `piet-direct2d`, and web uses `piet-web`.
 
 ```rust
 use druid::kurbo::{BezPath, Point, Rect};
@@ -237,11 +238,6 @@ druid = { git = "https://github.com/xi-editor/druid.git", version = "0.5" }
 
 ### Platform notes
 
-#### macOS
-
-On macOS, druid requires [cairo]; if you use homebrew, `brew install cairo`
-should be sufficient. Removing this dependency is on the roadmap.
-
 #### Linux
 
 On Linux, druid requires gtk+3; see [gtk-rs dependencies] for installation
@@ -283,7 +279,6 @@ active and friendly community.
 [basic utility and layout widgets]: ./druid/src/widget
 [Flutter's box layout model]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
 [value types]: https://sinusoid.es/lager/model.html#id2
-[cairo]: https://www.cairographics.org
 [gtk-rs dependencies]: http://gtk-rs.org/docs/requirements.html
 [Rust-native GUI experiments]: https://areweguiyet.com
 [CONTRIBUTING.md]: ./CONTRIBUTING.md

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -9,10 +9,6 @@ application, then it will show you how to set up a basic application, build it a
 ## Setting up Druid dependencies
 In addition to including the druid library in your project
 
-### macOS
-On macOS, druid requires [cairo]; if you use homebrew, `brew install cairo`
-should be sufficient. Removing this dependency is on the roadmap.
-
 ### Linux
 On Linux, druid requires gtk+3.
 
@@ -41,5 +37,4 @@ druid = "0.5.0"
 druid = { git = "https://github.com/xi-editor/druid.git", branch = "master" }
 ```
 
-[cairo]: https://www.cairographics.org
 [gtk-rs dependencies]: http://gtk-rs.org/docs/requirements.html


### PR DESCRIPTION
I added a changelog entry for the transition to Core Graphics on macOS and removed all references to cairo on macOS.