### PR TITLE
Do doc tests with the stable compiler.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,10 +301,10 @@ jobs:
           sudo apt install libgtk-3-dev
         if: contains(matrix.os, 'ubuntu')
 
-      - name: install nightly toolchain
+      - name: install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           override: true
 


### PR DESCRIPTION
Our doc tests are marked as required, so they should be done with the stable compiler instead. The nightly compiler has an issue right now and it's blocking merges.