### PR TITLE
Remove `KeyCode.is_printable`

### DIFF
--- a/druid-shell/src/keycodes.rs
+++ b/druid-shell/src/keycodes.rs
@@ -148,20 +148,3 @@ pub enum KeyCode {
 
     Unknown(platform::RawKeyCode),
 }
-
-impl KeyCode {
-    pub fn is_printable(self) -> bool {
-        use KeyCode::*;
-        match self {
-            Backtick | Key0 | Key1 | Key2 | Key3 | Key4 | Key5 | Key6 | Key7 | Key8 | Key9
-            | Minus | Equals | Tab | KeyQ | KeyW | KeyE | KeyR | KeyT | KeyY | KeyU | KeyI
-            | KeyO | KeyP | LeftBracket | RightBracket | Return | KeyA | KeyS | KeyD | KeyF
-            | KeyG | KeyH | KeyJ | KeyK | KeyL | Semicolon | Quote | Backslash | KeyZ | KeyX
-            | KeyC | KeyV | KeyB | KeyN | KeyM | Comma | Period | Slash | Space | Numpad0
-            | Numpad1 | Numpad2 | Numpad3 | Numpad4 | Numpad5 | Numpad6 | Numpad7 | Numpad8
-            | Numpad9 | NumpadEquals | NumpadSubtract | NumpadAdd | NumpadDecimal
-            | NumpadMultiply | NumpadDivide | NumpadEnter => true,
-            _ => false,
-        }
-    }
-}

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -661,7 +661,30 @@ impl WndProc for MyWndProc {
                     let key_code: KeyCode = (wparam as i32).into();
                     s.stashed_key_code = key_code;
 
-                    if key_code.is_printable() || key_code == KeyCode::Backspace {
+                    /*
+                     * FIXME: This match was originally in KeyCode.is_printable().
+                     * It is required in order to prevent an erroneous double KeyDown
+                     * event on the druid side as the WM_CHAR is also mapped to a
+                     * KeyDown but we cannot(?) easily find out the chars for the
+                     * WM_KEYDOWN in this context. As a result the hack of naively
+                     * determining if the key is supposedly printable and avoiding
+                     * propagating it if it does appear to be printable has been kept
+                     * despite the original KeyCode.is_printable() being removed.
+                     */
+                    use KeyCode::*;
+                    let probably_printable = match key_code {
+                        Backtick | Key0 | Key1 | Key2 | Key3 | Key4 | Key5 | Key6 | Key7 | Key8
+                        | Key9 | Minus | Equals | Tab | KeyQ | KeyW | KeyE | KeyR | KeyT | KeyY
+                        | KeyU | KeyI | KeyO | KeyP | LeftBracket | RightBracket | Return
+                        | KeyA | KeyS | KeyD | KeyF | KeyG | KeyH | KeyJ | KeyK | KeyL
+                        | Semicolon | Quote | Backslash | KeyZ | KeyX | KeyC | KeyV | KeyB
+                        | KeyN | KeyM | Comma | Period | Slash | Space | Numpad0 | Numpad1
+                        | Numpad2 | Numpad3 | Numpad4 | Numpad5 | Numpad6 | Numpad7 | Numpad8
+                        | Numpad9 | NumpadEquals | NumpadSubtract | NumpadAdd | NumpadDecimal
+                        | NumpadMultiply | NumpadDivide | NumpadEnter => true,
+                        _ => false,
+                    };
+                    if probably_printable || key_code == KeyCode::Backspace {
                         //FIXME: this will fail to propogate key combinations such as alt+s
                         return None;
                     }

--- a/druid/src/text/text_input.rs
+++ b/druid/src/text/text_input.rs
@@ -100,7 +100,8 @@ impl TextInput for BasicTextInput {
             // Delete
             k_e if (HotKey::new(None, KeyCode::Delete)).matches(k_e) => EditAction::Delete,
             // Actual typing
-            k_e if k_e.key_code.is_printable() => {
+            k_e if k_e.text().is_some() => {
+                // `if let` in a match case is currently unsupported
                 if let Some(chars) = k_e.text() {
                     EditAction::Insert(chars.to_owned())
                 } else {


### PR DESCRIPTION
Instead of checking if the KeyCode is printable in TextBox the more sound logic is to check if the key event's text option is Some. This allows the numpad on GTK to still be used for text insertion even when the keycodes are yet to be fixed. By removing the method altogether this will force applications to check the option as well.

The Windows shell relies on determining the printablity of a keydown to avoid sending double keydown events to the application (with one of them containing no text). While that is very much a hack it is entirely out of scope for this PR to fix and would likely require a deep dive to find a suitable solution. As a result I've moved the original `is_printable`'s match over in order to continue to use as a stopgap and retain current behaviour. I've additionally documented that thoroughly so that anyone looking at it in the future won't have to do quite so much git blame finagling to figure out what the heck it is doing.