### PR TITLE
Fix mouse events interaction with ALT/F10 on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 - X11: Support mouse scrolling. ([#961] by [@jneem])
 - `Painter` now properly repaints on data change in `Container`. ([#991] by [@cmyr])
 - macOS: The application menu is now immediately interactable after launch. ([#994] by [@xStrom])
+- Windows: Keep receiving mouse events after pressing ALT or F10 when the window has no menu. ([#997] by [@xStrom])
 
 ### Visual
 
@@ -251,6 +252,7 @@ This means that druid no longer requires cairo on macOS and uses Core Graphics i
 [#993]: https://github.com/xi-editor/druid/pull/993
 [#994]: https://github.com/xi-editor/druid/pull/994
 [#996]: https://github.com/xi-editor/druid/pull/996
+[#997]: https://github.com/xi-editor/druid/pull/997
 [#1001]: https://github.com/xi-editor/druid/pull/1001
 
 ## [0.5.0] - 2020-04-01


### PR DESCRIPTION
This issue was reported by @Azorlogh in zulip.

![KeyWeeArcticduck-small](https://user-images.githubusercontent.com/754881/83327506-23037280-a285-11ea-810d-4d544cb5b6f8.gif)

When pressing (just once, not holding) the ALT key or F10 key, the window stops receiving mouse events. This can be reproduced with e.g. the `timer` example.

The reason is that ALT/F10 are system hotkeys that focus the menu. However when there is no menu these hotkeys aren't useful. This PR fixes the issue by suppressing the system handling of these keys when the window has no menu.

I've made a table to help test the changes in this PR.

. | The `multiwin` example | The `timer` example
--- | --- | ---
`master` | Pressing ALT focuses the menu and hovering over the buttons doesn't change their appearance. | Pressing ALT stops mouse events so the box won't turn red due to mouse movement.
This PR | Pressing ALT focuses the menu and hovering over the buttons doesn't change their appearance. | Pressing ALT does nothing.