### PR TITLE
Update screenshots in the readme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Added new example for blocking functions. ([#840] by [@mastfissh])
 - Added a changelog containing development since the 0.5 release. ([#889] by [@finnerale])
 - Removed references to cairo on macOS. ([#943] by [@xStrom])
+- Updated screenshots in `README.md`. ([#967] by [@xStrom])
 
 ### Maintenance
 
@@ -215,6 +216,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#959]: https://github.com/xi-editor/druid/pull/959
 [#961]: https://github.com/xi-editor/druid/pull/961
 [#963]: https://github.com/xi-editor/druid/pull/963
+[#967]: https://github.com/xi-editor/druid/pull/967
 
 ## [0.5.0] - 2020-04-01
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,9 @@ druid's existing functionality and widgets.
 
 ## Screenshots
 
-#### Linux
-[![calc.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/calc.png)](./druid/examples/calc.rs)
-[![custom_widget.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/custom_widget.png)](./druid/examples/custom_widget.rs)
-[![hello.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/hello.png)](./druid/examples/hello.rs)
-[![slider.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/slider.png)](./druid/examples/slider.rs)
+[![calc.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/0.6.0/calc.png)](./druid/examples/calc.rs)
+[![flex.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/0.6.0/flex.png)](./druid/examples/flex.rs)
+[![custom_widget.rs example](https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/0.6.0/custom_widget.png)](./druid/examples/custom_widget.rs)
 
 ## Concepts
 


### PR DESCRIPTION
Screenshots I made:
- `calc` on Windows 10 / macOS Catalina / Ubuntu 20.04 / Firefox (Win10)
- `flex` on Windows 7 with debug borders enabled
- `custom_widget` on Windows 7

The `calc` screenshots are one big image so that they line up, while still keeping the image width below 600px so it shows up nicely on crates.io.

PS. The previous screenshots were uploaded to URLs like `https://raw.githubusercontent.com/xi-editor/druid/screenshots/images/calc.png`. I don't know how to do that, so mine are issue uploads like `https://user-images.githubusercontent.com/754881/82576269-5281f300-9b92-11ea-887b-1f61f1a2a8b0.png`.