### PR TITLE
Update bloat action

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -51,7 +51,8 @@ jobs:
             target/release/examples/calc
             target/release/examples/scroll_colors
             target/release/examples/multiwin
-            target/release/examples/textbox
+            target/release/examples/flex
+            target/release/examples/styled_text
             target/release/examples/custom_widget
 
       - name: checkout head
@@ -76,7 +77,8 @@ jobs:
             target/release/examples/calc
             target/release/examples/scroll_colors
             target/release/examples/multiwin
-            target/release/examples/textbox
+            target/release/examples/flex
+            target/release/examples/styled_text
             target/release/examples/custom_widget
 
       - name: compare


### PR DESCRIPTION
We've removed the 'textbox' example, so this wasn't working anymore;
I've removed that from the test list and added the flex and
styled_text examples.