### PR TITLE
Fix timer requests in update and lifecycle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Built-in widgets no longer stroke outside their `paint_rect`. ([#861] by [@jneem])
 - `Switch` toggles with animation when its data changes externally. ([#898] by [@finnerale])
 - Render progress bar correctly. ([#949] by [@scholtzan])
+- Scrollbars animate when the scroll container size changes. ([#964] by [@xStrom])
 
 ### Docs
 
@@ -222,6 +223,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#959]: https://github.com/xi-editor/druid/pull/959
 [#961]: https://github.com/xi-editor/druid/pull/961
 [#963]: https://github.com/xi-editor/druid/pull/963
+[#964]: https://github.com/xi-editor/druid/pull/964
 [#967]: https://github.com/xi-editor/druid/pull/967
 [#969]: https://github.com/xi-editor/druid/pull/969
 [#970]: https://github.com/xi-editor/druid/pull/970

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -896,7 +896,6 @@ impl<'a> ContextState<'a> {
     }
 
     fn request_timer(&self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {
-        widget_state.request_timer = true;
         let timer_token = self.window.request_timer(deadline);
         widget_state.add_timer(timer_token);
         timer_token

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -135,6 +135,7 @@ mod mouse;
 mod tests;
 pub mod text;
 pub mod theme;
+mod util;
 pub mod widget;
 mod win_handler;
 mod window;

--- a/druid/src/util.rs
+++ b/druid/src/util.rs
@@ -1,0 +1,52 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Miscellaneous utility functions.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::mem;
+
+/// Fast path for equal type extend + drain.
+pub trait ExtendDrain {
+    /// Extend the collection by draining the entries from `source`.
+    ///
+    /// This function may swap the underlying memory locations,
+    /// so keep that in mind if one of the collections has a large allocation
+    /// and it should keep that allocation.
+    fn extend_drain(&mut self, source: &mut Self);
+}
+
+impl<K, V> ExtendDrain for HashMap<K, V>
+where
+    K: Eq + Hash + Copy,
+    V: Copy,
+{
+    // Benchmarking this vs just extend+drain with a 10k entry map.
+    //
+    // running 2 tests
+    // test bench_extend       ... bench:       1,971 ns/iter (+/- 566)
+    // test bench_extend_drain ... bench:           0 ns/iter (+/- 0)
+    fn extend_drain(&mut self, source: &mut Self) {
+        if !source.is_empty() {
+            if self.is_empty() {
+                // If the target is empty we can just swap the pointers.
+                mem::swap(self, source);
+            } else {
+                // Otherwise we need to fall back to regular extend-drain.
+                self.extend(source.drain());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the handling of timer requests. Previously they were only collected in the window's `event` but I moved the collection to the general post processing step. I also removed the legacy `request_timer` `bool` which no longer served a purpose and was never being reset.

This also finally allowed to address #834. Scrollbars now briefly animate when the container is resized. This can be seen with e.g. the `scroll_colors` example when you resize the window.

Fixes #834.