### PR TITLE
Add the LifeCycle::Size event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `WidgetExt::debug_widget_id`, for displaying widget ids on hover. ([#876] by [@cmyr])
 - `im` feature, with `Data` support for the [`im` crate](https://docs.rs/im/) collections. ([#924] by [@cmyr])
 - `im::Vector` support for the `List` widget. ([#940] by [@xStrom])
+- `LifeCycle::Size` event to inform widgets that their size changed. ([#953] by [@xStrom])
 
 ### Changed
 
@@ -194,6 +195,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#942]: https://github.com/xi-editor/druid/pull/942
 [#943]: https://github.com/xi-editor/druid/pull/943
 [#951]: https://github.com/xi-editor/druid/pull/951
+[#953]: https://github.com/xi-editor/druid/pull/953
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -178,6 +178,14 @@ pub enum LifeCycle {
     /// [`WidgetPod`]: struct.WidgetPod.html
     /// [`LifeCycleCtx::register_for_focus`]: struct.LifeCycleCtx.html#method.register_for_focus
     WidgetAdded,
+    /// Called when the size of the widget changes.
+    ///
+    /// The [`Size`] is derived from the [`Rect`] that was set with [`WidgetPod::set_layout_rect`].
+    ///
+    /// [`Size`]: struct.Size.html
+    /// [`Rect`]: struct.Rect.html
+    /// [`WidgetPod::set_layout_rect`]: struct.WidgetPod.html#method.set_layout_rect
+    Size(Size),
     /// Called at the beginning of a new animation frame.
     ///
     /// On the first frame when transitioning from idle to animating, `interval`


### PR DESCRIPTION
There have been several occurrences now where a widget would like to know when its size changes and do some non-layout work. This was [disccused in zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/send.20command.20to.20sibling.20when.20resize) and this would also help solve an animation issue with the `Scroll` widget as explained in #834.

Thus this PR adds the `LifeCycle::Size` event which gets sent every time the size of the widget changes.