### PR TITLE
Common context state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `im::Vector` support for the `List` widget. ([#940] by [@xStrom])
 - `LifeCycle::Size` event to inform widgets that their size changed. ([#953] by [@xStrom])
 - `Button::dynamic` constructor. ([#963] by [@totsteps])
+- `set_menu` method on `UpdateCtx` and `LifeCycleCtx` ([#970] by [@cmyr])
 
 ### Changed
 
@@ -219,6 +220,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#963]: https://github.com/xi-editor/druid/pull/963
 [#967]: https://github.com/xi-editor/druid/pull/967
 [#969]: https://github.com/xi-editor/druid/pull/969
+[#970]: https://github.com/xi-editor/druid/pull/970
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -594,6 +594,27 @@ impl<'a> LifeCycleCtx<'a> {
         let target = target.into().unwrap_or_else(|| self.window_id.into());
         self.command_queue.push_back((target, command.into()))
     }
+
+    /// Set the menu of the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided
+    /// to [`AppLauncher::launch`]).
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        if self.app_data_type == TypeId::of::<T>() {
+            self.submit_command(
+                Command::new(commands::SET_MENU, menu),
+                Target::Window(self.window_id),
+            );
+        } else {
+            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
+            if cfg!(debug_assertions) {
+                panic!(MSG);
+            } else {
+                log::error!("EventCtx::set_menu: {}", MSG)
+            }
+        }
+    }
 }
 
 impl<'a> UpdateCtx<'a> {
@@ -684,6 +705,27 @@ impl<'a> UpdateCtx<'a> {
     ) {
         let target = target.into().unwrap_or_else(|| self.window_id.into());
         self.command_queue.push_back((target, command.into()))
+    }
+
+    /// Set the menu of the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided
+    /// to [`AppLauncher::launch`]).
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        if self.app_data_type == TypeId::of::<T>() {
+            self.submit_command(
+                Command::new(commands::SET_MENU, menu),
+                Target::Window(self.window_id),
+            );
+        } else {
+            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
+            if cfg!(debug_assertions) {
+                panic!(MSG);
+            } else {
+                log::error!("EventCtx::set_menu: {}", MSG)
+            }
+        }
     }
 
     /// Get an object which can create text layouts.

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -28,25 +28,30 @@ use crate::{
     Target, Text, TimerToken, Vec2, WidgetId, WindowDesc, WindowHandle, WindowId,
 };
 
+/// Static state that is shared between most contexts.
+pub(crate) struct ContextState<'a> {
+    pub(crate) command_queue: &'a mut CommandQueue,
+    pub(crate) window_id: WindowId,
+    pub(crate) window: &'a WindowHandle,
+    pub(crate) root_app_data_type: TypeId,
+}
+
 /// A mutable context provided to event handling methods of widgets.
 ///
 /// Widgets should call [`request_paint`] whenever an event causes a change
 /// in the widget's appearance, to schedule a repaint.
 ///
 /// [`request_paint`]: #method.request_paint
-pub struct EventCtx<'a> {
+pub struct EventCtx<'a, 'b> {
     // Note: there's a bunch of state that's just passed down, might
     // want to group that into a single struct.
+    pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) cursor: &'a mut Option<Cursor>,
     /// Commands submitted to be run after this event.
-    pub(crate) command_queue: &'a mut CommandQueue,
-    pub(crate) window_id: WindowId,
-    pub(crate) window: &'a WindowHandle,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) focus_widget: Option<WidgetId>,
     pub(crate) is_handled: bool,
     pub(crate) is_root: bool,
-    pub(crate) app_data_type: TypeId,
 }
 
 /// A mutable context provided to the [`lifecycle`] method on widgets.
@@ -58,11 +63,9 @@ pub struct EventCtx<'a> {
 /// [`lifecycle`]: trait.Widget.html#tymethod.lifecycle
 /// [`register_child`]: #method.register_child
 /// [`LifeCycle::WidgetAdded`]: enum.LifeCycle.html#variant.WidgetAdded
-pub struct LifeCycleCtx<'a> {
-    pub(crate) command_queue: &'a mut CommandQueue,
+pub struct LifeCycleCtx<'a, 'b> {
     pub(crate) widget_state: &'a mut WidgetState,
-    pub(crate) window_id: WindowId,
-    pub(crate) window: &'a WindowHandle,
+    pub(crate) state: &'a mut ContextState<'b>,
 }
 
 /// A mutable context provided to data update methods of widgets.
@@ -71,14 +74,8 @@ pub struct LifeCycleCtx<'a> {
 /// in the widget's appearance, to schedule a repaint.
 ///
 /// [`request_paint`]: #method.request_paint
-pub struct UpdateCtx<'a> {
-    pub(crate) window: &'a WindowHandle,
-    // Discussion: we probably want to propagate more fine-grained
-    // invalidations, which would mean a structure very much like
-    // `EventCtx` (and possibly using the same structure). But for
-    // now keep it super-simple.
-    pub(crate) command_queue: &'a mut CommandQueue,
-    pub(crate) window_id: WindowId,
+pub struct UpdateCtx<'a, 'b> {
+    pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,
 }
 
@@ -87,12 +84,10 @@ pub struct UpdateCtx<'a> {
 /// As of now, the main service provided is access to a factory for
 /// creating text layout objects, which are likely to be useful
 /// during widget layout.
-pub struct LayoutCtx<'a, 'b: 'a> {
-    pub(crate) command_queue: &'a mut CommandQueue,
+pub struct LayoutCtx<'a, 'b, 'c: 'a> {
+    pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,
-    pub(crate) text_factory: &'a mut Text<'b>,
-    pub(crate) window_id: WindowId,
-    pub(crate) window: &'a WindowHandle,
+    pub(crate) text_factory: &'a mut Text<'c>,
     pub(crate) mouse_pos: Option<Point>,
 }
 
@@ -110,7 +105,7 @@ pub(crate) struct ZOrderPaintOp {
 /// This struct is expected to grow, for example to include the
 /// "damage region" indicating that only a subset of the entire
 /// widget hierarchy needs repainting.
-pub struct PaintCtx<'a, 'b: 'a> {
+pub struct PaintCtx<'a, 'b> {
     /// The render context for actually painting.
     pub render_ctx: &'a mut Piet<'b>,
     pub window_id: WindowId,
@@ -133,7 +128,7 @@ pub struct PaintCtx<'a, 'b: 'a> {
 #[derive(Debug, Clone)]
 pub struct Region(Rect);
 
-impl<'a> EventCtx<'a> {
+impl EventCtx<'_, '_> {
     #[deprecated(since = "0.5.0", note = "use request_paint instead")]
     pub fn invalidate(&mut self) {
         self.request_paint();
@@ -183,7 +178,7 @@ impl<'a> EventCtx<'a> {
 
     /// Get an object which can create text layouts.
     pub fn text(&mut self) -> Text {
-        self.window.text()
+        self.state.window.text()
     }
 
     /// Set the cursor icon.
@@ -245,7 +240,7 @@ impl<'a> EventCtx<'a> {
 
     /// Returns a reference to the current `WindowHandle`.
     pub fn window(&self) -> &WindowHandle {
-        &self.window
+        &self.state.window
     }
 
     /// Create a new window.
@@ -253,7 +248,7 @@ impl<'a> EventCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
-        if self.app_data_type == TypeId::of::<T>() {
+        if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
                 Command::new(commands::NEW_WINDOW, SingleUse::new(desc)),
                 Target::Global,
@@ -273,19 +268,7 @@ impl<'a> EventCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        if self.app_data_type == TypeId::of::<T>() {
-            self.submit_command(
-                Command::new(commands::SET_MENU, menu),
-                Target::Window(self.window_id),
-            );
-        } else {
-            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("EventCtx::set_menu: {}", MSG)
-            }
-        }
+        self.state.set_menu(menu);
     }
 
     /// Show the context menu in the window containing the current widget.
@@ -293,10 +276,10 @@ impl<'a> EventCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {
-        if self.app_data_type == TypeId::of::<T>() {
+        if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
                 Command::new(commands::SHOW_CONTEXT_MENU, menu),
-                Target::Window(self.window_id),
+                Target::Window(self.state.window_id),
             );
         } else {
             const MSG: &str = "ContextMenu<T> - T must match the application data type.";
@@ -431,10 +414,7 @@ impl<'a> EventCtx<'a> {
     /// The return value is a token, which can be used to associate the
     /// request with the event.
     pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
-        self.widget_state.request_timer = true;
-        let timer_token = self.window.request_timer(deadline);
-        self.widget_state.add_timer(timer_token);
-        timer_token
+        self.state.request_timer(&mut self.widget_state, deadline)
     }
 
     /// The layout size.
@@ -458,18 +438,13 @@ impl<'a> EventCtx<'a> {
     ///
     /// [`Command`]: struct.Command.html
     /// [`update`]: trait.Widget.html#tymethod.update
-    pub fn submit_command(
-        &mut self,
-        command: impl Into<Command>,
-        target: impl Into<Option<Target>>,
-    ) {
-        let target = target.into().unwrap_or_else(|| self.window_id.into());
-        self.command_queue.push_back((target, command.into()))
+    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
+        self.state.submit_command(cmd.into(), target.into())
     }
 
     /// Get the window id.
     pub fn window_id(&self) -> WindowId {
-        self.window_id
+        self.state.window_id
     }
 
     /// get the `WidgetId` of the current widget.
@@ -478,7 +453,7 @@ impl<'a> EventCtx<'a> {
     }
 }
 
-impl<'a> LifeCycleCtx<'a> {
+impl LifeCycleCtx<'_, '_> {
     #[deprecated(since = "0.5.0", note = "use request_paint instead")]
     pub fn invalidate(&mut self) {
         self.request_paint();
@@ -559,10 +534,7 @@ impl<'a> LifeCycleCtx<'a> {
     /// The return value is a token, which can be used to associate the
     /// request with the event.
     pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
-        self.widget_state.request_timer = true;
-        let timer_token = self.window.request_timer(deadline);
-        self.widget_state.add_timer(timer_token);
-        timer_token
+        self.state.request_timer(&mut self.widget_state, deadline)
     }
 
     /// The layout size.
@@ -586,13 +558,8 @@ impl<'a> LifeCycleCtx<'a> {
     ///
     /// [`Command`]: struct.Command.html
     /// [`update`]: trait.Widget.html#tymethod.update
-    pub fn submit_command(
-        &mut self,
-        command: impl Into<Command>,
-        target: impl Into<Option<Target>>,
-    ) {
-        let target = target.into().unwrap_or_else(|| self.window_id.into());
-        self.command_queue.push_back((target, command.into()))
+    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
+        self.state.submit_command(cmd.into(), target.into())
     }
 
     /// Set the menu of the window containing the current widget.
@@ -601,23 +568,11 @@ impl<'a> LifeCycleCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        if self.app_data_type == TypeId::of::<T>() {
-            self.submit_command(
-                Command::new(commands::SET_MENU, menu),
-                Target::Window(self.window_id),
-            );
-        } else {
-            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("EventCtx::set_menu: {}", MSG)
-            }
-        }
+        self.state.set_menu(menu);
     }
 }
 
-impl<'a> UpdateCtx<'a> {
+impl<'a, 'b> UpdateCtx<'a, 'b> {
     #[deprecated(since = "0.5.0", note = "use request_paint instead")]
     pub fn invalidate(&mut self) {
         self.request_paint();
@@ -671,10 +626,7 @@ impl<'a> UpdateCtx<'a> {
     /// The return value is a token, which can be used to associate the
     /// request with the event.
     pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
-        self.widget_state.request_timer = true;
-        let timer_token = self.window.request_timer(deadline);
-        self.widget_state.add_timer(timer_token);
-        timer_token
+        self.state.request_timer(&mut self.widget_state, deadline)
     }
 
     /// The layout size.
@@ -698,13 +650,8 @@ impl<'a> UpdateCtx<'a> {
     /// layout, and paint have completed; this will trigger a new event cycle.
     ///
     /// [`Command`]: struct.Command.html
-    pub fn submit_command(
-        &mut self,
-        command: impl Into<Command>,
-        target: impl Into<Option<Target>>,
-    ) {
-        let target = target.into().unwrap_or_else(|| self.window_id.into());
-        self.command_queue.push_back((target, command.into()))
+    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
+        self.state.submit_command(cmd.into(), target.into());
     }
 
     /// Set the menu of the window containing the current widget.
@@ -713,35 +660,23 @@ impl<'a> UpdateCtx<'a> {
     ///
     /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        if self.app_data_type == TypeId::of::<T>() {
-            self.submit_command(
-                Command::new(commands::SET_MENU, menu),
-                Target::Window(self.window_id),
-            );
-        } else {
-            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
-            if cfg!(debug_assertions) {
-                panic!(MSG);
-            } else {
-                log::error!("EventCtx::set_menu: {}", MSG)
-            }
-        }
+        self.state.set_menu(menu)
     }
 
     /// Get an object which can create text layouts.
     pub fn text(&mut self) -> Text {
-        self.window.text()
+        self.state.window.text()
     }
 
     /// Returns a reference to the current `WindowHandle`.
     //TODO: can we delete this? where is it used?
     pub fn window(&self) -> &WindowHandle {
-        &self.window
+        &self.state.window
     }
 
     /// Get the window id.
     pub fn window_id(&self) -> WindowId {
-        self.window_id
+        self.state.window_id
     }
 
     /// get the `WidgetId` of the current widget.
@@ -750,15 +685,15 @@ impl<'a> UpdateCtx<'a> {
     }
 }
 
-impl<'a, 'b> LayoutCtx<'a, 'b> {
+impl<'c> LayoutCtx<'_, '_, 'c> {
     /// Get an object which can create text layouts.
-    pub fn text(&mut self) -> &mut Text<'b> {
+    pub fn text(&mut self) -> &mut Text<'c> {
         &mut self.text_factory
     }
 
     /// Get the window id.
     pub fn window_id(&self) -> WindowId {
-        self.window_id
+        self.state.window_id
     }
 
     /// Set explicit paint [`Insets`] for this widget.
@@ -777,7 +712,7 @@ impl<'a, 'b> LayoutCtx<'a, 'b> {
     }
 }
 
-impl<'a, 'b: 'a> PaintCtx<'a, 'b> {
+impl PaintCtx<'_, '_> {
     /// get the `WidgetId` of the current widget.
     pub fn widget_id(&self) -> WidgetId {
         self.widget_state.id
@@ -922,6 +857,49 @@ impl<'a, 'b: 'a> PaintCtx<'a, 'b> {
             paint_func: Box::new(paint_func),
             transform: current_transform,
         })
+    }
+}
+
+impl<'a> ContextState<'a> {
+    pub(crate) fn new<T: 'static>(
+        command_queue: &'a mut CommandQueue,
+        window: &'a WindowHandle,
+        window_id: WindowId,
+    ) -> Self {
+        ContextState {
+            command_queue,
+            window,
+            window_id,
+            root_app_data_type: TypeId::of::<T>(),
+        }
+    }
+
+    fn submit_command(&mut self, command: Command, target: Option<Target>) {
+        let target = target.unwrap_or_else(|| self.window_id.into());
+        self.command_queue.push_back((target, command))
+    }
+
+    fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        if self.root_app_data_type == TypeId::of::<T>() {
+            self.submit_command(
+                Command::new(commands::SET_MENU, menu),
+                Some(Target::Window(self.window_id)),
+            );
+        } else {
+            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
+            if cfg!(debug_assertions) {
+                panic!(MSG);
+            } else {
+                log::error!("EventCtx::set_menu: {}", MSG)
+            }
+        }
+    }
+
+    fn request_timer(&self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {
+        widget_state.request_timer = true;
+        let timer_token = self.window.request_timer(deadline);
+        widget_state.add_timer(timer_token);
+        timer_token
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -18,6 +18,7 @@ use std::collections::{HashMap, VecDeque};
 use std::mem;
 
 use crate::bloom::Bloom;
+use crate::contexts::ContextState;
 use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size, Vec2};
 use crate::piet::{
     FontBuilder, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
@@ -25,7 +26,7 @@ use crate::piet::{
 use crate::{
     BoxConstraints, Color, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
     LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Region, Target, TimerToken, UpdateCtx, Widget,
-    WidgetId, WindowHandle, WindowId,
+    WidgetId,
 };
 
 /// Our queue type
@@ -211,10 +212,8 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
 
         if old_size.is_none() || old_size.unwrap() != new_size {
             let mut child_ctx = LifeCycleCtx {
-                command_queue: ctx.command_queue,
                 widget_state: &mut self.state,
-                window_id: ctx.window_id,
-                window: ctx.window,
+                state: ctx.state,
             };
             let size_event = LifeCycle::Size(new_size);
             self.inner.lifecycle(&mut child_ctx, &size_event, data, env);
@@ -223,10 +222,8 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
 
         if WidgetPod::set_hot_state(
             &mut self.inner,
-            ctx.command_queue,
             &mut self.state,
-            ctx.window_id,
-            ctx.window,
+            ctx.state,
             layout_rect,
             ctx.mouse_pos,
             data,
@@ -331,13 +328,10 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
     /// Returns `true` if the hot state changed.
     ///
     /// The provided `child_state` should be merged up if this returns `true`.
-    #[allow(clippy::too_many_arguments)]
     fn set_hot_state(
         child: &mut W,
-        command_queue: &mut CommandQueue,
         child_state: &mut WidgetState,
-        window_id: WindowId,
-        window: &WindowHandle,
+        state: &mut ContextState,
         rect: Rect,
         mouse_pos: Option<Point>,
         data: &T,
@@ -351,10 +345,8 @@ impl<T, W: Widget<T>> WidgetPod<T, W> {
         if had_hot != child_state.is_hot {
             let hot_changed_event = LifeCycle::HotChanged(child_state.is_hot);
             let mut child_ctx = LifeCycleCtx {
-                command_queue,
+                state,
                 widget_state: child_state,
-                window_id,
-                window,
             };
             child.lifecycle(&mut child_ctx, &hot_changed_event, data, env);
             // if hot changes and we're showing widget ids, always repaint
@@ -517,10 +509,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             None => None,
         };
         let mut child_ctx = LayoutCtx {
-            command_queue: ctx.command_queue,
             widget_state: &mut self.state,
-            window_id: ctx.window_id,
-            window: ctx.window,
+            state: ctx.state,
             text_factory: ctx.text_factory,
             mouse_pos: child_mouse_pos,
         };
@@ -584,14 +574,11 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let had_active = self.state.has_active;
         let mut child_ctx = EventCtx {
             cursor: ctx.cursor,
-            command_queue: ctx.command_queue,
-            window: ctx.window,
-            window_id: ctx.window_id,
+            state: ctx.state,
             widget_state: &mut self.state,
             is_handled: false,
             is_root: false,
             focus_widget: ctx.focus_widget,
-            app_data_type: ctx.app_data_type,
         };
 
         let rect = child_ctx.widget_state.layout_rect.unwrap_or_default();
@@ -603,10 +590,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
                 InternalEvent::MouseLeave => {
                     let hot_changed = WidgetPod::set_hot_state(
                         &mut self.inner,
-                        child_ctx.command_queue,
                         child_ctx.widget_state,
-                        child_ctx.window_id,
-                        child_ctx.window,
+                        child_ctx.state,
                         rect,
                         None,
                         data,
@@ -651,10 +636,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             Event::MouseDown(mouse_event) => {
                 WidgetPod::set_hot_state(
                     &mut self.inner,
-                    child_ctx.command_queue,
                     child_ctx.widget_state,
-                    child_ctx.window_id,
-                    child_ctx.window,
+                    child_ctx.state,
                     rect,
                     Some(mouse_event.pos),
                     data,
@@ -668,10 +651,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             Event::MouseUp(mouse_event) => {
                 WidgetPod::set_hot_state(
                     &mut self.inner,
-                    child_ctx.command_queue,
                     child_ctx.widget_state,
-                    child_ctx.window_id,
-                    child_ctx.window,
+                    child_ctx.state,
                     rect,
                     Some(mouse_event.pos),
                     data,
@@ -685,10 +666,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             Event::MouseMove(mouse_event) => {
                 let hot_changed = WidgetPod::set_hot_state(
                     &mut self.inner,
-                    child_ctx.command_queue,
                     child_ctx.widget_state,
-                    child_ctx.window_id,
-                    child_ctx.window,
+                    child_ctx.state,
                     rect,
                     Some(mouse_event.pos),
                     data,
@@ -705,10 +684,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
             Event::Wheel(mouse_event) => {
                 WidgetPod::set_hot_state(
                     &mut self.inner,
-                    child_ctx.command_queue,
                     child_ctx.widget_state,
-                    child_ctx.window_id,
-                    child_ctx.window,
+                    child_ctx.state,
                     rect,
                     Some(mouse_event.pos),
                     data,
@@ -843,10 +820,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         };
 
         let mut child_ctx = LifeCycleCtx {
-            command_queue: ctx.command_queue,
+            state: ctx.state,
             widget_state: &mut self.state,
-            window_id: ctx.window_id,
-            window: ctx.window,
         };
 
         if recurse {
@@ -890,10 +865,8 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         }
 
         let mut child_ctx = UpdateCtx {
-            window: ctx.window,
+            state: ctx.state,
             widget_state: &mut self.state,
-            window_id: ctx.window_id,
-            command_queue: ctx.command_queue,
         };
 
         self.inner
@@ -995,7 +968,7 @@ impl WidgetState {
 mod tests {
     use super::*;
     use crate::widget::{Flex, Scroll, Split, TextBox};
-    use crate::{WidgetExt, WindowId};
+    use crate::{WidgetExt, WindowHandle, WindowId};
 
     const ID_1: WidgetId = WidgetId::reserved(0);
     const ID_2: WidgetId = WidgetId::reserved(1);
@@ -1017,12 +990,17 @@ mod tests {
         let mut widget = WidgetPod::new(widget).boxed();
 
         let mut command_queue: CommandQueue = VecDeque::new();
-        let mut state = WidgetState::new(WidgetId::next());
-        let mut ctx = LifeCycleCtx {
+        let mut widget_state = WidgetState::new(WidgetId::next());
+        let mut state = ContextState {
             command_queue: &mut command_queue,
-            widget_state: &mut state,
             window_id: WindowId::next(),
             window: &WindowHandle::default(),
+            root_app_data_type: std::any::TypeId::of::<Option<u32>>(),
+        };
+
+        let mut ctx = LifeCycleCtx {
+            widget_state: &mut widget_state,
+            state: &mut state,
         };
 
         let env = Env::default();

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -14,7 +14,6 @@
 
 //! Management of multiple windows.
 
-use std::any::TypeId;
 use std::collections::HashMap;
 use std::mem;
 
@@ -25,6 +24,7 @@ use crate::kurbo::{Point, Rect, Size};
 use crate::piet::{Piet, RenderContext};
 use crate::shell::{Counter, Cursor, WindowHandle};
 
+use crate::contexts::ContextState;
 use crate::core::{CommandQueue, FocusChange, WidgetState};
 use crate::widget::LabelText;
 use crate::win_handler::RUN_COMMANDS_TOKEN;
@@ -193,16 +193,14 @@ impl<T: Data> Window<T> {
 
         let mut widget_state = WidgetState::new(self.root.id());
         let is_handled = {
+            let mut state = ContextState::new::<T>(queue, &self.handle, self.id);
             let mut ctx = EventCtx {
                 cursor: &mut cursor,
-                command_queue: queue,
+                state: &mut state,
                 widget_state: &mut widget_state,
                 is_handled: false,
                 is_root: true,
-                window: &self.handle,
-                window_id: self.id,
                 focus_widget: self.focus,
-                app_data_type: TypeId::of::<T>(),
             };
 
             self.root.event(&mut ctx, &event, data, env);
@@ -251,11 +249,10 @@ impl<T: Data> Window<T> {
         if let LifeCycle::AnimFrame(_) = event {
             self.do_anim_frame(queue, data, env)
         } else {
+            let mut state = ContextState::new::<T>(queue, &self.handle, self.id);
             let mut widget_state = WidgetState::new(self.root.id());
             let mut ctx = LifeCycleCtx {
-                command_queue: queue,
-                window_id: self.id,
-                window: &self.handle,
+                state: &mut state,
                 widget_state: &mut widget_state,
             };
 
@@ -267,11 +264,11 @@ impl<T: Data> Window<T> {
 
     /// AnimFrame has special logic, so we implement it separately.
     fn do_anim_frame(&mut self, queue: &mut CommandQueue, data: &T, env: &Env) {
+        let mut state = ContextState::new::<T>(queue, &self.handle, self.id);
+
         let mut widget_state = WidgetState::new(self.root.id());
         let mut ctx = LifeCycleCtx {
-            command_queue: queue,
-            window_id: self.id,
-            window: &self.handle,
+            state: &mut state,
             widget_state: &mut widget_state,
         };
 
@@ -294,11 +291,10 @@ impl<T: Data> Window<T> {
         self.update_title(data, env);
 
         let mut widget_state = WidgetState::new(self.root.id());
+        let mut state = ContextState::new::<T>(queue, &self.handle, self.id);
         let mut update_ctx = UpdateCtx {
             widget_state: &mut widget_state,
-            command_queue: queue,
-            window: &self.handle,
-            window_id: self.id,
+            state: &mut state,
         };
 
         self.root.update(&mut update_ctx, data, env);
@@ -342,12 +338,11 @@ impl<T: Data> Window<T> {
 
     fn layout(&mut self, piet: &mut Piet, queue: &mut CommandQueue, data: &T, env: &Env) {
         let mut widget_state = WidgetState::new(self.root.id());
+        let mut state = ContextState::new::<T>(queue, &self.handle, self.id);
         let mut layout_ctx = LayoutCtx {
-            command_queue: queue,
+            state: &mut state,
             widget_state: &mut widget_state,
             text_factory: piet.text(),
-            window_id: self.id,
-            window: &self.handle,
             mouse_pos: self.last_mouse_pos,
         };
         let bc = BoxConstraints::tight(self.size);


### PR DESCRIPTION
This is two related commits:

- one adds the `set_menu` method to the lifecycle and update contexts
- one refactors contexts so that all of the state that is A) shared and B) comes from the window and never changes is in one place. This will let us put common implementations there, and reduce duplicate code.


This is based on #969, which should go in first.