### PR TITLE
Statically typed selectors, take two.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Replaced `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`. ([#931] by [@finnerale])
 - Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
 - Renamed `WidgetPod` methods: `paint` to `paint_raw`, `paint_with_offset` to `paint`, `paint_with_offset_always` to `paint_always`. ([#980] by [@totsteps])
-- `Command` and `Selector` are now statically typed, similarly to `Env` and `Key`. ([#993] by [@finnerale])
+- `Command` and `Selector` have been reworked and are now statically typed, similarly to `Env` and `Key`. ([#993] by [@finnerale])
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Replaced `NEW_WINDOW`, `SET_MENU` and `SHOW_CONTEXT_MENU` commands with methods on `EventCtx` and `DelegateCtx`. ([#931] by [@finnerale])
 - Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
 - Renamed `WidgetPod` methods: `paint` to `paint_raw`, `paint_with_offset` to `paint`, `paint_with_offset_always` to `paint_always`. ([#980] by [@totsteps])
+- `Command` and `Selector` are now statically typed, similarly to `Env` and `Key`. ([#993] by [@finnerale])
 
 ### Deprecated
 
@@ -242,6 +243,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#984]: https://github.com/xi-editor/druid/pull/984
 [#990]: https://github.com/xi-editor/druid/pull/990
 [#991]: https://github.com/xi-editor/druid/pull/991
+[#993]: https://github.com/xi-editor/druid/pull/993
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/examples/blocking_function.rs
+++ b/druid/examples/blocking_function.rs
@@ -23,9 +23,9 @@ use druid::{
 
 use druid::widget::{Button, Either, Flex, Label};
 
-const START_SLOW_FUNCTION: Selector = Selector::new("start_slow_function");
+const START_SLOW_FUNCTION: Selector<u32> = Selector::new("start_slow_function");
 
-const FINISH_SLOW_FUNCTION: Selector = Selector::new("finish_slow_function");
+const FINISH_SLOW_FUNCTION: Selector<u32> = Selector::new("finish_slow_function");
 
 struct Delegate {
     eventsink: ExtEventSink,
@@ -61,20 +61,15 @@ impl AppDelegate<AppState> for Delegate {
         data: &mut AppState,
         _env: &Env,
     ) -> bool {
-        match cmd.selector {
-            START_SLOW_FUNCTION => {
-                data.processing = true;
-                wrapped_slow_function(self.eventsink.clone(), data.value);
-                true
-            }
-            FINISH_SLOW_FUNCTION => {
-                data.processing = false;
-                let number = cmd.get_object::<u32>().expect("api violation");
-                data.value = *number;
-                true
-            }
-            _ => true,
+        if cmd.is(START_SLOW_FUNCTION) {
+            data.processing = true;
+            wrapped_slow_function(self.eventsink.clone(), data.value);
         }
+        if let Some(number) = cmd.get(FINISH_SLOW_FUNCTION) {
+            data.processing = false;
+            data.value = *number;
+        }
+        true
     }
 }
 

--- a/druid/examples/ext_event.rs
+++ b/druid/examples/ext_event.rs
@@ -22,7 +22,7 @@ use druid::kurbo::RoundedRect;
 use druid::widget::prelude::*;
 use druid::{AppLauncher, Color, Data, LocalizedString, Rect, Selector, WidgetExt, WindowDesc};
 
-const SET_COLOR: Selector = Selector::new("event-example.set-color");
+const SET_COLOR: Selector<Color> = Selector::new("event-example.set-color");
 
 /// A widget that displays a color.
 struct ColorWell;
@@ -53,8 +53,8 @@ impl ColorWell {
 impl Widget<MyColor> for ColorWell {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut MyColor, _env: &Env) {
         match event {
-            Event::Command(cmd) if cmd.selector == SET_COLOR => {
-                data.0 = cmd.get_object::<Color>().unwrap().clone();
+            Event::Command(cmd) if cmd.is(SET_COLOR) => {
+                data.0 = cmd.get_unchecked(SET_COLOR).clone();
                 ctx.request_paint();
             }
             _ => (),

--- a/druid/examples/identity.rs
+++ b/druid/examples/identity.rs
@@ -40,7 +40,7 @@ use druid::{
 
 const CYCLE_DURATION: Duration = Duration::from_millis(100);
 
-const FREEZE_COLOR: Selector = Selector::new("identity-example.freeze-color");
+const FREEZE_COLOR: Selector<Color> = Selector::new("identity-example.freeze-color");
 const UNFREEZE_COLOR: Selector = Selector::new("identity-example.unfreeze-color");
 
 /// Honestly: it's just a color in fancy clothing.
@@ -109,20 +109,13 @@ impl Widget<OurData> for ColorWell {
                 self.token = ctx.request_timer(CYCLE_DURATION);
                 ctx.request_paint();
             }
-
             Event::WindowConnected if self.randomize => {
                 self.token = ctx.request_timer(CYCLE_DURATION);
             }
-
-            Event::Command(cmd) if cmd.selector == FREEZE_COLOR => {
-                self.frozen = cmd
-                    .get_object::<Color>()
-                    .ok()
-                    .cloned()
-                    .expect("payload is always a Color")
-                    .into();
+            Event::Command(cmd) if cmd.is(FREEZE_COLOR) => {
+                self.frozen = cmd.get(FREEZE_COLOR).cloned();
             }
-            Event::Command(cmd) if cmd.selector == UNFREEZE_COLOR => self.frozen = None,
+            Event::Command(cmd) if cmd.is(UNFREEZE_COLOR) => self.frozen = None,
             _ => (),
         }
     }

--- a/druid/examples/multiwin.rs
+++ b/druid/examples/multiwin.rs
@@ -25,7 +25,7 @@ use druid::{
 };
 use log::info;
 
-const MENU_COUNT_ACTION: Selector = Selector::new("menu-count-action");
+const MENU_COUNT_ACTION: Selector<usize> = Selector::new("menu-count-action");
 const MENU_INCREMENT_ACTION: Selector = Selector::new("menu-increment-action");
 const MENU_DECREMENT_ACTION: Selector = Selector::new("menu-decrement-action");
 const MENU_SWITCH_GLOW_ACTION: Selector = Selector::new("menu-switch-glow");
@@ -155,16 +155,16 @@ impl AppDelegate<State> for Delegate {
         data: &mut State,
         _env: &Env,
     ) -> bool {
-        match cmd.selector {
-            sys_cmds::NEW_FILE => {
+        match cmd {
+            _ if cmd.is(sys_cmds::NEW_FILE) => {
                 let new_win = WindowDesc::new(ui_builder)
                     .menu(make_menu(data))
                     .window_size((data.selected as f64 * 100.0 + 300.0, 500.0));
                 ctx.new_window(new_win);
                 false
             }
-            MENU_COUNT_ACTION => {
-                data.selected = *cmd.get_object().unwrap();
+            _ if cmd.is(MENU_COUNT_ACTION) => {
+                data.selected = *cmd.get_unchecked(MENU_COUNT_ACTION);
                 let menu = make_menu::<State>(data);
                 for id in &self.windows {
                     ctx.set_menu(menu.clone(), *id);
@@ -173,7 +173,7 @@ impl AppDelegate<State> for Delegate {
             }
             // wouldn't it be nice if a menu (like a button) could just mutate state
             // directly if desired?
-            MENU_INCREMENT_ACTION => {
+            _ if cmd.is(MENU_INCREMENT_ACTION) => {
                 data.menu_count += 1;
                 let menu = make_menu::<State>(data);
                 for id in &self.windows {
@@ -181,7 +181,7 @@ impl AppDelegate<State> for Delegate {
                 }
                 false
             }
-            MENU_DECREMENT_ACTION => {
+            _ if cmd.is(MENU_DECREMENT_ACTION) => {
                 data.menu_count = data.menu_count.saturating_sub(1);
                 let menu = make_menu::<State>(data);
                 for id in &self.windows {
@@ -189,7 +189,7 @@ impl AppDelegate<State> for Delegate {
                 }
                 false
             }
-            MENU_SWITCH_GLOW_ACTION => {
+            _ if cmd.is(MENU_SWITCH_GLOW_ACTION) => {
                 data.glow_hot = !data.glow_hot;
                 false
             }

--- a/druid/src/app_delegate.rs
+++ b/druid/src/app_delegate.rs
@@ -57,7 +57,7 @@ impl<'a> DelegateCtx<'a> {
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         if self.app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::NEW_WINDOW, SingleUse::new(desc)),
+                Command::new(commands::NEW_WINDOW, SingleUse::new(Box::new(desc))),
                 Target::Global,
             );
         } else {
@@ -77,7 +77,7 @@ impl<'a> DelegateCtx<'a> {
     pub fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>, window: WindowId) {
         if self.app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::SET_MENU, menu),
+                Command::new(commands::SET_MENU, Box::new(menu)),
                 Target::Window(window),
             );
         } else {

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -237,7 +237,7 @@ impl<T> Selector<T> {
         Selector(s, PhantomData)
     }
 
-    pub(crate) const fn symbol(&self) -> SelectorSymbol {
+    pub(crate) const fn symbol(self) -> SelectorSymbol {
         self.0
     }
 }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -172,11 +172,10 @@ pub mod sys {
     /// Show the new file dialog.
     pub const NEW_FILE: Selector = Selector::new("druid-builtin.menu-file-new");
 
-    /// System command. A file picker dialog will be shown to the user, and an
-    /// [`OPEN_FILE`] command will be sent if a file is chosen.
+    /// When submitted by the application, a file picker dialog will be shown to the user,
+    /// and an [`OPEN_FILE`] command will be sent if a file is chosen.
     ///
     /// [`OPEN_FILE`]: constant.OPEN_FILE.html
-    /// [`FileDialogOptions`]: ../struct.FileDialogOptions.html
     pub const SHOW_OPEN_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-open");
 
@@ -185,12 +184,11 @@ pub mod sys {
     /// [`FileInfo`]: ../struct.FileInfo.html
     pub const OPEN_FILE: Selector<FileInfo> = Selector::new("druid-builtin.open-file-path");
 
-    /// Special command. When issued, the system will show the 'save as' panel,
+    /// When submitted by the application, the system will show the 'save as' panel,
     /// and if a path is selected the system will issue a [`SAVE_FILE`] command
     /// with the selected path as the payload.
     ///
     /// [`SAVE_FILE`]: constant.SAVE_FILE.html
-    /// [`FileDialogOptions`]: ../struct.FileDialogOptions.html
     pub const SHOW_SAVE_PANEL: Selector<FileDialogOptions> =
         Selector::new("druid-builtin.menu-file-save-as");
 

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -260,7 +260,10 @@ impl Command {
 
     /// Used to create a command from the types sent via an `ExtEventSink`.
     pub(crate) fn from_ext(selector: SelectorSymbol, object: Box<dyn Any>) -> Self {
-        Command { selector, object: object.into() }
+        Command {
+            selector,
+            object: object.into(),
+        }
     }
 
     /// Checks if this was created using `selector`.

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -81,14 +81,14 @@ pub struct Command {
 /// let num = CantClone(42);
 /// let command = Command::new(selector, SingleUse::new(num));
 ///
-/// let object: &SingleUse<CantClone> = command.get_unchecked(selector);
-/// if let Some(num) = object.take() {
+/// let payload: &SingleUse<CantClone> = command.get_unchecked(selector);
+/// if let Some(num) = payload.take() {
 ///     // now you own the data
 ///     assert_eq!(num.0, 42);
 /// }
 ///
 /// // subsequent calls will return `None`
-/// assert!(object.take().is_none());
+/// assert!(payload.take().is_none());
 /// ```
 ///
 /// [`Command`]: struct.Command.html
@@ -390,11 +390,12 @@ impl Into<Option<Target>> for WidgetId {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
-    fn get_object() {
+    fn get_payload() {
         let sel = Selector::new("my-selector");
-        let objs = vec![0, 1, 2];
-        let command = Command::new(sel, objs);
+        let payload = vec![0, 1, 2];
+        let command = Command::new(sel, payload);
         assert_eq!(command.get(sel), Some(&vec![0, 1, 2]));
     }
 }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -259,8 +259,8 @@ impl Command {
     }
 
     /// Used to create a command from the types sent via an `ExtEventSink`.
-    pub(crate) fn from_ext(selector: SelectorSymbol, object: Arc<dyn Any>) -> Self {
-        Command { selector, object }
+    pub(crate) fn from_ext(selector: SelectorSymbol, object: Box<dyn Any>) -> Self {
+        Command { selector, object: object.into() }
     }
 
     /// Checks if this was created using `selector`.

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -277,12 +277,12 @@ impl Command {
         }
     }
 
-    /// Checks if this was created using `selector`.
+    /// Returns `true` if `self` matches this `selector`.
     pub fn is<T>(&self, selector: Selector<T>) -> bool {
         self.symbol == selector.symbol()
     }
 
-    /// Returns `Some(reference)` to this `Command`'s payload, if the selector matches.
+    /// Returns `Some(&T)` (this `Command`'s payload) if the selector matches.
     ///
     /// Returns `None` when `self.is(selector) == false`.
     ///

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -244,8 +244,11 @@ impl<T> Selector<T> {
 impl<T: Any> Selector<T> {
     /// Convenience method for [`Command::new`] with this selector.
     ///
+    /// If the payload is `()` there is no need to call this,
+    /// as `Selector<()>` implements `Into<Command>`.
+    ///
     /// [`Command::new`]: struct.Command.html#method.new
-    pub fn carry(self, payload: T) -> Command {
+    pub fn with(self, payload: T) -> Command {
         Command::new(self, payload)
     }
 }
@@ -253,12 +256,12 @@ impl<T: Any> Selector<T> {
 impl Command {
     /// Create a new `Command` with a payload.
     ///
-    /// [`Selector::carry`] can be used to create `Command`s more conveniently.
+    /// [`Selector::with`] can be used to create `Command`s more conveniently.
     ///
     /// If you do not need a payload, [`Selector`] implements `Into<Command>`.
     ///
     /// [`Selector`]: struct.Selector.html
-    /// [`Selector::carry`]: struct.Selector.html#method.carry
+    /// [`Selector::with`]: struct.Selector.html#method.with
     pub fn new<T: Any>(selector: Selector<T>, payload: T) -> Self {
         Command {
             symbol: selector.symbol(),

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -14,25 +14,32 @@
 
 //! Custom commands.
 
-use std::any::Any;
-use std::sync::{Arc, Mutex};
+use std::any::{self, Any};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, Mutex},
+};
 
 use crate::{WidgetId, WindowId};
 
+pub(crate) type SelectorSymbol = &'static str;
+
 /// An identifier for a particular command.
+///
+/// The type parameter `T` specifies the commands payload type.
 ///
 /// This should be a unique string identifier. Certain `Selector`s are defined
 /// by druid, and have special meaning to the framework; these are listed in the
 /// [`druid::commands`] module.
 ///
 /// [`druid::commands`]: commands/index.html
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Selector(&'static str);
+#[derive(Debug, PartialEq, Eq)]
+pub struct Selector<T = ()>(SelectorSymbol, PhantomData<T>);
 
 /// An arbitrary command.
 ///
-/// A `Command` consists of a [`Selector`], that indicates what the command is,
-/// and an optional argument, that can be used to pass arbitrary data.
+/// A `Command` consists of a [`Selector`], that indicates what the command is
+/// and what type of payload it carries, as well as the actual payload.
 ///
 /// If the payload can't or shouldn't be cloned,
 /// wrapping it with [`SingleUse`] allows you to `take` the object.
@@ -45,7 +52,7 @@ pub struct Selector(&'static str);
 /// let rows = vec![1, 3, 10, 12];
 /// let command = Command::new(selector, rows);
 ///
-/// assert_eq!(command.get_object(), Ok(&vec![1, 3, 10, 12]));
+/// assert_eq!(command.get(selector), Some(&vec![1, 3, 10, 12]));
 /// ```
 ///
 /// [`Command::new`]: #method.new
@@ -54,9 +61,8 @@ pub struct Selector(&'static str);
 /// [`Selector`]: struct.Selector.html
 #[derive(Debug, Clone)]
 pub struct Command {
-    /// The command's `Selector`.
-    pub selector: Selector,
-    object: Option<Arc<dyn Any>>,
+    selector: SelectorSymbol,
+    object: Arc<dyn Any>,
 }
 
 /// A wrapper type for [`Command`] arguments that should only be used once.
@@ -74,7 +80,7 @@ pub struct Command {
 /// let num = CantClone(42);
 /// let command = Command::new(selector, SingleUse::new(num));
 ///
-/// let object: &SingleUse<CantClone> = command.get_object().unwrap();
+/// let object: &SingleUse<CantClone> = command.get_unchecked(selector);
 /// if let Some(num) = object.take() {
 ///     // now you own the data
 ///     assert_eq!(num.0, 42);
@@ -86,15 +92,6 @@ pub struct Command {
 ///
 /// [`Command`]: struct.Command.html
 pub struct SingleUse<T>(Mutex<Option<T>>);
-
-/// Errors that can occur when attempting to retrieve the a command's argument.
-#[derive(Debug, Clone, PartialEq)]
-pub enum ArgumentError {
-    /// The command did not have an argument.
-    NoArgument,
-    /// The argument could not be downcast to the specified type.
-    IncorrectType,
-}
 
 /// The target of a command.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -115,6 +112,8 @@ pub enum Target {
 /// [`Command`]: ../struct.Command.html
 pub mod sys {
     use super::Selector;
+    use crate::{FileDialogOptions, FileInfo, SingleUse};
+    use std::any::Any;
 
     /// Quit the running application. This command is handled by the druid library.
     pub const QUIT_APP: Selector = Selector::new("druid-builtin.quit-app");
@@ -126,7 +125,8 @@ pub mod sys {
     pub const HIDE_OTHERS: Selector = Selector::new("druid-builtin.menu-hide-others");
 
     /// The selector for a command to create a new window.
-    pub(crate) const NEW_WINDOW: Selector = Selector::new("druid-builtin.new-window");
+    pub(crate) const NEW_WINDOW: Selector<SingleUse<Box<dyn Any>>> =
+        Selector::new("druid-builtin.new-window");
 
     /// The selector for a command to close a window.
     ///
@@ -149,13 +149,14 @@ pub mod sys {
     /// object to be displayed.
     ///
     /// [`ContextMenu`]: ../struct.ContextMenu.html
-    pub(crate) const SHOW_CONTEXT_MENU: Selector = Selector::new("druid-builtin.show-context-menu");
+    pub(crate) const SHOW_CONTEXT_MENU: Selector<Box<dyn Any>> =
+        Selector::new("druid-builtin.show-context-menu");
 
     /// The selector for a command to set the window's menu. The argument should
     /// be a [`MenuDesc`] object.
     ///
     /// [`MenuDesc`]: ../struct.MenuDesc.html
-    pub(crate) const SET_MENU: Selector = Selector::new("druid-builtin.set-menu");
+    pub(crate) const SET_MENU: Selector<Box<dyn Any>> = Selector::new("druid-builtin.set-menu");
 
     /// Show the application preferences.
     pub const SHOW_PREFERENCES: Selector = Selector::new("druid-builtin.menu-show-preferences");
@@ -172,18 +173,15 @@ pub mod sys {
     /// System command. A file picker dialog will be shown to the user, and an
     /// [`OPEN_FILE`] command will be sent if a file is chosen.
     ///
-    /// The argument should be a [`FileDialogOptions`] struct.
-    ///
     /// [`OPEN_FILE`]: constant.OPEN_FILE.html
     /// [`FileDialogOptions`]: ../struct.FileDialogOptions.html
-    pub const SHOW_OPEN_PANEL: Selector = Selector::new("druid-builtin.menu-file-open");
+    pub const SHOW_OPEN_PANEL: Selector<FileDialogOptions> =
+        Selector::new("druid-builtin.menu-file-open");
 
-    /// Open a file.
-    ///
-    /// The argument must be a [`FileInfo`] object for the file to be opened.
+    /// Open a file, must be handled by the application.
     ///
     /// [`FileInfo`]: ../struct.FileInfo.html
-    pub const OPEN_FILE: Selector = Selector::new("druid-builtin.open-file-path");
+    pub const OPEN_FILE: Selector<FileInfo> = Selector::new("druid-builtin.open-file-path");
 
     /// Special command. When issued, the system will show the 'save as' panel,
     /// and if a path is selected the system will issue a [`SAVE_FILE`] command
@@ -193,12 +191,15 @@ pub mod sys {
     ///
     /// [`SAVE_FILE`]: constant.SAVE_FILE.html
     /// [`FileDialogOptions`]: ../struct.FileDialogOptions.html
-    pub const SHOW_SAVE_PANEL: Selector = Selector::new("druid-builtin.menu-file-save-as");
+    pub const SHOW_SAVE_PANEL: Selector<FileDialogOptions> =
+        Selector::new("druid-builtin.menu-file-save-as");
 
-    /// Save the current file.
+    /// Save the current file, must be handled by the application.
     ///
-    /// The argument, if present, should be the path where the file should be saved.
-    pub const SAVE_FILE: Selector = Selector::new("druid-builtin.menu-file-save");
+    /// How this should be handled depends on the payload:
+    /// `Some(handle)`: the app should save to that file and store the `handle` for future use.
+    /// `None`: the app should have received `Some` before and use the stored `FileInfo`.
+    pub const SAVE_FILE: Selector<Option<FileInfo>> = Selector::new("druid-builtin.menu-file-save");
 
     /// Show the print-setup window.
     pub const PRINT_SETUP: Selector = Selector::new("druid-builtin.menu-file-print-setup");
@@ -228,36 +229,92 @@ pub mod sys {
 impl Selector {
     /// A selector that does nothing.
     pub const NOOP: Selector = Selector::new("");
+}
 
+impl<T> Selector<T> {
     /// Create a new `Selector` with the given string.
-    pub const fn new(s: &'static str) -> Selector {
-        Selector(s)
+    pub const fn new(s: &'static str) -> Selector<T> {
+        Selector(s, PhantomData)
+    }
+
+    pub(crate) const fn symbol(&self) -> SelectorSymbol {
+        self.0
+    }
+}
+
+impl<T: Any> Selector<T> {
+    pub fn carry(self, object: T) -> Command {
+        Command::new(self, object)
     }
 }
 
 impl Command {
     /// Create a new `Command` with an argument. If you do not need
     /// an argument, `Selector` implements `Into<Command>`.
-    pub fn new(selector: Selector, arg: impl Any) -> Self {
+    pub fn new<T: Any>(selector: Selector<T>, object: T) -> Self {
         Command {
-            selector,
-            object: Some(Arc::new(arg)),
+            selector: selector.symbol(),
+            object: Arc::new(object),
         }
     }
 
     /// Used to create a command from the types sent via an `ExtEventSink`.
-    pub(crate) fn from_ext(selector: Selector, object: Option<Box<dyn Any + Send>>) -> Self {
-        let object: Option<Box<dyn Any>> = object.map(|obj| obj as Box<dyn Any>);
-        let object = object.map(|o| o.into());
+    pub(crate) fn from_ext(selector: SelectorSymbol, object: Arc<dyn Any>) -> Self {
         Command { selector, object }
     }
 
-    /// Return a reference to this `Command`'s object, if it has one.
-    pub fn get_object<T: Any>(&self) -> Result<&T, ArgumentError> {
-        match self.object.as_ref() {
-            Some(o) => o.downcast_ref().ok_or(ArgumentError::IncorrectType),
-            None => Err(ArgumentError::NoArgument),
+    /// Checks if this was created using `selector`.
+    pub fn is<T>(&self, selector: Selector<T>) -> bool {
+        self.selector == selector.symbol()
+    }
+
+    /// Returns `Some(reference)` to this `Command`'s object, if the selector matches.
+    ///
+    /// Returns `None` when `self.is(selector) == false`.
+    ///
+    /// If the selector has already been checked, [`get_unchecked`] can be used safely.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the payload has a different type, than what the selector is supposed to carry.
+    /// This can happen when two selectors with different types but the same key are used.
+    ///
+    /// [`get_unchecked`]: #method.get_unchecked
+    pub fn get<T: Any>(&self, selector: Selector<T>) -> Option<&T> {
+        if self.selector == selector.symbol() {
+            Some(self.object.downcast_ref().unwrap_or_else(|| {
+                panic!(
+                    "The selector \"{}\" exists twice with different types. See druid::Command::get_object for more information",
+                    selector.symbol()
+                )
+            }))
+        } else {
+            None
         }
+    }
+
+    /// Return a reference to this `Command`'s object.
+    ///
+    /// If the selector has already been checked, `get_unchecked` can be used safely.
+    /// Otherwise you should either use [`get`] instead, or check the selector using [`is`] first.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `self.is(selector) == false`.
+    ///
+    /// Panics when the payload has a different type, than what the selector is supposed to carry.
+    /// This can happen when two selectors with different types but the same key are used.
+    ///
+    /// [`is`]: #method.is
+    /// [`get`]: #method.get
+    pub fn get_unchecked<T: Any>(&self, selector: Selector<T>) -> &T {
+        self.get(selector).unwrap_or_else(|| {
+            panic!(
+                "Expected selector \"{}\" but the command was \"{}\".",
+                selector.symbol(),
+                self.selector
+            )
+        })
     }
 }
 
@@ -275,28 +332,26 @@ impl<T: Any> SingleUse<T> {
 impl From<Selector> for Command {
     fn from(selector: Selector) -> Command {
         Command {
-            selector,
-            object: None,
+            selector: selector.symbol(),
+            object: Arc::new(()),
         }
     }
 }
 
-impl std::fmt::Display for Selector {
+impl<T> std::fmt::Display for Selector<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Selector('{}')", self.0)
+        write!(f, "Selector(\"{}\", {})", self.0, any::type_name::<T>())
     }
 }
 
-impl std::fmt::Display for ArgumentError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            ArgumentError::NoArgument => write!(f, "Command has no argument"),
-            ArgumentError::IncorrectType => write!(f, "Downcast failed: wrong concrete type"),
-        }
+// This has do be done explicitly, to avoid the Copy bound on `T`.
+// See https://doc.rust-lang.org/std/marker/trait.Copy.html#how-can-i-implement-copy .
+impl<T> Copy for Selector<T> {}
+impl<T> Clone for Selector<T> {
+    fn clone(&self) -> Self {
+        *self
     }
 }
-
-impl std::error::Error for ArgumentError {}
 
 impl From<WindowId> for Target {
     fn from(id: WindowId) -> Target {
@@ -330,6 +385,6 @@ mod tests {
         let sel = Selector::new("my-selector");
         let objs = vec![0, 1, 2];
         let command = Command::new(sel, objs);
-        assert_eq!(command.get_object(), Ok(&vec![0, 1, 2]));
+        assert_eq!(command.get(sel), Some(&vec![0, 1, 2]));
     }
 }

--- a/druid/src/command.rs
+++ b/druid/src/command.rs
@@ -22,7 +22,7 @@ use std::{
 
 use crate::{WidgetId, WindowId};
 
-/// A [`Selector`]s identity.
+/// The identity of a [`Selector`].
 ///
 /// [`Selector`]: struct.Selector.html
 pub(crate) type SelectorSymbol = &'static str;
@@ -251,12 +251,13 @@ impl<T: Any> Selector<T> {
 }
 
 impl Command {
-    /// Create a new `Command` with payload.
+    /// Create a new `Command` with a payload.
     ///
     /// [`Selector::carry`] can be used to create `Command`s more conveniently.
     ///
-    /// If you do not need an payload, `Selector` implements `Into<Command>`.
+    /// If you do not need a payload, [`Selector`] implements `Into<Command>`.
     ///
+    /// [`Selector`]: struct.Selector.html
     /// [`Selector::carry`]: struct.Selector.html#method.carry
     pub fn new<T: Any>(selector: Selector<T>, payload: T) -> Self {
         Command {

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -250,7 +250,7 @@ impl EventCtx<'_, '_> {
     pub fn new_window<T: Any>(&mut self, desc: WindowDesc<T>) {
         if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::NEW_WINDOW, SingleUse::new(desc)),
+                Command::new(commands::NEW_WINDOW, SingleUse::new(Box::new(desc))),
                 Target::Global,
             );
         } else {
@@ -278,7 +278,7 @@ impl EventCtx<'_, '_> {
     pub fn show_context_menu<T: Any>(&mut self, menu: ContextMenu<T>) {
         if self.state.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::SHOW_CONTEXT_MENU, menu),
+                Command::new(commands::SHOW_CONTEXT_MENU, Box::new(menu)),
                 Target::Window(self.state.window_id),
             );
         } else {
@@ -883,7 +883,7 @@ impl<'a> ContextState<'a> {
     fn set_menu<T: Any>(&mut self, menu: MenuDesc<T>) {
         if self.root_app_data_type == TypeId::of::<T>() {
             self.submit_command(
-                Command::new(commands::SET_MENU, menu),
+                Command::new(commands::SET_MENU, Box::new(menu)),
                 Some(Target::Window(self.window_id)),
             );
         } else {

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -22,7 +22,7 @@ use crate::shell::IdleHandle;
 use crate::win_handler::EXT_EVENT_IDLE_TOKEN;
 use crate::{command::SelectorSymbol, Command, Selector, Target, WindowId};
 
-pub(crate) type ExtCommand = (SelectorSymbol, Arc<dyn Any + Send + Sync>, Option<Target>);
+pub(crate) type ExtCommand = (SelectorSymbol, Box<dyn Any + Send>, Option<Target>);
 
 /// A thing that can move into other threads and be used to submit commands back
 /// to the running application.
@@ -103,11 +103,11 @@ impl ExtEventSink {
     pub fn submit_command<T: Any + Send + Sync>(
         &self,
         selector: Selector<T>,
-        object: T,
+        object: impl Into<Box<T>>,
         target: impl Into<Option<Target>>,
     ) -> Result<(), ExtEventError> {
         let target = target.into();
-        let object = Arc::new(object);
+        let object = object.into();
         if let Some(handle) = self.handle.lock().unwrap().as_mut() {
             handle.schedule_idle(EXT_EVENT_IDLE_TOKEN);
         }

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -20,9 +20,9 @@ use std::sync::{Arc, Mutex};
 
 use crate::shell::IdleHandle;
 use crate::win_handler::EXT_EVENT_IDLE_TOKEN;
-use crate::{Command, Selector, Target, WindowId};
+use crate::{command::SelectorSymbol, Command, Selector, Target, WindowId};
 
-pub(crate) type ExtCommand = (Selector, Option<Box<dyn Any + Send>>, Option<Target>);
+pub(crate) type ExtCommand = (SelectorSymbol, Arc<dyn Any + Send + Sync>, Option<Target>);
 
 /// A thing that can move into other threads and be used to submit commands back
 /// to the running application.
@@ -90,8 +90,7 @@ impl ExtEventSink {
     /// instead you have to pass the [`Selector`] and the (optional) argument
     /// separately, and it will be turned into a `Command` when it is received.
     ///
-    /// The `obj` argument can be any type which implements `Any + Send`, or `None`
-    /// if this command has no argument.
+    /// The `object` argument must implement `Any + Send + Sync`.
     ///
     /// If no explicit `Target` is submitted, the `Command` will be sent to
     /// the application's first window; if that window is subsequently closed,
@@ -101,21 +100,22 @@ impl ExtEventSink {
     ///
     /// [`Command`]: struct.Command.html
     /// [`Selector`]: struct.Selector.html
-    pub fn submit_command<T: Any + Send>(
+    pub fn submit_command<T: Any + Send + Sync>(
         &self,
-        sel: Selector,
-        obj: impl Into<Option<T>>,
+        selector: Selector<T>,
+        object: T,
         target: impl Into<Option<Target>>,
     ) -> Result<(), ExtEventError> {
         let target = target.into();
-        let obj = obj.into().map(|o| Box::new(o) as Box<dyn Any + Send>);
+        let object = Arc::new(object);
         if let Some(handle) = self.handle.lock().unwrap().as_mut() {
             handle.schedule_idle(EXT_EVENT_IDLE_TOKEN);
         }
-        self.queue
-            .lock()
-            .map_err(|_| ExtEventError)?
-            .push_back((sel, obj, target));
+        self.queue.lock().map_err(|_| ExtEventError)?.push_back((
+            selector.symbol(),
+            object,
+            target,
+        ));
         Ok(())
     }
 }

--- a/druid/src/ext_event.rs
+++ b/druid/src/ext_event.rs
@@ -87,10 +87,10 @@ impl ExtEventSink {
     /// Submit a [`Command`] to the running application.
     ///
     /// [`Command`] is not thread safe, so you cannot submit it directly;
-    /// instead you have to pass the [`Selector`] and the (optional) argument
+    /// instead you have to pass the [`Selector`] and the payload
     /// separately, and it will be turned into a `Command` when it is received.
     ///
-    /// The `object` argument must implement `Any + Send + Sync`.
+    /// The `payload` must implement `Any + Send + Sync`.
     ///
     /// If no explicit `Target` is submitted, the `Command` will be sent to
     /// the application's first window; if that window is subsequently closed,
@@ -103,17 +103,17 @@ impl ExtEventSink {
     pub fn submit_command<T: Any + Send + Sync>(
         &self,
         selector: Selector<T>,
-        object: impl Into<Box<T>>,
+        payload: impl Into<Box<T>>,
         target: impl Into<Option<Target>>,
     ) -> Result<(), ExtEventError> {
         let target = target.into();
-        let object = object.into();
+        let payload = payload.into();
         if let Some(handle) = self.handle.lock().unwrap().as_mut() {
             handle.schedule_idle(EXT_EVENT_IDLE_TOKEN);
         }
         self.queue.lock().map_err(|_| ExtEventError)?.push_back((
             selector.symbol(),
-            object,
+            payload,
             target,
         ));
         Ok(())

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -542,7 +542,7 @@ pub mod sys {
             pub fn open<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-open"),
-                    commands::SHOW_OPEN_PANEL.carry(FileDialogOptions::default()),
+                    commands::SHOW_OPEN_PANEL.with(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Ctrl, "o")
             }
@@ -559,7 +559,7 @@ pub mod sys {
             pub fn save<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save"),
-                    commands::SAVE_FILE.carry(None),
+                    commands::SAVE_FILE.with(None),
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }
@@ -570,7 +570,7 @@ pub mod sys {
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),
-                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
+                    commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }
@@ -579,7 +579,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
+                    commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::CtrlShift, "s")
             }
@@ -746,7 +746,7 @@ pub mod sys {
             pub fn open_file<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-open"),
-                    commands::SHOW_OPEN_PANEL.carry(FileDialogOptions::default()),
+                    commands::SHOW_OPEN_PANEL.with(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Meta, "o")
             }
@@ -764,7 +764,7 @@ pub mod sys {
             pub fn save<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save"),
-                    commands::SAVE_FILE.carry(None),
+                    commands::SAVE_FILE.with(None),
                 )
                 .hotkey(RawMods::Meta, "s")
             }
@@ -775,7 +775,7 @@ pub mod sys {
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),
-                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
+                    commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Meta, "s")
             }
@@ -784,7 +784,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
+                    commands::SHOW_SAVE_PANEL.with(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::MetaShift, "s")
             }

--- a/druid/src/menu.rs
+++ b/druid/src/menu.rs
@@ -268,7 +268,7 @@ impl<T: Data> MenuDesc<T> {
     /// use druid::{Command, LocalizedString, MenuDesc, MenuItem, Selector};
     ///
     /// let num_items: usize = 4;
-    /// const MENU_COUNT_ACTION: Selector = Selector::new("menu-count-action");
+    /// const MENU_COUNT_ACTION: Selector<usize> = Selector::new("menu-count-action");
     ///
     /// let my_menu: MenuDesc<u32> = MenuDesc::empty()
     ///     .append_iter(|| (0..num_items).map(|i| {
@@ -508,6 +508,7 @@ pub mod sys {
         /// [the win32 documentation]: https://docs.microsoft.com/en-us/windows/win32/uxguide/cmd-menus#standard-menus
         pub mod file {
             use super::*;
+            use crate::FileDialogOptions;
 
             /// A default file menu.
             ///
@@ -541,7 +542,7 @@ pub mod sys {
             pub fn open<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-open"),
-                    commands::SHOW_OPEN_PANEL,
+                    commands::SHOW_OPEN_PANEL.carry(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Ctrl, "o")
             }
@@ -558,7 +559,7 @@ pub mod sys {
             pub fn save<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save"),
-                    commands::SAVE_FILE,
+                    commands::SAVE_FILE.carry(None),
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }
@@ -569,7 +570,7 @@ pub mod sys {
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),
-                    commands::SHOW_SAVE_PANEL,
+                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Ctrl, "s")
             }
@@ -578,7 +579,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    commands::SHOW_SAVE_PANEL,
+                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::CtrlShift, "s")
             }
@@ -705,6 +706,7 @@ pub mod sys {
         /// The file menu.
         pub mod file {
             use super::*;
+            use crate::FileDialogOptions;
 
             /// A default file menu.
             ///
@@ -744,7 +746,7 @@ pub mod sys {
             pub fn open_file<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-open"),
-                    commands::SHOW_OPEN_PANEL,
+                    commands::SHOW_OPEN_PANEL.carry(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Meta, "o")
             }
@@ -762,7 +764,7 @@ pub mod sys {
             pub fn save<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save"),
-                    commands::SAVE_FILE,
+                    commands::SAVE_FILE.carry(None),
                 )
                 .hotkey(RawMods::Meta, "s")
             }
@@ -773,7 +775,7 @@ pub mod sys {
             pub fn save_ellipsis<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-ellipsis"),
-                    commands::SHOW_SAVE_PANEL,
+                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::Meta, "s")
             }
@@ -782,7 +784,7 @@ pub mod sys {
             pub fn save_as<T: Data>() -> MenuItem<T> {
                 MenuItem::new(
                     LocalizedString::new("common-menu-file-save-as"),
-                    commands::SHOW_SAVE_PANEL,
+                    commands::SHOW_SAVE_PANEL.carry(FileDialogOptions::default()),
                 )
                 .hotkey(RawMods::MetaShift, "s")
             }

--- a/druid/src/tests/helpers.rs
+++ b/druid/src/tests/helpers.rs
@@ -214,7 +214,7 @@ impl<T: Data> ReplaceChild<T> {
 impl<T: Data> Widget<T> for ReplaceChild<T> {
     fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
         if let Event::Command(cmd) = event {
-            if cmd.selector == REPLACE_CHILD {
+            if cmd.is(REPLACE_CHILD) {
                 self.inner = WidgetPod::new((self.replacer)());
                 ctx.children_changed();
                 return;

--- a/druid/src/tests/mod.rs
+++ b/druid/src/tests/mod.rs
@@ -158,7 +158,7 @@ fn take_focus() {
         ModularWidget::new(inner)
             .event_fn(|_, ctx, event, _data, _env| {
                 if let Event::Command(cmd) = event {
-                    if cmd.selector == TAKE_FOCUS {
+                    if cmd.is(TAKE_FOCUS) {
                         ctx.request_focus();
                     }
                 }
@@ -225,12 +225,12 @@ fn focus_changed() {
         ModularWidget::new(children)
             .event_fn(|children, ctx, event, data, env| {
                 if let Event::Command(cmd) = event {
-                    if cmd.selector == TAKE_FOCUS {
+                    if cmd.is(TAKE_FOCUS) {
                         ctx.request_focus();
                         // Stop propagating this command so children
                         // aren't requesting focus too.
                         ctx.set_handled();
-                    } else if cmd.selector == ALL_TAKE_FOCUS_BEFORE {
+                    } else if cmd.is(ALL_TAKE_FOCUS_BEFORE) {
                         ctx.request_focus();
                     }
                 }
@@ -238,7 +238,7 @@ fn focus_changed() {
                     .iter_mut()
                     .for_each(|a| a.event(ctx, event, data, env));
                 if let Event::Command(cmd) = event {
-                    if cmd.selector == ALL_TAKE_FOCUS_AFTER {
+                    if cmd.is(ALL_TAKE_FOCUS_AFTER) {
                         ctx.request_focus();
                     }
                 }

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -53,7 +53,8 @@ pub struct TextBox {
 
 impl TextBox {
     /// Perform an `EditAction`. The payload *must* be an `EditAction`.
-    pub const PERFORM_EDIT: Selector = Selector::new("druid-builtin.textbox.perform-edit");
+    pub const PERFORM_EDIT: Selector<EditAction> =
+        Selector::new("druid-builtin.textbox.perform-edit");
 
     /// Create a new TextBox widget
     pub fn new() -> TextBox {
@@ -281,22 +282,19 @@ impl Widget<String> for TextBox {
             }
             Event::Command(ref cmd)
                 if ctx.is_focused()
-                    && (cmd.selector == crate::commands::COPY
-                        || cmd.selector == crate::commands::CUT) =>
+                    && (cmd.is(crate::commands::COPY) || cmd.is(crate::commands::CUT)) =>
             {
                 if let Some(text) = data.slice(self.selection.range()) {
                     Application::global().clipboard().put_string(text);
                 }
-                if !self.selection.is_caret() && cmd.selector == crate::commands::CUT {
+                if !self.selection.is_caret() && cmd.is(crate::commands::CUT) {
                     edit_action = Some(EditAction::Delete);
                 }
                 ctx.set_handled();
             }
-            Event::Command(cmd) if cmd.selector == RESET_BLINK => self.reset_cursor_blink(ctx),
-            Event::Command(cmd) if cmd.selector == TextBox::PERFORM_EDIT => {
-                let edit = cmd
-                    .get_object::<EditAction>()
-                    .expect("PERFORM_EDIT contained non-edit payload");
+            Event::Command(cmd) if cmd.is(RESET_BLINK) => self.reset_cursor_blink(ctx),
+            Event::Command(cmd) if cmd.is(TextBox::PERFORM_EDIT) => {
+                let edit = cmd.get_unchecked(TextBox::PERFORM_EDIT);
                 self.do_edit_action(edit.to_owned(), data);
             }
             Event::Paste(ref item) => {


### PR DESCRIPTION
The (hopefully) final part of #908 .

This time it just refactors `Selector` and `Command`.