### PR TITLE
Increase versions in preparation for 0.6.0.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,16 @@ then there might be a chance to help out with the preparation of new releases.
 Whether you're new or have prepared druid releases many times already,
 it helps to follow a checklist of what needs to be done. This is that list.
 
+### Increasing the versions
+
+The `druid`, `druid-shell`, and `druid-derive` `Cargo.toml` files need to be updated.
+The `version` field needs to be increased to the next [semver] version that makes sense.
+These packages all also import eachother and those cross-dependency versions need updating too.
+
+You should also search for the previous version number across the whole workspace
+to find any other references that might need updating. There are for example plenty of links
+to specific version documentation that will need updating.
+
 ### Changelog
 
 - Add a new *Unreleased* section by copying the current one.

--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ a lone dependency (it re-exports all the parts of druid-shell, piet, and kurbo
 that you'll need):
 
 ```toml
-druid = "0.5.0"
+druid = "0.6.0"
 ```
 
 Since druid is currently in fast-evolving state, you might prefer to drink from
 the firehose:
 
 ```toml
-druid = { git = "https://github.com/xi-editor/druid.git", version = "0.5" }
+druid = { git = "https://github.com/xi-editor/druid.git" }
 ```
 
 ### Platform notes
@@ -283,12 +283,12 @@ active and friendly community.
 [Zulip chat instance]: https://xi.zulipchat.com
 [non-druid examples]: ./druid-shell/examples/shello.rs
 [crates.io]: https://crates.io/crates/druid
-[EventCtx]: https://docs.rs/druid/0.5.0/druid/struct.EventCtx.html
-[LifeCycleCtx]: https://docs.rs/druid/0.5.0/druid/struct.EventCtx.html
-[LayoutCtx]: https://docs.rs/druid/0.5.0/druid/struct.LayoutCtx.html
-[PaintCtx]: https://docs.rs/druid/0.5.0/druid/struct.PaintCtx.html
-[UpdateCtx]: https://docs.rs/druid/0.5.0/druid/struct.UpdateCtx.html
-[Widget trait]: https://docs.rs/druid/0.5.0/druid/trait.Widget.html
-[Data trait]: https://docs.rs/druid/0.5.0/druid/trait.Data.html
-[Lens datatype]: https://docs.rs/druid/0.5.0/druid/trait.Lens.html
+[EventCtx]: https://docs.rs/druid/0.6.0/druid/struct.EventCtx.html
+[LifeCycleCtx]: https://docs.rs/druid/0.6.0/druid/struct.EventCtx.html
+[LayoutCtx]: https://docs.rs/druid/0.6.0/druid/struct.LayoutCtx.html
+[PaintCtx]: https://docs.rs/druid/0.6.0/druid/struct.PaintCtx.html
+[UpdateCtx]: https://docs.rs/druid/0.6.0/druid/struct.UpdateCtx.html
+[Widget trait]: https://docs.rs/druid/0.6.0/druid/trait.Widget.html
+[Data trait]: https://docs.rs/druid/0.6.0/druid/trait.Data.html
+[Lens datatype]: https://docs.rs/druid/0.6.0/druid/trait.Lens.html
 [druid book]: https://xi-editor.io/druid/intro.html

--- a/docs/src/custom_widgets.md
+++ b/docs/src/custom_widgets.md
@@ -80,10 +80,10 @@ v controller, painter
 - request paint & request layout
 - changing widgets at runtime
 
-[`Controller`]: https://docs.rs/druid/0.5.0/druid/widget/trait.Controller.html
+[`Controller`]: https://docs.rs/druid/0.6.0/druid/widget/trait.Controller.html
 [`Widget`]: ./widget.md
-[`Painter`]: https://docs.rs/druid/0.5.0/druid/widget/struct.Painter.html
-[`SizedBox`]: https://docs.rs/druid/0.5.0/druid/widget/struct.SizedBox.html
-[`Container`]: https://docs.rs/druid/0.5.0/druid/widget/struct.Container.html
-[`WidgetExt`]: https://docs.rs/druid/0.5.0/druid/trait.WidgetExt.html
-[`background`]: https://docs.rs/druid/0.5.0/druid/trait.WidgetExt.html#background
+[`Painter`]: https://docs.rs/druid/0.6.0/druid/widget/struct.Painter.html
+[`SizedBox`]: https://docs.rs/druid/0.6.0/druid/widget/struct.SizedBox.html
+[`Container`]: https://docs.rs/druid/0.6.0/druid/widget/struct.Container.html
+[`WidgetExt`]: https://docs.rs/druid/0.6.0/druid/trait.WidgetExt.html
+[`background`]: https://docs.rs/druid/0.6.0/druid/trait.WidgetExt.html#background

--- a/docs/src/env.md
+++ b/docs/src/env.md
@@ -84,15 +84,15 @@ In general, you should not need to worry about localization directly. See the
 [localization] chapter for an overview of localization in druid.
 
 
-[`Env`]: https://docs.rs/druid/0.5.0/druid/struct.Env.html
-[`Key`]: https://docs.rs/druid/0.5.0/druid/struct.Key.html
-[`Value`]: https://docs.rs/druid/0.5.0/druid/struct.Value.html
-[`LocalizedString`]: https://docs.rs/druid/0.5.0/druid/struct.LocalizedString.html
-[`resolve`]: https://docs.rs/druid/0.5.0/druid/struct.LocalizedString.html#method.resolve
+[`Env`]: https://docs.rs/druid/0.6.0/druid/struct.Env.html
+[`Key`]: https://docs.rs/druid/0.6.0/druid/struct.Key.html
+[`Value`]: https://docs.rs/druid/0.6.0/druid/struct.Value.html
+[`LocalizedString`]: https://docs.rs/druid/0.6.0/druid/struct.LocalizedString.html
+[`resolve`]: https://docs.rs/druid/0.6.0/druid/struct.LocalizedString.html#method.resolve
 [localization]: ./localization.md
 [reverse-DNS]: https://en.wikipedia.org/wiki/Reverse_domain_name_notation
-[`AppLauncher::configure_env`]: https://docs.rs/druid/0.5.0/druid/struct.AppLauncher.html#method.configure_env
-[`KeyOrValue`]: https://docs.rs/druid/0.5.0/druid/enum.KeyOrValue.html
-[`EnvScope`]: https://docs.rs/druid/0.5.0/druid/widget/struct.EnvScope.html
-[`WidgetExt`]: https://docs.rs/druid/0.5.0/druid/trait.WidgetExt.html
-[`env_scope`]: https://docs.rs/druid/0.5.0/druid/trait.WidgetExt.html#method.env_scope
+[`AppLauncher::configure_env`]: https://docs.rs/druid/0.6.0/druid/struct.AppLauncher.html#method.configure_env
+[`KeyOrValue`]: https://docs.rs/druid/0.6.0/druid/enum.KeyOrValue.html
+[`EnvScope`]: https://docs.rs/druid/0.6.0/druid/widget/struct.EnvScope.html
+[`WidgetExt`]: https://docs.rs/druid/0.6.0/druid/trait.WidgetExt.html
+[`env_scope`]: https://docs.rs/druid/0.6.0/druid/trait.WidgetExt.html#method.env_scope

--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -13,7 +13,7 @@ Setting up a project is a simple as creating a new Rust project;
 And then adding druid as a dependency to Cargo.toml
 ```toml
 [dependencies]
-druid = "0.5.0"
+druid = "0.6.0"
 ```
 
 To show a minimal window with a label replace `main.rs` with this;

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -32,9 +32,9 @@ cargo new my-application
 and adding the druid dependency to your Cargo.toml
 ```no_compile
 [dependencies]
-druid = "0.5.0"
-// or:
-druid = { git = "https://github.com/xi-editor/druid.git", branch = "master" }
+druid = "0.6.0"
+// or to be on the bleeding edge:
+druid = { git = "https://github.com/xi-editor/druid.git" }
 ```
 
 [gtk-rs dependencies]: http://gtk-rs.org/docs/requirements.html

--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "druid-derive"
-version = "0.4.0"
+version = "0.3.1"
 license = "Apache-2.0"
 authors = ["Druid authors"]
 description = "derive impls for druid, a Rust UI toolkit."
@@ -11,7 +11,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = "1.0.25"
+syn = "1.0.29"
 quote = "1.0.6"
 proc-macro2 = "1.0.17"
 

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -68,11 +68,11 @@ gtk-sys = "0.9.2"
 gtk = { version = "0.8.1", features = ["v3_20"] }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-wasm-bindgen = "0.2.62"
-js-sys = "0.3.39"
+wasm-bindgen = "0.2.63"
+js-sys = "0.3.40"
 
 [target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
-version = "0.3.39"
+version = "0.3.40"
 features = ["Window", "MouseEvent", "CssStyleDeclaration", "WheelEvent", "KeyEvent", "KeyboardEvent"]
 
 [dev-dependencies]

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -24,7 +24,7 @@ svg = ["usvg"]
 
 [dependencies]
 druid-shell = { version = "0.6.0", path = "../druid-shell" }
-druid-derive = { version = "0.4.0", path = "../druid-derive" }
+druid-derive = { version = "0.3.1", path = "../druid-derive" }
 
 log = "0.4.8"
 simple_logger = { version = "1.6.0", default-features = false }

--- a/druid/examples/hello_wasm_web/Cargo.toml
+++ b/druid/examples/hello_wasm_web/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-druid = { path="../.."}
-wasm-bindgen = "0.2.60"
-console_error_panic_hook = { version = "0.1.6" }
+druid = { path="../.." }
+wasm-bindgen = "0.2.63"
+console_error_panic_hook = "0.1.6"

--- a/druid/examples/wasm/Cargo.toml
+++ b/druid/examples/wasm/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 druid = { path="../.." }
-wasm-bindgen = "0.2.62"
+wasm-bindgen = "0.2.63"
 console_error_panic_hook = "0.1.6"
 log = "0.4.8"
 instant = { version = "0.1.4", features = ["wasm-bindgen"] }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -98,7 +98,7 @@
 //! [`Event`]: enum.Event.html
 //! [`druid-shell`]: https://docs.rs/druid-shell
 //! [`piet`]: https://docs.rs/piet
-//! [`druid/examples`]: https://github.com/xi-editor/druid/tree/v0.5.0/druid/examples
+//! [`druid/examples`]: https://github.com/xi-editor/druid/tree/v0.6.0/druid/examples
 //! [druid book]: https://xi-editor.io/druid/intro.html
 
 #![deny(intra_doc_link_resolution_failure, unsafe_code)]


### PR DESCRIPTION
This PR takes another step towards being ready to publish `0.6.0`.

- The `druid` and `druid-shell` versions were already bumped to `0.6.0`.
- The `druid-derive` version was also already bumped but needlessly far to `0.4.0`. There haven't been any changes or additions since `0.3.0`. Just a few test updates and minor version bumps of dependencies. Thus `0.3.1` is the more logical step according to semver.
- Documentation links/references were updated to `0.6.0`.
- I added a short section to `CONTRIBUTING.md` describing what I did so that the process is more accessible.

- I simplified the two git imports we mention in our documentation.
    * One also specified the version, but according to [The Cargo Book](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations) `version` is ignored when using `git`. It's there so that when you publish your package, that specified version is used instead of the git address.
    * One also specified the branch, but according to [The Cargo Book](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) cargo will default to `master` anyway, so that is also just noise for beginners.

---

Going forward, I also think we shouldn't bump version numbers until we're close to releasing. As the `druid-derive` `0.4.0` vs `0.3.1` situation shows we can't predict how many changes will be there. Also we might want to do a quick minor release with some bug fixes shortly after a major release, and that would also clash with an immediate major release bump that we've done way ahead of time.