### PR TITLE
Standardize Text type in Contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - Replaced `Command::one_shot` and `::take_object` with a `SingleUse` payload wrapper type. ([#959] by [@finnerale])
 - Renamed `WidgetPod` methods: `paint` to `paint_raw`, `paint_with_offset` to `paint`, `paint_with_offset_always` to `paint_always`. ([#980] by [@totsteps])
 - `Command` and `Selector` have been reworked and are now statically typed, similarly to `Env` and `Key`. ([#993] by [@finnerale])
+- Standardize the type returned by the contexts' `text()` methods. ([#996] by
+  [@cmyr])
 
 ### Deprecated
 
@@ -244,6 +246,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#990]: https://github.com/xi-editor/druid/pull/990
 [#991]: https://github.com/xi-editor/druid/pull/991
 [#993]: https://github.com/xi-editor/druid/pull/993
+[#996]: https://github.com/xi-editor/druid/pull/996
 
 ## [0.5.0] - 2020-04-01
 

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -85,10 +85,9 @@ pub struct UpdateCtx<'a, 'b> {
 /// As of now, the main service provided is access to a factory for
 /// creating text layout objects, which are likely to be useful
 /// during widget layout.
-pub struct LayoutCtx<'a, 'b, 'c: 'a> {
+pub struct LayoutCtx<'a, 'b> {
     pub(crate) state: &'a mut ContextState<'b>,
     pub(crate) widget_state: &'a mut WidgetState,
-    pub(crate) text_factory: &'a mut Text<'c>,
     pub(crate) mouse_pos: Option<Point>,
 }
 
@@ -685,10 +684,10 @@ impl<'a, 'b> UpdateCtx<'a, 'b> {
     }
 }
 
-impl<'c> LayoutCtx<'_, '_, 'c> {
+impl LayoutCtx<'_, '_> {
     /// Get an object which can create text layouts.
-    pub fn text(&mut self) -> &mut Text<'c> {
-        &mut self.text_factory
+    pub fn text(&mut self) -> Text {
+        self.state.window.text()
     }
 
     /// Get the window id.
@@ -716,6 +715,11 @@ impl PaintCtx<'_, '_, '_> {
     /// get the `WidgetId` of the current widget.
     pub fn widget_id(&self) -> WidgetId {
         self.widget_state.id
+    }
+
+    /// Get an object which can create text layouts.
+    pub fn text(&mut self) -> Text {
+        self.state.window.text()
     }
 
     /// Query the "hot" state of the widget.

--- a/druid/src/core.rs
+++ b/druid/src/core.rs
@@ -497,7 +497,6 @@ impl<T: Data, W: Widget<T>> WidgetPod<T, W> {
         let mut child_ctx = LayoutCtx {
             widget_state: &mut self.state,
             state: ctx.state,
-            text_factory: ctx.text_factory,
             mouse_pos: child_mouse_pos,
         };
         let size = self.inner.layout(&mut child_ctx, bc, data, env);

--- a/druid/src/tests/harness.rs
+++ b/druid/src/tests/harness.rs
@@ -259,7 +259,7 @@ impl<T: Data> Harness<'_, T> {
 
     /// Only do a layout pass, without painting
     pub fn just_layout(&mut self) {
-        self.inner.layout(&mut self.piet)
+        self.inner.layout()
     }
 
     pub fn paint_rect(&mut self, invalid_rect: Rect) {
@@ -287,9 +287,9 @@ impl<T: Data> Inner<T> {
         self.window.update(&mut self.cmds, &self.data, &self.env);
     }
 
-    fn layout(&mut self, piet: &mut Piet) {
+    fn layout(&mut self) {
         self.window
-            .just_layout(piet, &mut self.cmds, &self.data, &self.env);
+            .just_layout(&mut self.cmds, &self.data, &self.env);
     }
 
     #[allow(dead_code)]

--- a/druid/src/widget/label.rs
+++ b/druid/src/widget/label.rs
@@ -265,17 +265,11 @@ impl<T: Data> Widget<T> for Label<T> {
         }
     }
 
-    fn layout(
-        &mut self,
-        layout_ctx: &mut LayoutCtx,
-        bc: &BoxConstraints,
-        _data: &T,
-        env: &Env,
-    ) -> Size {
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, _data: &T, env: &Env) -> Size {
         bc.debug_check("Label");
 
         let font_size = self.size.resolve(env);
-        let text_layout = self.get_layout(layout_ctx.text(), env);
+        let text_layout = self.get_layout(&mut ctx.text(), env);
         bc.constrain(Size::new(
             text_layout.width() + 2. * LABEL_X_PADDING,
             font_size * LINE_HEIGHT_FACTOR,
@@ -284,7 +278,7 @@ impl<T: Data> Widget<T> for Label<T> {
 
     fn paint(&mut self, ctx: &mut PaintCtx, _data: &T, env: &Env) {
         let font_size = self.size.resolve(env);
-        let text_layout = self.get_layout(ctx.text(), env);
+        let text_layout = self.get_layout(&mut ctx.text(), env);
         let line_height = font_size * LINE_HEIGHT_FACTOR;
 
         // Find the origin for the text

--- a/druid/src/widget/textbox.rs
+++ b/druid/src/widget/textbox.rs
@@ -417,7 +417,7 @@ impl Widget<String> for TextBox {
             rc.clip(clip_rect);
 
             // Calculate layout
-            let text_layout = self.get_layout(rc.text(), &content, env);
+            let text_layout = self.get_layout(&mut rc.text(), &content, env);
 
             // Shift everything inside the clip by the hscroll_offset
             rc.transform(Affine::translate((-self.hscroll_offset, 0.)));

--- a/druid/src/window.rs
+++ b/druid/src/window.rs
@@ -313,7 +313,7 @@ impl<T: Data> Window<T> {
         self.lifecycle(queue, &LifeCycle::AnimFrame(0), data, env, true);
 
         if self.root.state().needs_layout {
-            self.layout(piet, queue, data, env);
+            self.layout(queue, data, env);
         }
 
         piet.fill(
@@ -323,13 +323,12 @@ impl<T: Data> Window<T> {
         self.paint(piet, invalid_rect, queue, data, env);
     }
 
-    fn layout(&mut self, piet: &mut Piet, queue: &mut CommandQueue, data: &T, env: &Env) {
+    fn layout(&mut self, queue: &mut CommandQueue, data: &T, env: &Env) {
         let mut widget_state = WidgetState::new(self.root.id());
         let mut state = ContextState::new::<T>(queue, &self.handle, self.id, self.focus);
         let mut layout_ctx = LayoutCtx {
             state: &mut state,
             widget_state: &mut widget_state,
-            text_factory: piet.text(),
             mouse_pos: self.last_mouse_pos,
         };
         let bc = BoxConstraints::tight(self.size);
@@ -346,14 +345,8 @@ impl<T: Data> Window<T> {
     /// only expose `layout` for testing; normally it is called as part of `do_paint`
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(test)]
-    pub(crate) fn just_layout(
-        &mut self,
-        piet: &mut Piet,
-        queue: &mut CommandQueue,
-        data: &T,
-        env: &Env,
-    ) {
-        self.layout(piet, queue, data, env)
+    pub(crate) fn just_layout(&mut self, queue: &mut CommandQueue, data: &T, env: &Env) {
+        self.layout(queue, data, env)
     }
 
     fn paint(


### PR DESCRIPTION
A long standing pet-peeve of mine: Previously there were a
number of different lifetypes associated with the text factory
depending on where it came from.

This standardizes that, so that all contexts' text() method returns
an owned PietText handle.

This has the added advantage of getting rid of the weird lifetime
in LayoutContext, which will also unblock my macro work.

This is a breaking change in a fairly minor way; `LayoutCtx` returns `Text` now instead of `&mut Text`.