### PR TITLE
Use a macro to implement context methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `LifeCycle::Size` event to inform widgets that their size changed. ([#953] by [@xStrom])
 - `Button::dynamic` constructor. ([#963] by [@totsteps])
 - `set_menu` method on `UpdateCtx` and `LifeCycleCtx` ([#970] by [@cmyr])
+- Standardize and expose more methods on more contexts ([#972] by [@cmyr])
 
 ### Changed
 
@@ -73,8 +74,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
 - Renamed `WidgetPod` methods: `paint` to `paint_raw`, `paint_with_offset` to `paint`, `paint_with_offset_always` to `paint_always`. ([#980] by [@totsteps])
 - `Command` and `Selector` have been reworked and are now statically typed, similarly to `Env` and `Key`. ([#993] by [@finnerale])
-- Standardize the type returned by the contexts' `text()` methods. ([#996] by
-  [@cmyr])
+- Standardize the type returned by the contexts' `text()` methods. ([#996] by [@cmyr])
 
 ### Deprecated
 
@@ -240,6 +240,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#967]: https://github.com/xi-editor/druid/pull/967
 [#969]: https://github.com/xi-editor/druid/pull/969
 [#970]: https://github.com/xi-editor/druid/pull/970
+[#972]: https://github.com/xi-editor/druid/pull/972
 [#980]: https://github.com/xi-editor/druid/pull/980
 [#982]: https://github.com/xi-editor/druid/pull/982
 [#984]: https://github.com/xi-editor/druid/pull/984

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -30,7 +30,7 @@ use crate::{
 
 /// A macro for implementing methods on multiple contexts.
 ///
-/// There are a lot of methods defined on multiple methods; this lets us only
+/// There are a lot of methods defined on multiple contexts; this lets us only
 /// have to write them out once.
 macro_rules! impl_context_method {
     ($ty:ty,  { $($method:item)+ } ) => {


### PR DESCRIPTION
This attempts to solve the issue of duplicate code and out of
date documentation for methods shared between multiple contexts.

The approach taken here is to use a simple macro to implement
those methods.

~The macro was actually a real pain to write, and kind of gross API
wise; in particular you need to pass in all of the lifetimes twice.
I've given up trying to improve it, and given that this is private API
it doesn't matter too much, but it does offend my sensibilites
somewhat.~

~There are a few bits of future work; window & window_id should
be shared between all contexts, but that requires a change to
PaintCtx; another change would let us reuse is_focused.~

~In any case, I think this is a step in a good direction.~

~This is based off of #970, which should go in first.~
