### PR TITLE
Add the request_timer method to LifeCycleCtx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `MouseButtons` to `MouseEvent` to track which buttons are being held down during an event. ([#843] by [@xStrom])
 - `Env` and `Key` gained methods for inspecting an `Env` at runtime ([#880] by [@Zarenor])
 - `UpdateCtx::request_timer` and `UpdateCtx::request_anim_frame`. ([#898] by [@finnerale])
+- `LifeCycleCtx::request_timer`. ([#954] by [@xStrom])
 - `UpdateCtx::size` and `LifeCycleCtx::size`. ([#917] by [@jneem])
 - `WidgetExt::debug_widget_id`, for displaying widget ids on hover. ([#876] by [@cmyr])
 - `im` feature, with `Data` support for the [`im` crate](https://docs.rs/im/) collections. ([#924] by [@cmyr])
@@ -196,6 +197,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#943]: https://github.com/xi-editor/druid/pull/943
 [#951]: https://github.com/xi-editor/druid/pull/951
 [#953]: https://github.com/xi-editor/druid/pull/953
+[#954]: https://github.com/xi-editor/druid/pull/954
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -62,6 +62,7 @@ pub struct LifeCycleCtx<'a> {
     pub(crate) command_queue: &'a mut CommandQueue,
     pub(crate) base_state: &'a mut BaseState,
     pub(crate) window_id: WindowId,
+    pub(crate) window: &'a WindowHandle,
 }
 
 /// A mutable context provided to data update methods of widgets.
@@ -91,6 +92,7 @@ pub struct LayoutCtx<'a, 'b: 'a> {
     pub(crate) base_state: &'a mut BaseState,
     pub(crate) text_factory: &'a mut Text<'b>,
     pub(crate) window_id: WindowId,
+    pub(crate) window: &'a WindowHandle,
     pub(crate) mouse_pos: Option<Point>,
 }
 
@@ -546,6 +548,17 @@ impl<'a> LifeCycleCtx<'a> {
     pub fn request_anim_frame(&mut self) {
         self.base_state.request_anim = true;
         self.request_paint();
+    }
+
+    /// Request a timer event.
+    ///
+    /// The return value is a token, which can be used to associate the
+    /// request with the event.
+    pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
+        self.base_state.request_timer = true;
+        let timer_token = self.window.request_timer(deadline);
+        self.base_state.add_timer(timer_token);
+        timer_token
     }
 
     /// The layout size.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -213,6 +213,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
                 command_queue: ctx.command_queue,
                 base_state: &mut self.state,
                 window_id: ctx.window_id,
+                window: ctx.window,
             };
             let size_event = LifeCycle::Size(new_size);
             self.inner.lifecycle(&mut child_ctx, &size_event, data, env);
@@ -703,6 +704,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     child_ctx.command_queue,
                     child_ctx.base_state,
                     child_ctx.window_id,
+                    child_ctx.window,
                     rect,
                     Some(mouse_event.pos),
                     data,

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -24,7 +24,7 @@ use crate::piet::{
 use crate::{
     BoxConstraints, Color, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
     LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Region, Target, TimerToken, UpdateCtx, Widget,
-    WidgetId, WindowId,
+    WidgetId, WindowHandle, WindowId,
 };
 
 /// Our queue type
@@ -224,6 +224,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
             ctx.command_queue,
             &mut self.state,
             ctx.window_id,
+            ctx.window,
             layout_rect,
             ctx.mouse_pos,
             data,
@@ -334,6 +335,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         command_queue: &mut CommandQueue,
         child_state: &mut BaseState,
         window_id: WindowId,
+        window: &WindowHandle,
         rect: Rect,
         mouse_pos: Option<Point>,
         data: &T,
@@ -350,6 +352,7 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
                 command_queue,
                 base_state: child_state,
                 window_id,
+                window,
             };
             child.lifecycle(&mut child_ctx, &hot_changed_event, data, env);
             // if hot changes and we're showing widget ids, always repaint
@@ -515,6 +518,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             command_queue: ctx.command_queue,
             base_state: &mut self.state,
             window_id: ctx.window_id,
+            window: ctx.window,
             text_factory: ctx.text_factory,
             mouse_pos: child_mouse_pos,
         };
@@ -600,6 +604,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                         child_ctx.command_queue,
                         child_ctx.base_state,
                         child_ctx.window_id,
+                        child_ctx.window,
                         rect,
                         None,
                         data,
@@ -647,6 +652,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     child_ctx.command_queue,
                     child_ctx.base_state,
                     child_ctx.window_id,
+                    child_ctx.window,
                     rect,
                     Some(mouse_event.pos),
                     data,
@@ -663,6 +669,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     child_ctx.command_queue,
                     child_ctx.base_state,
                     child_ctx.window_id,
+                    child_ctx.window,
                     rect,
                     Some(mouse_event.pos),
                     data,
@@ -679,6 +686,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                     child_ctx.command_queue,
                     child_ctx.base_state,
                     child_ctx.window_id,
+                    child_ctx.window,
                     rect,
                     Some(mouse_event.pos),
                     data,
@@ -839,6 +847,7 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             command_queue: ctx.command_queue,
             base_state: &mut self.state,
             window_id: ctx.window_id,
+            window: ctx.window,
         };
 
         if recurse {
@@ -1005,6 +1014,7 @@ mod tests {
             command_queue: &mut command_queue,
             base_state: &mut state,
             window_id: WindowId::next(),
+            window: &WindowHandle::default(),
         };
 
         let env = Env::default();


### PR DESCRIPTION
This PR adds the `request_timer` method to `LifeCycleCtx` which will allow to fix the `Scroll` widget as explained in #834.

To achieve this I had to introduce the `WindowHandle` pointer to both `LifeCycleCtx` and `LayoutCtx`.