### PR TITLE
Add hot state updating via wheel events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - X11: Support key and mouse button state. ([#920] by [@jneem])
 - Routing `LifeCycle::FocusChanged` to descendant widgets. ([#925] by [@yrns])
 - Built-in open and save menu items now show the correct label and submit the right commands. ([#930] by [@finnerale])
+- Wheel events now properly update hot state. ([#951] by [@xStrom])
 
 ### Visual
 
@@ -192,6 +193,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#940]: https://github.com/xi-editor/druid/pull/940
 [#942]: https://github.com/xi-editor/druid/pull/942
 [#943]: https://github.com/xi-editor/druid/pull/943
+[#951]: https://github.com/xi-editor/druid/pull/951
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -658,6 +658,22 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 mouse_event.pos -= rect.origin().to_vec2();
                 Event::MouseMove(mouse_event)
             }
+            Event::Wheel(mouse_event) => {
+                WidgetPod::set_hot_state(
+                    &mut self.inner,
+                    child_ctx.command_queue,
+                    child_ctx.base_state,
+                    child_ctx.window_id,
+                    rect,
+                    Some(mouse_event.pos),
+                    data,
+                    env,
+                );
+                recurse = had_active || child_ctx.base_state.is_hot;
+                let mut mouse_event = mouse_event.clone();
+                mouse_event.pos -= rect.origin().to_vec2();
+                Event::Wheel(mouse_event)
+            }
             Event::KeyDown(e) => {
                 recurse = child_ctx.has_focus();
                 Event::KeyDown(*e)
@@ -669,12 +685,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             Event::Paste(e) => {
                 recurse = child_ctx.has_focus();
                 Event::Paste(e.clone())
-            }
-            Event::Wheel(wheel_event) => {
-                recurse = had_active || child_ctx.base_state.is_hot;
-                let mut wheel_event = wheel_event.clone();
-                wheel_event.pos -= rect.origin().to_vec2();
-                Event::Wheel(wheel_event)
             }
             Event::Zoom(zoom) => {
                 recurse = had_active || child_ctx.base_state.is_hot;


### PR DESCRIPTION
This fixes an edge case where we receive a wheel event at a location different than the last move event.