### PR TITLE
Don't log with error when optional Windows function cannot be loaded

### DIFF
--- a/druid-shell/src/platform/windows/util.rs
+++ b/druid-shell/src/platform/windows/util.rs
@@ -166,7 +166,7 @@ fn load_optional_functions() -> OptionalFunctions {
             let function_ptr = unsafe { GetProcAddress($lib, cstr.as_ptr()) };
 
             if function_ptr.is_null() {
-                log::error!(
+                log::info!(
                     "Could not load `{}`. Windows {} or later is needed",
                     name,
                     $min_windows_version


### PR DESCRIPTION
Someone I know was trying out druid on Windows and was worried by the errors that this was spitting out. I don't know the full context of these optional functions as I rarely work on the Windows shell but swapping this `error!` call for `info!` feels like a small but positive change.