### PR TITLE
Fix progress bar rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#953]: https://github.com/xi-editor/druid/pull/953
 [#954]: https://github.com/xi-editor/druid/pull/954
 [#959]: https://github.com/xi-editor/druid/pull/959
+[#949]: https://github.com/xi-editor/druid/pull/949
 
 ## [0.5.0] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Keep hot state consistent with mouse position. ([#841] by [@xStrom])
 - Open file menu item works again. ([#851] by [@kindlychung])
 - Supply correct `LifeCycleCtx` to `Event::FocusChanged`. ([#878] by [@cmyr])
-- Windows: Termiate app when all windows have closed. ([#763] by [@xStrom])
+- Windows: Terminate app when all windows have closed. ([#763] by [@xStrom])
 - macOS: `Application::quit` now quits the run loop instead of killing the process. ([#763] by [@xStrom])
 - macOS/GTK/web: `MouseButton::X1` and `MouseButton::X2` clicks are now recognized. ([#843] by [@xStrom])
 - GTK: Support disabled menu items. ([#897] by [@jneem])
@@ -105,6 +105,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Improved `Split` accuracy. ([#738] by [@xStrom])
 - Built-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
 - `Switch` toggles with animation when its data changes externally. ([#898] by [@finnerale])
+- Render progress bar correctly. ([#949] by [@scholtzan])
 
 ### Docs
 
@@ -231,6 +232,7 @@ Last release without a changelog :(
 [@Zarenor]: https://github.com/Zarenor
 [@yrns]: https://github.com/yrns
 [@jrmuizel]: https://github.com/jrmuizel
+[@scholtzan]: https://github.com/scholtzan
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.5.0...master
 [0.5.0]: https://github.com/xi-editor/druid/compare/v0.4.0...v0.5.0

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -60,6 +60,7 @@ impl Widget<f64> for ProgressBar {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &f64, env: &Env) {
         let clamped = data.max(0.0).min(1.0);
         let stroke_width = 2.0;
+        let inset = -stroke_width / 2.0;
 
         let rounded_rect = Rect::from_origin_size(
             Point::ORIGIN,
@@ -69,13 +70,13 @@ impl Widget<f64> for ProgressBar {
             })
             .to_vec2(),
         )
-        .inset(-stroke_width / 2.0)
+        .inset(inset)
         .to_rounded_rect(4.0);
 
-        //Paint the border
+        // Paint the border
         ctx.stroke(rounded_rect, &env.get(theme::BORDER_DARK), stroke_width);
 
-        //Paint the background
+        // Paint the background
         let background_gradient = LinearGradient::new(
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
@@ -86,18 +87,20 @@ impl Widget<f64> for ProgressBar {
         );
         ctx.fill(rounded_rect, &background_gradient);
 
-        //Paint the bar
+        // Paint the bar
         let calculated_bar_width = clamped * rounded_rect.width();
+
         let rounded_rect = Rect::from_origin_size(
-            Point::ORIGIN,
+            Point::new(-inset, 0.),
             (Size {
                 width: calculated_bar_width,
                 height: env.get(theme::BASIC_WIDGET_HEIGHT),
             })
             .to_vec2(),
         )
-        .inset(-stroke_width / 2.0)
+        .inset((0.0, inset))
         .to_rounded_rect(env.get(theme::PROGRESS_BAR_RADIUS));
+
         let bar_gradient = LinearGradient::new(
             UnitPoint::TOP,
             UnitPoint::BOTTOM,


### PR DESCRIPTION
Fixes https://github.com/xi-editor/druid/issues/919

The problem causing this rendering issue is that insets get applied to a `Rect` with zero width. This results in a `Rect` of some negative width getting displayed when the progress bar is at zero.