### PR TITLE
Fix test harness crashing on failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Added docs generation testing for all features. ([#942] by [@xStrom])
 - Renamed `BaseState` to `WidgetState` ([#969] by [@cmyr])
 - X11: Reworked error handling ([#982] by [@jneem])
+- Fixed test harness crashing on failure. ([#984] by [@xStrom])
 
 ### Outside News
 
@@ -232,6 +233,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#970]: https://github.com/xi-editor/druid/pull/970
 [#980]: https://github.com/xi-editor/druid/pull/980
 [#982]: https://github.com/xi-editor/druid/pull/982
+[#984]: https://github.com/xi-editor/druid/pull/984
 [#991]: https://github.com/xi-editor/druid/pull/991
 
 ## [0.5.0] - 2020-04-01

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -157,7 +157,6 @@ impl<T: Data> Harness<'_, T> {
                 window_size,
             };
             harness_closure(&mut harness);
-            harness.piet.finish().expect("piet finish failed");
         }
         render_context_closure(target)
     }
@@ -297,6 +296,16 @@ impl<T: Data> Inner<T> {
     fn paint_rect(&mut self, piet: &mut Piet, invalid_rect: Rect) {
         self.window
             .do_paint(piet, invalid_rect, &mut self.cmds, &self.data, &self.env);
+    }
+}
+
+impl<T> Drop for Harness<'_, T> {
+    fn drop(&mut self) {
+        // We need to call finish even if a test assert failed
+        if let Err(err) = self.piet.finish() {
+            // We can't panic, because we might already be panicking
+            log::error!("piet finish failed: {}", err);
+        }
     }
 }
 


### PR DESCRIPTION
The piet context needs to be finished even if a test case fails. This PR achieves that via implementing `Drop` for `Harness`.

Fixes #950.