### PR TITLE
Fix GTK folder selection with filters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ You can find its changes [documented below](#060---2020-06-01).
 
 ### Fixed
 
+- GTK: Directory selection now properly ignores file filters. ([#957] by [@xStrom])
+
 ### Visual
 
 - `TextBox` stroke remains inside its `paint_rect`. ([#1007] by [@jneem])
@@ -295,6 +297,7 @@ Last release without a changelog :(
 [#951]: https://github.com/xi-editor/druid/pull/951
 [#953]: https://github.com/xi-editor/druid/pull/953
 [#954]: https://github.com/xi-editor/druid/pull/954
+[#957]: https://github.com/xi-editor/druid/pull/957
 [#959]: https://github.com/xi-editor/druid/pull/959
 [#961]: https://github.com/xi-editor/druid/pull/961
 [#963]: https://github.com/xi-editor/druid/pull/963

--- a/druid-shell/src/platform/gtk/dialog.rs
+++ b/druid-shell/src/platform/gtk/dialog.rs
@@ -53,7 +53,9 @@ pub(crate) fn get_file_dialog_path(
 
     dialog.set_show_hidden(options.show_hidden);
 
-    dialog.set_select_multiple(options.multi_selection);
+    if action != FileChooserAction::Save {
+        dialog.set_select_multiple(options.multi_selection);
+    }
 
     // Don't set the filters when showing the folder selection dialog,
     // because then folder traversing won't work.
@@ -76,15 +78,9 @@ pub(crate) fn get_file_dialog_path(
             }
         }
 
-        if let Some(default_file_type) = &options.default_type {
-            if options.allowed_types.is_some() && !found_default_filter {
-                // It's ok to set a default file filter without providing a list of
-                // allowed filters, but it's not ok (or at least, doesn't work in gtk)
-                // to provide a default filter that isn't in the (present) list
-                // of allowed filters.
-                log::warn!("default file type not found in allowed types");
-            } else if !found_default_filter {
-                dialog.set_filter(&file_filter(default_file_type));
+        if let Some(dt) = &options.default_type {
+            if !found_default_filter {
+                log::warn!("The default type {:?} is not present in allowed types.", dt);
             }
         }
     }

--- a/druid-shell/src/platform/gtk/dialog.rs
+++ b/druid-shell/src/platform/gtk/dialog.rs
@@ -55,33 +55,37 @@ pub(crate) fn get_file_dialog_path(
 
     dialog.set_select_multiple(options.multi_selection);
 
-    let mut found_default_filter = false;
-    if let Some(file_types) = &options.allowed_types {
-        for f in file_types {
-            let filter = file_filter(f);
-            dialog.add_filter(&filter);
+    // Don't set the filters when showing the folder selection dialog,
+    // because then folder traversing won't work.
+    if action != FileChooserAction::SelectFolder {
+        let mut found_default_filter = false;
+        if let Some(file_types) = &options.allowed_types {
+            for f in file_types {
+                let filter = file_filter(f);
+                dialog.add_filter(&filter);
 
-            if let Some(default) = &options.default_type {
-                if default == f {
-                    // Note that we're providing the same FileFilter object to
-                    // add_filter and set_filter, because gtk checks them for
-                    // identity, not structural equality.
-                    dialog.set_filter(&filter);
-                    found_default_filter = true;
+                if let Some(default) = &options.default_type {
+                    if default == f {
+                        // Note that we're providing the same FileFilter object to
+                        // add_filter and set_filter, because gtk checks them for
+                        // identity, not structural equality.
+                        dialog.set_filter(&filter);
+                        found_default_filter = true;
+                    }
                 }
             }
         }
-    }
 
-    if let Some(default_file_type) = &options.default_type {
-        if options.allowed_types.is_some() && !found_default_filter {
-            // It's ok to set a default file filter without providing a list of
-            // allowed filters, but it's not ok (or at least, doesn't work in gtk)
-            // to provide a default filter that isn't in the (present) list
-            // of allowed filters.
-            log::warn!("default file type not found in allowed types");
-        } else if !found_default_filter {
-            dialog.set_filter(&file_filter(default_file_type));
+        if let Some(default_file_type) = &options.default_type {
+            if options.allowed_types.is_some() && !found_default_filter {
+                // It's ok to set a default file filter without providing a list of
+                // allowed filters, but it's not ok (or at least, doesn't work in gtk)
+                // to provide a default filter that isn't in the (present) list
+                // of allowed filters.
+                log::warn!("default file type not found in allowed types");
+            } else if !found_default_filter {
+                dialog.set_filter(&file_filter(default_file_type));
+            }
         }
     }
 


### PR DESCRIPTION
This PR disables file filters when opening folders, because the filter makes it impossible to traverse in the folder structure.

Fixes #947.