### PR TITLE
Fix nightly feature docs.

### DIFF
--- a/druid-derive/Cargo.toml
+++ b/druid-derive/Cargo.toml
@@ -10,6 +10,10 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+default-target = "x86_64-pc-windows-msvc"
+
 [dependencies]
 syn = "1.0.29"
 quote = "1.0.6"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -9,11 +9,12 @@ readme = "README.md"
 categories = ["os::macos-apis", "os::windows-apis", "gui"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+default-target = "x86_64-pc-windows-msvc"
+
 [features]
 x11 = ["xcb", "cairo-sys-rs"]
-
-[package.metadata.docs.rs]
-default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 # Once cargo doc becomes smart enough to handle multiple versions of the same crate,
 # the "svg" and "image" features should be enabled for the docs.rs output.
 features = ["im"]
+rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]

--- a/druid/src/widget/mod.rs
+++ b/druid/src/widget/mod.rs
@@ -76,7 +76,6 @@ pub use spinner::Spinner;
 pub use split::Split;
 pub use stepper::Stepper;
 #[cfg(feature = "svg")]
-#[cfg_attr(docsrs, doc(cfg(feature = "svg")))]
 pub use svg::{Svg, SvgData};
 pub use switch::Switch;
 pub use textbox::TextBox;


### PR DESCRIPTION
This PR fixes the nightly doc generation feature where individual item docs will have a notice about being guarded by a feature flag.

None of the `Cargo.toml` files were specifying the custom cfg flag that we use to guard the nightly docs feature with.

I also removed two unneeded uses of this doc cfg usage. It's only needed next to the `mod foo;` line and doesn't need to be duplicated on `use` lines.