### PR TITLE
Fix macOS main menu not working before refocus.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Wheel events now properly update hot state. ([#951] by [@xStrom])
 - X11: Support mouse scrolling. ([#961] by [@jneem])
 - `Painter` now properly repaints on data change in `Container`. ([#991] by [@cmyr])
+- macOS: The application menu is now immediately interactable after launch. ([#994] by [@xStrom])
 
 ### Visual
 
@@ -247,6 +248,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#990]: https://github.com/xi-editor/druid/pull/990
 [#991]: https://github.com/xi-editor/druid/pull/991
 [#993]: https://github.com/xi-editor/druid/pull/993
+[#994]: https://github.com/xi-editor/druid/pull/994
 [#996]: https://github.com/xi-editor/druid/pull/996
 
 ## [0.5.0] - 2020-04-01

--- a/druid-shell/src/platform/mac/application.rs
+++ b/druid-shell/src/platform/mac/application.rs
@@ -172,6 +172,8 @@ lazy_static! {
 extern "C" fn application_did_finish_launching(_this: &mut Object, _: Sel, _notification: id) {
     unsafe {
         let ns_app = NSApp();
+        // We need to delay setting the activation policy and activating the app
+        // until we have the main menu all set up. Otherwise the menu won't be interactable.
         ns_app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
         let () = msg_send![ns_app, activateIgnoringOtherApps: YES];
     }

--- a/druid-shell/src/platform/mac/application.rs
+++ b/druid-shell/src/platform/mac/application.rs
@@ -53,10 +53,7 @@ impl Application {
         util::assert_main_thread();
         unsafe {
             let _pool = NSAutoreleasePool::new(nil);
-
             let ns_app = NSApp();
-            ns_app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
-
             let state = Rc::new(RefCell::new(State { quitting: false }));
 
             Ok(Application { ns_app, state })
@@ -174,7 +171,9 @@ lazy_static! {
 
 extern "C" fn application_did_finish_launching(_this: &mut Object, _: Sel, _notification: id) {
     unsafe {
-        let () = msg_send![NSApp(), activateIgnoringOtherApps: YES];
+        let ns_app = NSApp();
+        ns_app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
+        let () = msg_send![ns_app, activateIgnoringOtherApps: YES];
     }
 }
 


### PR DESCRIPTION
This PR fixes the issue on macOS where the application menu can't be interacted with until the window loses and regains focus.

There are some pretty wild workarounds [out there](https://ar.al/2018/09/17/workaround-for-unclickable-app-menu-bug-with-window.makekeyandorderfront-and-nsapp.activate-on-macos/) for this, like setting a timer to automatically refocus the window. However as shown in this PR it can be done in an easier fashion. From the surface it seems to be mostly about not letting the app activate before the menu is all set up.

Fixes #753.