### PR TITLE
Remove one shot commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `AppDelegate::command` now receives a `Target` instead of a `&Target`. ([#909] by [@xStrom])
 - `SHOW_WINDOW` and `CLOSE_WINDOW` commands now only use `Target` to determine the affected window. ([#928] by [@finnerale])
 - Replaced `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`. ([#931] by [@finnerale])
+- Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
 
 ### Deprecated
 
@@ -198,6 +199,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#951]: https://github.com/xi-editor/druid/pull/951
 [#953]: https://github.com/xi-editor/druid/pull/953
 [#954]: https://github.com/xi-editor/druid/pull/954
+[#959]: https://github.com/xi-editor/druid/pull/959
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -19,7 +19,9 @@ use std::{
     collections::VecDeque,
 };
 
-use crate::{commands, Command, Data, Env, Event, MenuDesc, Target, WindowDesc, WindowId};
+use crate::{
+    command::SingleUse, commands, Command, Data, Env, Event, MenuDesc, Target, WindowDesc, WindowId,
+};
 
 /// A context passed in to [`AppDelegate`] functions.
 ///
@@ -55,7 +57,7 @@ impl<'a> DelegateCtx<'a> {
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         if self.app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::one_shot(commands::NEW_WINDOW, desc),
+                Command::new(commands::NEW_WINDOW, SingleUse::new(desc)),
                 Target::Global,
             );
         } else {

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use crate::{
-    command::SingleUse, commands, Command, Data, Env, Event, MenuDesc, Target, WindowDesc, WindowId,
+    commands, Command, Data, Env, Event, MenuDesc, SingleUse, Target, WindowDesc, WindowId,
 };
 
 /// A context passed in to [`AppDelegate`] functions.

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -35,7 +35,7 @@ pub struct Selector(&'static str);
 /// and an optional argument, that can be used to pass arbitrary data.
 ///
 /// If the payload can't or shouldn't be cloned,
-/// wrapping it with [`SingleUse`] allows `take`ing the object.
+/// wrapping it with [`SingleUse`] allows you to `take` the object.
 ///
 /// # Examples
 /// ```

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -230,11 +230,6 @@ impl Command {
     }
 
     /// Return a reference to this `Command`'s object, if it has one.
-    ///
-    /// This only works for 'reusable' commands; it does not work for commands
-    /// created with [`one_shot`].
-    ///
-    /// [`one_shot`]: #method.one_shot
     pub fn get_object<T: Any>(&self) -> Result<&T, ArgumentError> {
         match self.object.as_ref() {
             Some(o) => o.downcast_ref().ok_or(ArgumentError::IncorrectType),

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -59,9 +59,32 @@ pub struct Command {
     object: Option<Arc<dyn Any>>,
 }
 
-/// `SingleUse` is intended for cases where a command payload should only be
-/// used once; an example would be if you have some resource that cannot be
+/// A wrapper type for [`Command`] arguments that should only be used once.
+///
+/// This is useful if you have some resource that cannot be
 /// cloned, and you wish to send it to another widget.
+///
+/// # Examples
+/// ```
+/// use druid::{Command, Selector, SingleUse};
+///
+/// struct CantClone(u8);
+///
+/// let selector = Selector::new("use-once");
+/// let num = CantClone(42);
+/// let command = Command::new(selector, SingleUse::new(num));
+///
+/// let object: &SingleUse<CantClone> = command.get_object().unwrap();
+/// if let Some(num) = object.take() {
+///     // now you own the data
+///     assert_eq!(num.0, 42);
+/// }
+///
+/// // subsequent calls will return `None`
+/// assert!(object.take().is_none());
+/// ```
+///
+/// [`Command`]: struct.Command.html
 pub struct SingleUse<T>(Mutex<Option<T>>);
 
 /// Errors that can occur when attempting to retrieve the a command's argument.

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -24,8 +24,8 @@ use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::piet::Piet;
 use crate::piet::RenderContext;
 use crate::{
-    commands, Affine, Command, ContextMenu, Cursor, Insets, MenuDesc, Point, Rect, Size, Target,
-    Text, TimerToken, Vec2, WidgetId, WindowDesc, WindowHandle, WindowId,
+    command::SingleUse, commands, Affine, Command, ContextMenu, Cursor, Insets, MenuDesc, Point,
+    Rect, Size, Target, Text, TimerToken, Vec2, WidgetId, WindowDesc, WindowHandle, WindowId,
 };
 
 /// A mutable context provided to event handling methods of widgets.
@@ -255,7 +255,7 @@ impl<'a> EventCtx<'a> {
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         if self.app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::one_shot(commands::NEW_WINDOW, desc),
+                Command::new(commands::NEW_WINDOW, SingleUse::new(desc)),
                 Target::Global,
             );
         } else {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -24,8 +24,8 @@ use crate::core::{BaseState, CommandQueue, FocusChange};
 use crate::piet::Piet;
 use crate::piet::RenderContext;
 use crate::{
-    command::SingleUse, commands, Affine, Command, ContextMenu, Cursor, Insets, MenuDesc, Point,
-    Rect, Size, Target, Text, TimerToken, Vec2, WidgetId, WindowDesc, WindowHandle, WindowId,
+    commands, Affine, Command, ContextMenu, Cursor, Insets, MenuDesc, Point, Rect, SingleUse, Size,
+    Target, Text, TimerToken, Vec2, WidgetId, WindowDesc, WindowHandle, WindowId,
 };
 
 /// A mutable context provided to event handling methods of widgets.

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -153,7 +153,7 @@ pub use crate::core::WidgetPod;
 pub use app::{AppLauncher, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
-pub use command::{sys as commands, Command, Selector, Target};
+pub use command::{sys as commands, Command, Selector, SingleUse, Target};
 pub use contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, Region, UpdateCtx};
 pub use data::Data;
 pub use env::{Env, Key, KeyOrValue, Value, ValueType};

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -593,7 +593,7 @@ impl<T: Data> AppState<T> {
     fn new_window(&mut self, cmd: Command) -> Result<(), Box<dyn std::error::Error>> {
         let desc = cmd.get_object::<SingleUse<WindowDesc<T>>>()?;
         // The NEW_WINDOW command is private and only druid can receive it by normal means,
-        // thus unwrapping can be considered save or deserves a panic.
+        // thus unwrapping can be considered safe and deserves a panic.
         let desc = desc.take().unwrap();
         let window = desc.build_native(self)?;
         window.show();

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -35,7 +35,7 @@ use crate::{
     WindowId,
 };
 
-use crate::command::sys as sys_cmd;
+use crate::command::{sys as sys_cmd, SingleUse};
 
 pub(crate) const RUN_COMMANDS_TOKEN: IdleToken = IdleToken::new(1);
 
@@ -591,7 +591,10 @@ impl<T: Data> AppState<T> {
     }
 
     fn new_window(&mut self, cmd: Command) -> Result<(), Box<dyn std::error::Error>> {
-        let desc = cmd.take_object::<WindowDesc<T>>()?;
+        let desc = cmd.get_object::<SingleUse<WindowDesc<T>>>()?;
+        // The NEW_WINDOW command is private and only druid can receive it by normal means,
+        // thus unwrapping can be considered save or deserves a panic.
+        let desc = desc.take().unwrap();
         let window = desc.build_native(self)?;
         window.show();
         Ok(())

--- a/druid/src/win_handler.rs
+++ b/druid/src/win_handler.rs
@@ -31,11 +31,11 @@ use crate::ext_event::ExtEventHost;
 use crate::menu::ContextMenu;
 use crate::window::Window;
 use crate::{
-    Command, Data, Env, Event, InternalEvent, KeyEvent, MenuDesc, Target, TimerToken, WindowDesc,
-    WindowId,
+    Command, Data, Env, Event, InternalEvent, KeyEvent, MenuDesc, SingleUse, Target, TimerToken,
+    WindowDesc, WindowId,
 };
 
-use crate::command::{sys as sys_cmd, SingleUse};
+use crate::command::sys as sys_cmd;
 
 pub(crate) const RUN_COMMANDS_TOKEN: IdleToken = IdleToken::new(1);
 


### PR DESCRIPTION
Fourth part of #908 .

I gave the suggestion by @cmyr a try and replaced one shot commands with a `SingleUse` wrapper type and it seems to work really well.

To summarize the change:
```rust
ctx.submit_command(
    Command::one_shot(commands::NEW_WINDOW, desc),
    Target::Global,
);

let desc = cmd.take_object::<WindowDesc<T>>().unwrap();
```
is now
```rust
ctx.submit_command(
    Command::new(commands::NEW_WINDOW, SingleUse::new(desc)),
    Target::Global,
);

let desc = cmd.get_object::<SingleUse<WindowDesc<T>>>().unwrap().take().unwrap();
```

which can easily be utilized by typed selectors.