### PR TITLE
Rename BaseState to WidgetState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - X11: Refactored `Window` to support some reentrancy and invalidation. ([#894] by [@xStrom])
 - Refactored DPI scaling. ([#904] by [@xStrom])
 - Added docs generation testing for all features. ([#942] by [@xStrom])
+- Renamed `BaseState` to `WidgetState` ([#969] by [@cmyr])
 
 ### Outside News
 
@@ -217,6 +218,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#961]: https://github.com/xi-editor/druid/pull/961
 [#963]: https://github.com/xi-editor/druid/pull/963
 [#967]: https://github.com/xi-editor/druid/pull/967
+[#969]: https://github.com/xi-editor/druid/pull/969
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -239,7 +239,7 @@ pub enum InternalLifeCycle {
         /// the widget that is gaining focus, if any
         new: Option<WidgetId>,
     },
-    /// Testing only: request the `BaseState` of a specific widget.
+    /// Testing only: request the `WidgetState` of a specific widget.
     ///
     /// During testing, you may wish to verify that the state of a widget
     /// somewhere in the tree is as expected. In that case you can dispatch
@@ -308,16 +308,16 @@ pub(crate) use state_cell::{StateCell, StateCheckFn};
 
 #[cfg(test)]
 mod state_cell {
-    use crate::core::BaseState;
+    use crate::core::WidgetState;
     use crate::WidgetId;
     use std::{cell::RefCell, rc::Rc};
 
     /// An interior-mutable struct for fetching BasteState.
     #[derive(Clone, Default)]
-    pub struct StateCell(Rc<RefCell<Option<BaseState>>>);
+    pub struct StateCell(Rc<RefCell<Option<WidgetState>>>);
 
     #[derive(Clone)]
-    pub struct StateCheckFn(Rc<dyn Fn(&BaseState)>);
+    pub struct StateCheckFn(Rc<dyn Fn(&WidgetState)>);
 
     /// a hacky way of printing the widget id if we panic
     struct WidgetDrop(bool, WidgetId);
@@ -332,7 +332,7 @@ mod state_cell {
 
     impl StateCell {
         /// Set the state. This will panic if it is called twice.
-        pub(crate) fn set(&self, state: BaseState) {
+        pub(crate) fn set(&self, state: WidgetState) {
             assert!(
                 self.0.borrow_mut().replace(state).is_none(),
                 "StateCell already set"
@@ -340,18 +340,18 @@ mod state_cell {
         }
 
         #[allow(dead_code)]
-        pub(crate) fn take(&self) -> Option<BaseState> {
+        pub(crate) fn take(&self) -> Option<WidgetState> {
             self.0.borrow_mut().take()
         }
     }
 
     impl StateCheckFn {
         #[cfg(not(target_arch = "wasm32"))]
-        pub(crate) fn new(f: impl Fn(&BaseState) + 'static) -> Self {
+        pub(crate) fn new(f: impl Fn(&WidgetState) + 'static) -> Self {
             StateCheckFn(Rc::new(f))
         }
 
-        pub(crate) fn call(&self, state: &BaseState) {
+        pub(crate) fn call(&self, state: &WidgetState) {
             let mut panic_reporter = WidgetDrop(true, state.id);
             (self.0)(&state);
             panic_reporter.0 = false;

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -16,7 +16,7 @@
 
 use std::path::Path;
 
-use crate::core::{BaseState, CommandQueue};
+use crate::core::{CommandQueue, WidgetState};
 use crate::piet::{BitmapTarget, Device, Error, ImageFormat, Piet};
 use crate::*;
 
@@ -182,16 +182,16 @@ impl<T: Data> Harness<'_, T> {
         &self.inner.data
     }
 
-    /// Retrieve a copy of this widget's `BaseState`, or die trying.
-    pub(crate) fn get_state(&mut self, widget: WidgetId) -> BaseState {
+    /// Retrieve a copy of this widget's `WidgetState`, or die trying.
+    pub(crate) fn get_state(&mut self, widget: WidgetId) -> WidgetState {
         match self.try_get_state(widget) {
             Some(thing) => thing,
             None => panic!("get_state failed for widget {:?}", widget),
         }
     }
 
-    /// Attempt to retrieve a copy of this widget's `BaseState`.
-    pub(crate) fn try_get_state(&mut self, widget: WidgetId) -> Option<BaseState> {
+    /// Attempt to retrieve a copy of this widget's `WidgetState`.
+    pub(crate) fn try_get_state(&mut self, widget: WidgetId) -> Option<WidgetState> {
         let cell = StateCell::default();
         let state_cell = cell.clone();
         self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugRequestState {
@@ -201,10 +201,10 @@ impl<T: Data> Harness<'_, T> {
         cell.take()
     }
 
-    /// Inspect the `BaseState` of each widget in the tree.
+    /// Inspect the `WidgetState` of each widget in the tree.
     ///
     /// The provided closure will be called on each widget.
-    pub(crate) fn inspect_state(&mut self, f: impl Fn(&BaseState) + 'static) {
+    pub(crate) fn inspect_state(&mut self, f: impl Fn(&WidgetState) + 'static) {
         let checkfn = StateCheckFn::new(f);
         self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugInspectState(
             checkfn,

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -299,7 +299,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
         self.recording
-            .push(Record::Update(ctx.base_state.invalid.to_rect()));
+            .push(Record::Update(ctx.widget_state.invalid.to_rect()));
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {


### PR DESCRIPTION
This is motivated by a desire to avoid some confusion with a
future patch that adds a RootState struct to unify some of the
other stuff shared between various contexts.