### PR TITLE
Share context code via default trait implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - `SHOW_WINDOW` and `CLOSE_WINDOW` commands now only use `Target` to determine the affected window. ([#928] by [@finnerale])
 - Replaced `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`. ([#931] by [@finnerale])
 - Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
+- Renamed `BaseState` to `WidgetState` ([#969] by [@cmyr])
 
 ### Deprecated
 
@@ -215,6 +216,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#959]: https://github.com/xi-editor/druid/pull/959
 [#961]: https://github.com/xi-editor/druid/pull/961
 [#963]: https://github.com/xi-editor/druid/pull/963
+[#969]: https://github.com/xi-editor/druid/pull/969
 
 ## [0.5.0] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Replaced `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`. ([#931] by [@finnerale])
 - Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
 - Renamed `BaseState` to `WidgetState` ([#969] by [@cmyr])
+- Add  `set_menu` method to `UpdateCtx` and `LifeCycleCtx` ([#970] by [@cmyr])
 
 ### Deprecated
 
@@ -217,6 +218,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#961]: https://github.com/xi-editor/druid/pull/961
 [#963]: https://github.com/xi-editor/druid/pull/963
 [#969]: https://github.com/xi-editor/druid/pull/969
+[#970]: https://github.com/xi-editor/druid/pull/970
 
 ## [0.5.0] - 2020-04-01
 

--- a/docs/book_examples/src/custom_widgets_md.rs
+++ b/docs/book_examples/src/custom_widgets_md.rs
@@ -1,3 +1,4 @@
+use druid::widget::prelude::*;
 use druid::widget::{Controller, Label, Painter, SizedBox, TextBox};
 use druid::{
     Color, Env, Event, EventCtx, KeyCode, PaintCtx, RenderContext, Selector, TimerToken, Widget,

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -21,6 +21,7 @@ use druid::{
     Selector, Target, Widget, WidgetExt, WindowDesc,
 };
 
+use druid::widget::prelude::*;
 use druid::widget::{Button, Either, Flex, Label};
 
 const START_SLOW_FUNCTION: Selector = Selector::new("start_slow_function");

--- a/druid/examples/calc.rs
+++ b/druid/examples/calc.rs
@@ -19,6 +19,7 @@ use druid::{
     WindowDesc,
 };
 
+use druid::widget::prelude::*;
 use druid::widget::{CrossAxisAlignment, Flex, Label, Painter};
 
 #[derive(Clone, Data, Lens)]

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -32,6 +32,7 @@ use std::time::Duration;
 
 use druid::kurbo::RoundedRect;
 use druid::widget::{Button, CrossAxisAlignment, Flex, WidgetId};
+use druid::widget::prelude::*;
 use druid::{
     AppLauncher, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, LayoutCtx, Lens,
     LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size,

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -31,8 +31,8 @@ use instant::Instant;
 use std::time::Duration;
 
 use druid::kurbo::RoundedRect;
-use druid::widget::{Button, CrossAxisAlignment, Flex, WidgetId};
 use druid::widget::prelude::*;
+use druid::widget::{Button, CrossAxisAlignment, Flex, WidgetId};
 use druid::{
     AppLauncher, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, LayoutCtx, Lens,
     LifeCycle, LifeCycleCtx, LocalizedString, PaintCtx, Rect, RenderContext, Selector, Size,

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -26,7 +26,6 @@ pub fn main() {
 
 #[cfg(feature = "image")]
 pub fn main() {
-    use druid::widget::prelude::*;
     use druid::{
         widget::{FillStrat, Flex, Image, ImageData, WidgetExt},
         AppLauncher, Color, Widget, WindowDesc,

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -26,6 +26,7 @@ pub fn main() {
 
 #[cfg(feature = "image")]
 pub fn main() {
+    use druid::widget::prelude::*;
     use druid::{
         widget::{FillStrat, Flex, Image, ImageData, WidgetExt},
         AppLauncher, Color, Widget, WindowDesc,

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -97,7 +97,6 @@ impl<W> Glow<W> {
 impl<W: Widget<State>> Widget<State> for Glow<W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut State, env: &Env) {
         self.inner.event(ctx, event, data, env);
-        println!("Got: {:?}", ctx.sizer());
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &State, env: &Env) {

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -97,6 +97,7 @@ impl<W> Glow<W> {
 impl<W: Widget<State>> Widget<State> for Glow<W> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut State, env: &Env) {
         self.inner.event(ctx, event, data, env);
+        println!("Got: {:?}", ctx.sizer());
     }
 
     fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &State, env: &Env) {

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::widget::{Align, Button, Flex, TextBox};
 use druid::widget::prelude::*;
+use druid::widget::{Align, Button, Flex, TextBox};
 use druid::{
     AppDelegate, AppLauncher, Command, DelegateCtx, Env, FileDialogOptions, FileInfo, FileSpec,
     LocalizedString, Target, Widget, WindowDesc,

--- a/druid/examples/open_save.rs
+++ b/druid/examples/open_save.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use druid::widget::{Align, Button, Flex, TextBox};
+use druid::widget::prelude::*;
 use druid::{
     AppDelegate, AppLauncher, Command, DelegateCtx, Env, FileDialogOptions, FileInfo, FileSpec,
     LocalizedString, Target, Widget, WindowDesc,

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -16,6 +16,7 @@
 
 use druid::kurbo::Circle;
 use druid::widget::{Flex, Label, Painter};
+use druid::widget::prelude::*;
 use druid::{
     AppLauncher, Color, LinearGradient, LocalizedString, PlatformError, RenderContext, UnitPoint,
     Widget, WidgetExt, WindowDesc,

--- a/druid/examples/panels.rs
+++ b/druid/examples/panels.rs
@@ -15,8 +15,8 @@
 //! This example shows how to construct a basic layout.
 
 use druid::kurbo::Circle;
-use druid::widget::{Flex, Label, Painter};
 use druid::widget::prelude::*;
+use druid::widget::{Flex, Label, Painter};
 use druid::{
     AppLauncher, Color, LinearGradient, LocalizedString, PlatformError, RenderContext, UnitPoint,
     Widget, WidgetExt, WindowDesc,

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -15,6 +15,7 @@
 //! Example of dynamic text styling
 
 use druid::widget::{Checkbox, Flex, Label, MainAxisAlignment, Painter, Parse, Stepper, TextBox};
+use druid::widget::prelude::*;
 use druid::{
     theme, AppLauncher, Color, Data, Key, Lens, LensExt, LensWrap, LocalizedString, PlatformError,
     RenderContext, Widget, WidgetExt, WindowDesc,

--- a/druid/examples/styled_text.rs
+++ b/druid/examples/styled_text.rs
@@ -14,8 +14,8 @@
 
 //! Example of dynamic text styling
 
-use druid::widget::{Checkbox, Flex, Label, MainAxisAlignment, Painter, Parse, Stepper, TextBox};
 use druid::widget::prelude::*;
+use druid::widget::{Checkbox, Flex, Label, MainAxisAlignment, Painter, Parse, Stepper, TextBox};
 use druid::{
     theme, AppLauncher, Color, Data, Key, Lens, LensExt, LensWrap, LocalizedString, PlatformError,
     RenderContext, Widget, WidgetExt, WindowDesc,

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -27,6 +27,7 @@ pub fn main() {
 pub fn main() {
     use log::error;
 
+    use druid::widget::prelude::*;
     use druid::{
         widget::{FillStrat, Flex, Svg, SvgData, WidgetExt},
         AppLauncher, LocalizedString, Widget, WindowDesc,

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -27,7 +27,6 @@ pub fn main() {
 pub fn main() {
     use log::error;
 
-    use druid::widget::prelude::*;
     use druid::{
         widget::{FillStrat, Flex, Svg, SvgData, WidgetExt},
         AppLauncher, LocalizedString, Widget, WindowDesc,

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -594,6 +594,27 @@ impl<'a> LifeCycleCtx<'a> {
         let target = target.into().unwrap_or_else(|| self.window_id.into());
         self.command_queue.push_back((target, command.into()))
     }
+
+    /// Set the menu of the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided
+    /// to [`AppLauncher::launch`]).
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        if self.app_data_type == TypeId::of::<T>() {
+            self.submit_command(
+                Command::new(commands::SET_MENU, menu),
+                Target::Window(self.window_id),
+            );
+        } else {
+            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
+            if cfg!(debug_assertions) {
+                panic!(MSG);
+            } else {
+                log::error!("EventCtx::set_menu: {}", MSG)
+            }
+        }
+    }
 }
 
 impl<'a> UpdateCtx<'a> {
@@ -684,6 +705,27 @@ impl<'a> UpdateCtx<'a> {
     ) {
         let target = target.into().unwrap_or_else(|| self.window_id.into());
         self.command_queue.push_back((target, command.into()))
+    }
+
+    /// Set the menu of the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided
+    /// to [`AppLauncher::launch`]).
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        if self.app_data_type == TypeId::of::<T>() {
+            self.submit_command(
+                Command::new(commands::SET_MENU, menu),
+                Target::Window(self.window_id),
+            );
+        } else {
+            const MSG: &str = "MenuDesc<T> - T must match the application data type.";
+            if cfg!(debug_assertions) {
+                panic!(MSG);
+            } else {
+                log::error!("EventCtx::set_menu: {}", MSG)
+            }
+        }
     }
 
     /// Get an object which can create text layouts.

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -120,9 +120,84 @@ pub struct PaintCtx<'a, 'b: 'a> {
 #[derive(Debug, Clone)]
 pub struct Region(Rect);
 
-impl<'a, 'b> EventCtx<'a, 'b> {
+use crate::ctx_field_traits::{RootStateMut, WidgetStateMut, WidgetStateRef};
+
+/// Common methods that exist on all contexts.
+pub trait BaseCtx: WidgetStateRef {
+    /// Get the `WidgetId` of the current widget.
+    fn widget_id(&self) -> WidgetId {
+        self.widget_state().id
+    }
+    //TODO: give PaintCtx a `RootState` handle and put `window` and `window_id` in here
+}
+
+/// Common methods that exist on all contexts except `LayoutCtx`.
+pub trait LaidOutCtx: WidgetStateRef {
+    /// The layout size.
+    ///
+    /// This is the layout size as ultimately determined by the parent
+    /// container, on the previous layout pass.
+    ///
+    /// Generally it will be the same as the size returned by the child widget's
+    /// [`layout`] method.
+    ///
+    /// [`layout`]: trait.Widget.html#tymethod.layout
+    fn size(&self) -> Size {
+        self.widget_state().size()
+    }
+
+    /// The "hot" (aka hover) status of a widget.
+    ///
+    /// A widget is "hot" when the mouse is hovered over it. Widgets will
+    /// often change their appearance as a visual indication that they
+    /// will respond to mouse interaction.
+    ///
+    /// The hot status is computed from the widget's layout rect. In a
+    /// container hierarchy, all widgets with layout rects containing the
+    /// mouse position have hot status.
+    ///
+    /// Discussion: there is currently some confusion about whether a
+    /// widget can be considered hot when some other widget is active (for
+    /// example, when clicking to one widget and dragging to the next).
+    /// The documentation should clearly state the resolution.
+    fn is_hot(&self) -> bool {
+        self.widget_state().is_hot
+    }
+
+    /// The active status of a widget.
+    ///
+    /// Active status generally corresponds to a mouse button down. Widgets
+    /// with behavior similar to a button will call [`set_active`] on mouse
+    /// down and then up.
+    ///
+    /// When a widget is active, it gets mouse events even when the mouse
+    /// is dragged away.
+    ///
+    /// [`set_active`]: struct.EventCtx.html#method.set_active
+    fn is_active(&self) -> bool {
+        self.widget_state().is_active
+    }
+
+    //TODO: move is_focused in here, by moving `focus_widget` into `RootState`?
+    /// The (tree) focus status of a widget.
+    ///
+    /// Returns `true` if either this specific widget or any one of its descendants is focused.
+    /// To check if only this specific widget is focused use [`is_focused`],
+    /// (available on `EventCtx` and `PaintCtx`).
+    ///
+    /// See [`EventCtx::is_focused`] for more information about focus.
+    ///
+    /// [`is_focused`]: #method.is_focused
+    /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
+    fn has_focus(&self) -> bool {
+        self.widget_state().has_focus
+    }
+}
+
+/// Common methods that exist on `EventCtx`, `LifeCycleCtx`, and `UpdateCtx`.
+pub trait ExtraCtx<'b>: WidgetStateMut + RootStateMut<'b> {
     #[deprecated(since = "0.5.0", note = "use request_paint instead")]
-    pub fn invalidate(&mut self) {
+    fn invalidate(&mut self) {
         self.request_paint();
     }
 
@@ -132,9 +207,9 @@ impl<'a, 'b> EventCtx<'a, 'b> {
     /// [`paint`]: trait.Widget.html#tymethod.paint
     /// [`request_paint_rect`]: struct.EventCtx.html#method.request_paint_rect
     /// [`paint_rect`]: struct.WidgetPod.html#method.paint_rect
-    pub fn request_paint(&mut self) {
+    fn request_paint(&mut self) {
         self.request_paint_rect(
-            self.widget_state.paint_rect() - self.widget_state.layout_rect().origin().to_vec2(),
+            self.widget_state().paint_rect() - self.widget_state().layout_rect().origin().to_vec2(),
         );
     }
 
@@ -142,8 +217,8 @@ impl<'a, 'b> EventCtx<'a, 'b> {
     /// rectangle.
     ///
     /// [`paint`]: trait.Widget.html#tymethod.paint
-    pub fn request_paint_rect(&mut self, rect: Rect) {
-        self.widget_state.invalid.add_rect(rect);
+    fn request_paint_rect(&mut self, rect: Rect) {
+        self.widget_state_mut().invalid.add_rect(rect);
     }
 
     /// Request a layout pass.
@@ -156,18 +231,75 @@ impl<'a, 'b> EventCtx<'a, 'b> {
     /// response to some event) it must call this method.
     ///
     /// [`layout`]: trait.Widget.html#tymethod.layout
-    pub fn request_layout(&mut self) {
-        self.widget_state.needs_layout = true;
+    fn request_layout(&mut self) {
+        self.widget_state_mut().needs_layout = true;
+    }
+
+    /// Request an animation frame.
+    fn request_anim_frame(&mut self) {
+        self.widget_state_mut().request_anim = true;
+        self.request_paint();
+    }
+
+    /// Request a timer event.
+    ///
+    /// The return value is a token, which can be used to associate the
+    /// request with the event.
+    fn request_timer(&mut self, deadline: Duration) -> TimerToken {
+        self.widget_state_mut().request_timer = true;
+        let timer_token = self.root_state().window.request_timer(deadline);
+        self.widget_state_mut().add_timer(timer_token);
+        timer_token
     }
 
     /// Indicate that your children have changed.
     ///
     /// Widgets must call this method after adding a new child.
-    pub fn children_changed(&mut self) {
-        self.widget_state.children_changed = true;
+    fn children_changed(&mut self) {
+        self.widget_state_mut().children_changed = true;
         self.request_layout();
     }
 
+    /// Submit a [`Command`] to be run after this event is handled.
+    ///
+    /// Commands are run in the order they are submitted; all commands
+    /// submitted during the handling of an event are executed before
+    /// the [`update`] method is called.
+    ///
+    /// [`Command`]: struct.Command.html
+    /// [`update`]: trait.Widget.html#tymethod.update
+    fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
+        self.root_state_mut()
+            .submit_command(cmd.into(), target.into())
+    }
+
+    /// Set the menu of the window containing the current widget.
+    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
+    ///
+    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
+    fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
+        self.root_state_mut().set_menu(menu);
+    }
+}
+
+impl BaseCtx for EventCtx<'_, '_> {}
+impl LaidOutCtx for EventCtx<'_, '_> {}
+impl<'b> ExtraCtx<'b> for EventCtx<'_, 'b> {}
+
+impl BaseCtx for LifeCycleCtx<'_, '_> {}
+impl LaidOutCtx for LifeCycleCtx<'_, '_> {}
+impl<'b> ExtraCtx<'b> for LifeCycleCtx<'_, 'b> {}
+
+impl BaseCtx for UpdateCtx<'_, '_> {}
+impl LaidOutCtx for UpdateCtx<'_, '_> {}
+impl<'b> ExtraCtx<'b> for UpdateCtx<'_, 'b> {}
+
+impl BaseCtx for LayoutCtx<'_, '_, '_> {}
+
+impl BaseCtx for PaintCtx<'_, '_> {}
+impl LaidOutCtx for PaintCtx<'_, '_> {}
+
+impl<'a, 'b> EventCtx<'a, 'b> {
     /// Get an object which can create text layouts.
     pub fn text(&mut self) -> Text {
         self.root_state.window.text()
@@ -198,38 +330,6 @@ impl<'a, 'b> EventCtx<'a, 'b> {
         // TODO: plumb mouse grab through to platform (through druid-shell)
     }
 
-    /// The "hot" (aka hover) status of a widget.
-    ///
-    /// A widget is "hot" when the mouse is hovered over it. Widgets will
-    /// often change their appearance as a visual indication that they
-    /// will respond to mouse interaction.
-    ///
-    /// The hot status is computed from the widget's layout rect. In a
-    /// container hierarchy, all widgets with layout rects containing the
-    /// mouse position have hot status.
-    ///
-    /// Discussion: there is currently some confusion about whether a
-    /// widget can be considered hot when some other widget is active (for
-    /// example, when clicking to one widget and dragging to the next).
-    /// The documentation should clearly state the resolution.
-    pub fn is_hot(&self) -> bool {
-        self.widget_state.is_hot
-    }
-
-    /// The active status of a widget.
-    ///
-    /// Active status generally corresponds to a mouse button down. Widgets
-    /// with behavior similar to a button will call [`set_active`] on mouse
-    /// down and then up.
-    ///
-    /// When a widget is active, it gets mouse events even when the mouse
-    /// is dragged away.
-    ///
-    /// [`set_active`]: struct.EventCtx.html#method.set_active
-    pub fn is_active(&self) -> bool {
-        self.widget_state.is_active
-    }
-
     /// Returns a reference to the current `WindowHandle`.
     pub fn window(&self) -> &WindowHandle {
         &self.root_state.window
@@ -253,14 +353,6 @@ impl<'a, 'b> EventCtx<'a, 'b> {
                 log::error!("EventCtx::new_window: {}", MSG)
             }
         }
-    }
-
-    /// Set the menu of the window containing the current widget.
-    /// `T` must be the application's root `Data` type (the type provided to [`AppLauncher::launch`]).
-    ///
-    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
-    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        self.root_state.set_menu(menu);
     }
 
     /// Show the context menu in the window containing the current widget.
@@ -315,18 +407,6 @@ impl<'a, 'b> EventCtx<'a, 'b> {
     /// [`has_focus`]: struct.EventCtx.html#method.has_focus
     pub fn is_focused(&self) -> bool {
         self.focus_widget == Some(self.widget_id())
-    }
-
-    /// The (tree) focus status of a widget.
-    ///
-    /// Returns `true` if either this specific widget or any one of its descendants is focused.
-    /// To check if only this specific widget is focused use [`is_focused`].
-    ///
-    /// See [`is_focused`] for more information about focus.
-    ///
-    /// [`is_focused`]: struct.EventCtx.html#method.is_focused
-    pub fn has_focus(&self) -> bool {
-        self.widget_state.has_focus
     }
 
     /// Request keyboard focus.
@@ -395,97 +475,13 @@ impl<'a, 'b> EventCtx<'a, 'b> {
         }
     }
 
-    /// Request an animation frame.
-    pub fn request_anim_frame(&mut self) {
-        self.widget_state.request_anim = true;
-        self.request_paint();
-    }
-
-    /// Request a timer event.
-    ///
-    /// The return value is a token, which can be used to associate the
-    /// request with the event.
-    pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
-        self.root_state
-            .request_timer(&mut self.widget_state, deadline)
-    }
-
-    /// The layout size.
-    ///
-    /// This is the layout size as ultimately determined by the parent
-    /// container, on the previous layout pass.
-    ///
-    /// Generally it will be the same as the size returned by the child widget's
-    /// [`layout`] method.
-    ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
-    pub fn size(&self) -> Size {
-        self.widget_state.size()
-    }
-
-    /// Submit a [`Command`] to be run after this event is handled.
-    ///
-    /// Commands are run in the order they are submitted; all commands
-    /// submitted during the handling of an event are executed before
-    /// the [`update`] method is called.
-    ///
-    /// [`Command`]: struct.Command.html
-    /// [`update`]: trait.Widget.html#tymethod.update
-    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
-        self.root_state.submit_command(cmd.into(), target.into())
-    }
-
     /// Get the window id.
     pub fn window_id(&self) -> WindowId {
         self.root_state.window_id
     }
-
-    /// get the `WidgetId` of the current widget.
-    pub fn widget_id(&self) -> WidgetId {
-        self.widget_state.id
-    }
 }
 
 impl<'a, 'b> LifeCycleCtx<'a, 'b> {
-    #[deprecated(since = "0.5.0", note = "use request_paint instead")]
-    pub fn invalidate(&mut self) {
-        self.request_paint();
-    }
-
-    /// Request a [`paint`] pass. This is equivalent to calling [`request_paint_rect`] for the
-    /// widget's [`paint_rect`].
-    ///
-    /// [`paint`]: trait.Widget.html#tymethod.paint
-    /// [`request_paint_rect`]: struct.LifeCycleCtx.html#method.request_paint_rect
-    /// [`paint_rect`]: struct.WidgetPod.html#method.paint_rect
-    pub fn request_paint(&mut self) {
-        self.request_paint_rect(
-            self.widget_state.paint_rect() - self.widget_state.layout_rect().origin().to_vec2(),
-        );
-    }
-
-    /// Request a [`paint`] pass for redrawing a rectangle, which is given relative to our layout
-    /// rectangle.
-    ///
-    /// [`paint`]: trait.Widget.html#tymethod.paint
-    pub fn request_paint_rect(&mut self, rect: Rect) {
-        self.widget_state.invalid.add_rect(rect);
-    }
-
-    /// Request layout.
-    ///
-    /// See [`EventCtx::request_layout`] for more information.
-    ///
-    /// [`EventCtx::request_layout`]: struct.EventCtx.html#method.request_layout
-    pub fn request_layout(&mut self) {
-        self.widget_state.needs_layout = true;
-    }
-
-    /// Returns the current widget's `WidgetId`.
-    pub fn widget_id(&self) -> WidgetId {
-        self.widget_state.id
-    }
-
     /// Registers a child widget.
     ///
     /// This should only be called in response to a `LifeCycle::WidgetAdded` event.
@@ -507,157 +503,9 @@ impl<'a, 'b> LifeCycleCtx<'a, 'b> {
     pub fn register_for_focus(&mut self) {
         self.widget_state.focus_chain.push(self.widget_id());
     }
-
-    /// Indicate that your children have changed.
-    ///
-    /// Widgets must call this method after adding a new child.
-    pub fn children_changed(&mut self) {
-        self.widget_state.children_changed = true;
-        self.request_layout();
-    }
-
-    /// Request an animation frame.
-    pub fn request_anim_frame(&mut self) {
-        self.widget_state.request_anim = true;
-        self.request_paint();
-    }
-
-    /// Request a timer event.
-    ///
-    /// The return value is a token, which can be used to associate the
-    /// request with the event.
-    pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
-        self.root_state
-            .request_timer(&mut self.widget_state, deadline)
-    }
-
-    /// The layout size.
-    ///
-    /// This is the layout size as ultimately determined by the parent
-    /// container, on the previous layout pass.
-    ///
-    /// Generally it will be the same as the size returned by the child widget's
-    /// [`layout`] method.
-    ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
-    pub fn size(&self) -> Size {
-        self.widget_state.size()
-    }
-
-    /// Submit a [`Command`] to be run after this event is handled.
-    ///
-    /// Commands are run in the order they are submitted; all commands
-    /// submitted during the handling of an event are executed before
-    /// the [`update`] method is called.
-    ///
-    /// [`Command`]: struct.Command.html
-    /// [`update`]: trait.Widget.html#tymethod.update
-    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
-        self.root_state.submit_command(cmd.into(), target.into())
-    }
-
-    /// Set the menu of the window containing the current widget.
-    /// `T` must be the application's root `Data` type (the type provided
-    /// to [`AppLauncher::launch`]).
-    ///
-    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
-    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        self.root_state.set_menu(menu);
-    }
 }
 
 impl<'a, 'b> UpdateCtx<'a, 'b> {
-    #[deprecated(since = "0.5.0", note = "use request_paint instead")]
-    pub fn invalidate(&mut self) {
-        self.request_paint();
-    }
-
-    /// Request a [`paint`] pass. This is equivalent to calling [`request_paint_rect`] for the
-    /// widget's [`paint_rect`].
-    ///
-    /// [`paint`]: trait.Widget.html#tymethod.paint
-    /// [`request_paint_rect`]: struct.UpdateCtx.html#method.request_paint_rect
-    /// [`paint_rect`]: struct.WidgetPod.html#method.paint_rect
-    pub fn request_paint(&mut self) {
-        self.request_paint_rect(
-            self.widget_state.paint_rect() - self.widget_state.layout_rect().origin().to_vec2(),
-        );
-    }
-
-    /// Request a [`paint`] pass for redrawing a rectangle, which is given relative to our layout
-    /// rectangle.
-    ///
-    /// [`paint`]: trait.Widget.html#tymethod.paint
-    pub fn request_paint_rect(&mut self, rect: Rect) {
-        self.widget_state.invalid.add_rect(rect);
-    }
-
-    /// Request layout.
-    ///
-    /// See [`EventCtx::request_layout`] for more information.
-    ///
-    /// [`EventCtx::request_layout`]: struct.EventCtx.html#method.request_layout
-    pub fn request_layout(&mut self) {
-        self.widget_state.needs_layout = true;
-    }
-
-    /// Indicate that your children have changed.
-    ///
-    /// Widgets must call this method after adding a new child.
-    pub fn children_changed(&mut self) {
-        self.widget_state.children_changed = true;
-        self.request_layout();
-    }
-
-    /// Request an animation frame.
-    pub fn request_anim_frame(&mut self) {
-        self.widget_state.request_anim = true;
-        self.request_paint();
-    }
-
-    /// Request a timer event.
-    ///
-    /// The return value is a token, which can be used to associate the
-    /// request with the event.
-    pub fn request_timer(&mut self, deadline: Duration) -> TimerToken {
-        self.root_state
-            .request_timer(&mut self.widget_state, deadline)
-    }
-
-    /// The layout size.
-    ///
-    /// This is the layout size as ultimately determined by the parent
-    /// container, on the previous layout pass.
-    ///
-    /// Generally it will be the same as the size returned by the child widget's
-    /// [`layout`] method.
-    ///
-    /// [`layout`]: trait.Widget.html#tymethod.layout
-    pub fn size(&self) -> Size {
-        self.widget_state.size()
-    }
-
-    /// Submit a [`Command`] to be run after layout and paint finish.
-    ///
-    /// **Note:**
-    ///
-    /// Commands submited during an `update` call are handled *after* update,
-    /// layout, and paint have completed; this will trigger a new event cycle.
-    ///
-    /// [`Command`]: struct.Command.html
-    pub fn submit_command(&mut self, cmd: impl Into<Command>, target: impl Into<Option<Target>>) {
-        self.root_state.submit_command(cmd.into(), target.into());
-    }
-
-    /// Set the menu of the window containing the current widget.
-    /// `T` must be the application's root `Data` type (the type provided
-    /// to [`AppLauncher::launch`]).
-    ///
-    /// [`AppLauncher::launch`]: struct.AppLauncher.html#method.launch
-    pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
-        self.root_state.set_menu(menu)
-    }
-
     /// Get an object which can create text layouts.
     pub fn text(&mut self) -> Text {
         self.root_state.window.text()
@@ -672,11 +520,6 @@ impl<'a, 'b> UpdateCtx<'a, 'b> {
     /// Get the window id.
     pub fn window_id(&self) -> WindowId {
         self.root_state.window_id
-    }
-
-    /// get the `WidgetId` of the current widget.
-    pub fn widget_id(&self) -> WidgetId {
-        self.widget_state.id
     }
 }
 
@@ -708,35 +551,6 @@ impl<'a, 'b, 'c> LayoutCtx<'a, 'b, 'c> {
 }
 
 impl<'a, 'b: 'a> PaintCtx<'a, 'b> {
-    /// get the `WidgetId` of the current widget.
-    pub fn widget_id(&self) -> WidgetId {
-        self.widget_state.id
-    }
-
-    /// Query the "hot" state of the widget.
-    ///
-    /// See [`EventCtx::is_hot`](struct.EventCtx.html#method.is_hot) for
-    /// additional information.
-    pub fn is_hot(&self) -> bool {
-        self.widget_state.is_hot
-    }
-
-    /// Query the "active" state of the widget.
-    ///
-    /// See [`EventCtx::is_active`](struct.EventCtx.html#method.is_active) for
-    /// additional information.
-    pub fn is_active(&self) -> bool {
-        self.widget_state.is_active
-    }
-
-    /// Returns the layout size of the current widget.
-    ///
-    /// See [`EventCtx::size`](struct.EventCtx.html#method.size) for
-    /// additional information.
-    pub fn size(&self) -> Size {
-        self.widget_state.size()
-    }
-
     /// The focus status of a widget.
     ///
     /// Returns `true` if this specific widget is focused.
@@ -748,19 +562,6 @@ impl<'a, 'b: 'a> PaintCtx<'a, 'b> {
     /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
     pub fn is_focused(&self) -> bool {
         self.focus_widget == Some(self.widget_id())
-    }
-
-    /// The (tree) focus status of a widget.
-    ///
-    /// Returns `true` if either this specific widget or any one of its descendants is focused.
-    /// To check if only this specific widget is focused use [`is_focused`].
-    ///
-    /// See [`EventCtx::is_focused`] for more information about focus.
-    ///
-    /// [`is_focused`]: #method.is_focused
-    /// [`EventCtx::is_focused`]: struct.EventCtx.html#method.is_focused
-    pub fn has_focus(&self) -> bool {
-        self.widget_state.has_focus
     }
 
     /// The depth in the tree of the currently painting widget.
@@ -888,13 +689,6 @@ impl<'a> RootState<'a> {
                 log::error!("EventCtx::set_menu: {}", MSG)
             }
         }
-    }
-
-    fn request_timer(&self, widget_state: &mut WidgetState, deadline: Duration) -> TimerToken {
-        widget_state.request_timer = true;
-        let timer_token = self.window.request_timer(deadline);
-        widget_state.add_timer(timer_token);
-        timer_token
     }
 }
 

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -24,9 +24,9 @@ use crate::piet::{
     FontBuilder, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
 };
 use crate::{
-    BoxConstraints, Color, Command, Data, Env, Event, EventCtx, InternalEvent, InternalLifeCycle,
-    LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Region, Target, TimerToken, UpdateCtx, Widget,
-    WidgetId, WindowHandle, WindowId,
+    BaseCtx, BoxConstraints, Color, Command, Data, Env, Event, EventCtx, ExtraCtx, InternalEvent,
+    InternalLifeCycle, LaidOutCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Region, Target,
+    TimerToken, UpdateCtx, Widget, WidgetId, WindowHandle, WindowId,
 };
 
 /// Our queue type
@@ -54,7 +54,8 @@ pub struct WidgetPod<T, W> {
 }
 
 /// Static state that is shared between most contexts.
-pub(crate) struct RootState<'a> {
+#[doc(hidden)]
+pub struct RootState<'a> {
     pub(crate) command_queue: &'a mut CommandQueue,
     pub(crate) window_id: WindowId,
     pub(crate) window: &'a WindowHandle,
@@ -76,8 +77,9 @@ pub(crate) struct RootState<'a> {
 ///
 /// [`paint`]: trait.Widget.html#tymethod.paint
 /// [`WidgetPod`]: struct.WidgetPod.html
+#[doc(hidden)]
 #[derive(Clone)]
-pub(crate) struct WidgetState {
+pub struct WidgetState {
     pub(crate) id: WidgetId,
     /// The frame of this widget in its parents coordinate space.
     /// This should always be set; it is only an `Option` so that we

--- a/druid/src/ctx_field_traits.rs
+++ b/druid/src/ctx_field_traits.rs
@@ -1,0 +1,147 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Private traits that enable default trait implementations to access struct fields.
+//!
+//! The traits themselves have to be public, but the module is private.
+
+use crate::contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, UpdateCtx};
+use crate::core::{RootState, WidgetState};
+
+pub trait WidgetStateRef {
+    fn widget_state(&self) -> &WidgetState;
+}
+
+pub trait WidgetStateMut: WidgetStateRef {
+    fn widget_state_mut(&mut self) -> &mut WidgetState;
+}
+
+pub trait RootStateRef<'a> {
+    fn root_state(&self) -> &RootState<'a>;
+}
+
+pub trait RootStateMut<'a>: RootStateRef<'a> {
+    fn root_state_mut(&mut self) -> &mut RootState<'a>;
+}
+
+impl WidgetStateRef for EventCtx<'_, '_> {
+    #[inline]
+    fn widget_state(&self) -> &WidgetState {
+        &self.widget_state
+    }
+}
+impl WidgetStateMut for EventCtx<'_, '_> {
+    #[inline]
+    fn widget_state_mut(&mut self) -> &mut WidgetState {
+        &mut self.widget_state
+    }
+}
+
+impl WidgetStateRef for LifeCycleCtx<'_, '_> {
+    #[inline]
+    fn widget_state(&self) -> &WidgetState {
+        &self.widget_state
+    }
+}
+impl WidgetStateMut for LifeCycleCtx<'_, '_> {
+    #[inline]
+    fn widget_state_mut(&mut self) -> &mut WidgetState {
+        &mut self.widget_state
+    }
+}
+
+impl WidgetStateRef for UpdateCtx<'_, '_> {
+    #[inline]
+    fn widget_state(&self) -> &WidgetState {
+        &self.widget_state
+    }
+}
+impl WidgetStateMut for UpdateCtx<'_, '_> {
+    #[inline]
+    fn widget_state_mut(&mut self) -> &mut WidgetState {
+        &mut self.widget_state
+    }
+}
+
+impl WidgetStateRef for LayoutCtx<'_, '_, '_> {
+    #[inline]
+    fn widget_state(&self) -> &WidgetState {
+        &self.widget_state
+    }
+}
+impl WidgetStateMut for LayoutCtx<'_, '_, '_> {
+    #[inline]
+    fn widget_state_mut(&mut self) -> &mut WidgetState {
+        &mut self.widget_state
+    }
+}
+
+impl WidgetStateRef for PaintCtx<'_, '_> {
+    #[inline]
+    fn widget_state(&self) -> &WidgetState {
+        &self.widget_state
+    }
+}
+
+impl<'a> RootStateRef<'a> for EventCtx<'_, 'a> {
+    #[inline]
+    fn root_state(&self) -> &RootState<'a> {
+        &self.root_state
+    }
+}
+impl<'a> RootStateMut<'a> for EventCtx<'_, 'a> {
+    #[inline]
+    fn root_state_mut(&mut self) -> &mut RootState<'a> {
+        &mut self.root_state
+    }
+}
+
+impl<'a> RootStateRef<'a> for LifeCycleCtx<'_, 'a> {
+    #[inline]
+    fn root_state(&self) -> &RootState<'a> {
+        &self.root_state
+    }
+}
+impl<'a> RootStateMut<'a> for LifeCycleCtx<'_, 'a> {
+    #[inline]
+    fn root_state_mut(&mut self) -> &mut RootState<'a> {
+        &mut self.root_state
+    }
+}
+
+impl<'a> RootStateRef<'a> for UpdateCtx<'_, 'a> {
+    #[inline]
+    fn root_state(&self) -> &RootState<'a> {
+        &self.root_state
+    }
+}
+impl<'a> RootStateMut<'a> for UpdateCtx<'_, 'a> {
+    #[inline]
+    fn root_state_mut(&mut self) -> &mut RootState<'a> {
+        &mut self.root_state
+    }
+}
+
+impl<'a> RootStateRef<'a> for LayoutCtx<'_, '_, 'a> {
+    #[inline]
+    fn root_state(&self) -> &RootState<'a> {
+        &self.root_state
+    }
+}
+impl<'a> RootStateMut<'a> for LayoutCtx<'_, '_, 'a> {
+    #[inline]
+    fn root_state_mut(&mut self) -> &mut RootState<'a> {
+        &mut self.root_state
+    }
+}

--- a/druid/src/event.rs
+++ b/druid/src/event.rs
@@ -239,7 +239,7 @@ pub enum InternalLifeCycle {
         /// the widget that is gaining focus, if any
         new: Option<WidgetId>,
     },
-    /// Testing only: request the `BaseState` of a specific widget.
+    /// Testing only: request the `WidgetState` of a specific widget.
     ///
     /// During testing, you may wish to verify that the state of a widget
     /// somewhere in the tree is as expected. In that case you can dispatch
@@ -308,16 +308,16 @@ pub(crate) use state_cell::{StateCell, StateCheckFn};
 
 #[cfg(test)]
 mod state_cell {
-    use crate::core::BaseState;
+    use crate::core::WidgetState;
     use crate::WidgetId;
     use std::{cell::RefCell, rc::Rc};
 
     /// An interior-mutable struct for fetching BasteState.
     #[derive(Clone, Default)]
-    pub struct StateCell(Rc<RefCell<Option<BaseState>>>);
+    pub struct StateCell(Rc<RefCell<Option<WidgetState>>>);
 
     #[derive(Clone)]
-    pub struct StateCheckFn(Rc<dyn Fn(&BaseState)>);
+    pub struct StateCheckFn(Rc<dyn Fn(&WidgetState)>);
 
     /// a hacky way of printing the widget id if we panic
     struct WidgetDrop(bool, WidgetId);
@@ -332,7 +332,7 @@ mod state_cell {
 
     impl StateCell {
         /// Set the state. This will panic if it is called twice.
-        pub(crate) fn set(&self, state: BaseState) {
+        pub(crate) fn set(&self, state: WidgetState) {
             assert!(
                 self.0.borrow_mut().replace(state).is_none(),
                 "StateCell already set"
@@ -340,18 +340,18 @@ mod state_cell {
         }
 
         #[allow(dead_code)]
-        pub(crate) fn take(&self) -> Option<BaseState> {
+        pub(crate) fn take(&self) -> Option<WidgetState> {
             self.0.borrow_mut().take()
         }
     }
 
     impl StateCheckFn {
         #[cfg(not(target_arch = "wasm32"))]
-        pub(crate) fn new(f: impl Fn(&BaseState) + 'static) -> Self {
+        pub(crate) fn new(f: impl Fn(&WidgetState) + 'static) -> Self {
             StateCheckFn(Rc::new(f))
         }
 
-        pub(crate) fn call(&self, state: &BaseState) {
+        pub(crate) fn call(&self, state: &WidgetState) {
             let mut panic_reporter = WidgetDrop(true, state.id);
             (self.0)(&state);
             panic_reporter.0 = false;

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -122,6 +122,7 @@ mod box_constraints;
 mod command;
 mod contexts;
 mod core;
+mod ctx_field_traits;
 mod data;
 mod env;
 mod event;
@@ -154,7 +155,9 @@ pub use app::{AppLauncher, WindowDesc};
 pub use app_delegate::{AppDelegate, DelegateCtx};
 pub use box_constraints::BoxConstraints;
 pub use command::{sys as commands, Command, Selector, SingleUse, Target};
-pub use contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, Region, UpdateCtx};
+pub use contexts::{
+    BaseCtx, EventCtx, ExtraCtx, LaidOutCtx, LayoutCtx, LifeCycleCtx, PaintCtx, Region, UpdateCtx,
+};
 pub use data::Data;
 pub use env::{Env, Key, KeyOrValue, Value, ValueType};
 pub use event::{Event, InternalEvent, InternalLifeCycle, LifeCycle};

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -16,7 +16,7 @@
 
 use std::path::Path;
 
-use crate::core::{BaseState, CommandQueue};
+use crate::core::{CommandQueue, WidgetState};
 use crate::piet::{BitmapTarget, Device, Error, ImageFormat, Piet};
 use crate::*;
 
@@ -182,16 +182,16 @@ impl<T: Data> Harness<'_, T> {
         &self.inner.data
     }
 
-    /// Retrieve a copy of this widget's `BaseState`, or die trying.
-    pub(crate) fn get_state(&mut self, widget: WidgetId) -> BaseState {
+    /// Retrieve a copy of this widget's `WidgetState`, or die trying.
+    pub(crate) fn get_state(&mut self, widget: WidgetId) -> WidgetState {
         match self.try_get_state(widget) {
             Some(thing) => thing,
             None => panic!("get_state failed for widget {:?}", widget),
         }
     }
 
-    /// Attempt to retrieve a copy of this widget's `BaseState`.
-    pub(crate) fn try_get_state(&mut self, widget: WidgetId) -> Option<BaseState> {
+    /// Attempt to retrieve a copy of this widget's `WidgetState`.
+    pub(crate) fn try_get_state(&mut self, widget: WidgetId) -> Option<WidgetState> {
         let cell = StateCell::default();
         let state_cell = cell.clone();
         self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugRequestState {
@@ -201,10 +201,10 @@ impl<T: Data> Harness<'_, T> {
         cell.take()
     }
 
-    /// Inspect the `BaseState` of each widget in the tree.
+    /// Inspect the `WidgetState` of each widget in the tree.
     ///
     /// The provided closure will be called on each widget.
-    pub(crate) fn inspect_state(&mut self, f: impl Fn(&BaseState) + 'static) {
+    pub(crate) fn inspect_state(&mut self, f: impl Fn(&WidgetState) + 'static) {
         let checkfn = StateCheckFn::new(f);
         self.lifecycle(LifeCycle::Internal(InternalLifeCycle::DebugInspectState(
             checkfn,

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -299,7 +299,7 @@ impl<T: Data, W: Widget<T>> Widget<T> for Recorder<W> {
     fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
         self.inner.update(ctx, old_data, data, env);
         self.recording
-            .push(Record::Update(ctx.base_state.invalid.to_rect()));
+            .push(Record::Update(ctx.widget_state.invalid.to_rect()));
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {

--- a/druid/src/widget/checkbox.rs
+++ b/druid/src/widget/checkbox.rs
@@ -17,6 +17,7 @@
 use crate::kurbo::{BezPath, Point, Rect, Size};
 use crate::piet::{LineCap, LineJoin, LinearGradient, RenderContext, StrokeStyle, UnitPoint};
 use crate::theme;
+use crate::widget::prelude::*;
 use crate::widget::{Label, LabelText};
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,

--- a/druid/src/widget/click.rs
+++ b/druid/src/widget/click.rs
@@ -16,6 +16,7 @@
 //!
 //! [`Controller`]: struct.Controller.html
 
+use crate::widget::prelude::*;
 use crate::widget::Controller;
 use crate::{Data, Env, Event, EventCtx, LifeCycle, LifeCycleCtx, Widget};
 

--- a/druid/src/widget/container.rs
+++ b/druid/src/widget/container.rs
@@ -16,6 +16,7 @@
 
 use super::BackgroundBrush;
 use crate::shell::kurbo::{Point, Rect, Size};
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Color, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle,
     LifeCycleCtx, PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,

--- a/druid/src/widget/either.rs
+++ b/druid/src/widget/either.rs
@@ -15,6 +15,7 @@
 //! A widget that switches dynamically between two child views.
 
 use crate::kurbo::{Point, Rect, Size};
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     UpdateCtx, Widget, WidgetPod,

--- a/druid/src/widget/image.rs
+++ b/druid/src/widget/image.rs
@@ -19,6 +19,7 @@ use std::convert::AsRef;
 use std::error::Error;
 use std::path::Path;
 
+use crate::widget::prelude::*;
 use crate::{
     piet::{ImageFormat, InterpolationMode},
     widget::common::FillStrat,

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -18,6 +18,7 @@ use crate::piet::{
     Color, FontBuilder, PietText, PietTextLayout, RenderContext, Text, TextLayout,
     TextLayoutBuilder, UnitPoint,
 };
+use crate::widget::prelude::*;
 use crate::{
     theme, BoxConstraints, Data, Env, Event, EventCtx, KeyOrValue, LayoutCtx, LifeCycle,
     LifeCycleCtx, LocalizedString, PaintCtx, Point, Size, UpdateCtx, Widget,

--- a/druid/src/widget/list.rs
+++ b/druid/src/widget/list.rs
@@ -22,6 +22,7 @@ use crate::im::Vector;
 
 use crate::kurbo::{Point, Rect, Size};
 
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     UpdateCtx, Widget, WidgetPod,

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -112,7 +112,7 @@ pub use widget_ext::WidgetExt;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-        RenderContext, Size, UpdateCtx, Widget, WidgetId,
+        BaseCtx, BoxConstraints, Env, Event, EventCtx, ExtraCtx, LaidOutCtx, LayoutCtx, LifeCycle,
+        LifeCycleCtx, PaintCtx, RenderContext, Size, UpdateCtx, Widget, WidgetId,
     };
 }

--- a/druid/src/widget/painter.rs
+++ b/druid/src/widget/painter.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::piet::{FixedGradient, LinearGradient, PaintBrush, RadialGradient};
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Color, Data, Env, Event, EventCtx, Key, LayoutCtx, LifeCycle, LifeCycleCtx,
     PaintCtx, RenderContext, Size, UpdateCtx, Widget,

--- a/druid/src/widget/progress_bar.rs
+++ b/druid/src/widget/progress_bar.rs
@@ -16,6 +16,7 @@
 
 use crate::kurbo::{Point, Rect, Size};
 use crate::theme;
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
     PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,

--- a/druid/src/widget/radio.rs
+++ b/druid/src/widget/radio.rs
@@ -16,6 +16,7 @@
 
 use crate::kurbo::{Circle, Point, Rect, Size};
 use crate::theme;
+use crate::widget::prelude::*;
 use crate::widget::{CrossAxisAlignment, Flex, Label, LabelText, Padding};
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,

--- a/druid/src/widget/scroll.rs
+++ b/druid/src/widget/scroll.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use crate::kurbo::{Affine, Point, Rect, RoundedRect, Size, Vec2};
 use crate::theme;
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     RenderContext, TimerToken, UpdateCtx, Widget, WidgetPod,

--- a/druid/src/widget/slider.rs
+++ b/druid/src/widget/slider.rs
@@ -16,6 +16,7 @@
 
 use crate::kurbo::{Circle, Point, Rect, Shape, Size};
 use crate::theme;
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, LinearGradient,
     PaintCtx, RenderContext, UnitPoint, UpdateCtx, Widget,

--- a/druid/src/widget/split.rs
+++ b/druid/src/widget/split.rs
@@ -16,6 +16,7 @@
 
 use crate::kurbo::{Line, Point, Rect, Size};
 use crate::widget::flex::Axis;
+use crate::widget::prelude::*;
 use crate::{
     theme, BoxConstraints, Color, Cursor, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle,
     LifeCycleCtx, PaintCtx, RenderContext, UpdateCtx, Widget, WidgetPod,

--- a/druid/src/widget/stepper.rs
+++ b/druid/src/widget/stepper.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use crate::kurbo::{BezPath, Rect};
 use crate::piet::{LinearGradient, RenderContext, UnitPoint};
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,
     TimerToken, UpdateCtx, Widget,

--- a/druid/src/widget/svg.rs
+++ b/druid/src/widget/svg.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use log::error;
 
+use crate::widget::prelude::*;
 use crate::{
     kurbo::BezPath, widget::common::FillStrat, Affine, BoxConstraints, Color, Data, Env, Event,
     EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Rect, RenderContext, Size, UpdateCtx,

--- a/druid/src/widget/switch.rs
+++ b/druid/src/widget/switch.rs
@@ -19,6 +19,7 @@ use crate::piet::{
     FontBuilder, LinearGradient, RenderContext, Text, TextLayout, TextLayoutBuilder, UnitPoint,
 };
 use crate::theme;
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, UpdateCtx,
     Widget,

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -16,6 +16,7 @@
 
 use std::time::Duration;
 
+use crate::widget::prelude::*;
 use crate::{
     Application, BoxConstraints, Cursor, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx,
     LifeCycle, LifeCycleCtx, PaintCtx, Selector, SysMods, TimerToken, UpdateCtx, Widget,

--- a/druid/src/widget/view_switcher.rs
+++ b/druid/src/widget/view_switcher.rs
@@ -14,6 +14,7 @@
 
 //! A widget that can dynamically switch between one of many views.
 
+use crate::widget::prelude::*;
 use crate::{
     BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
     Point, Rect, Size, UpdateCtx, Widget, WidgetPod,


### PR DESCRIPTION
This is an alternative approach to #972 which aims to reduce copied code. Here, instead of macros, I implement it using traits.

Code inside of macros can't be formatted using `cargo fmt`. This means that over time the code formatting will be all over the place and will make it harder to read the code. Alternatively we would have to spend time manually checking formatting during code reviews, which seems almost worse.

I've also had some really annoying debugging experiences with macros due to compiler errors and line numbers not being meaningful. I'm not well versed in Rust macros so I can't say for sure if this will apply here, but I can say that I've had the issue with other macros.

Thus I propose we solve the issue without using macros. One way I can think of is using default trait implementations, whcih I did in this PR. That solves the problems that macros introduce. Traits also allow for more powerful function signatures in applications where the function is willing to take any context that implements a specific method.

The trait approach may have a bit of downside. The documentation for the context structs won't contain trait method docs. I've done a bit of googling but not thorough. Other people are having the same issue, but it's unclear if it's already possible to inline the docs to the struct, or if that's something that might become possible in a future version of `cargo doc`.

*PS. This PR still needs some cleanup, but I wanted to get the general idea out there as it is working already.*