### PR TITLE
Fix simple logger init checks.

### DIFF
--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -87,9 +87,9 @@ impl<T: Data> AppLauncher<T> {
     /// Meant for use during development only.
     pub fn use_simple_logger(self) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
-        simple_logger::init().ok();
+        simple_logger::init().expect("Failed to init simple logger");
         #[cfg(target_arch = "wasm32")]
-        console_log::init_with_level(log::Level::Trace).ok();
+        console_log::init_with_level(log::Level::Trace).expect("Failed to init simple logger");
         self
     }
 

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -85,9 +85,9 @@ impl<T: Data> AppLauncher<T> {
     /// Initialize a minimal logger for printing logs out to stderr.
     ///
     /// Meant for use during development only.
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the logger fails to initialize.
     pub fn use_simple_logger(self) -> Self {
         #[cfg(not(target_arch = "wasm32"))]

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -85,6 +85,10 @@ impl<T: Data> AppLauncher<T> {
     /// Initialize a minimal logger for printing logs out to stderr.
     ///
     /// Meant for use during development only.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the logger fails to initialize.
     pub fn use_simple_logger(self) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         simple_logger::init().expect("Failed to init simple logger");


### PR DESCRIPTION
Converting the `Result` into an `Option` and not doing anything with it seems like a mistake. I think `unwrap` was intended. I went with `expect` with a bit more info.