### PR TITLE
Port X11 backend from xcb to x11rb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ You can find its changes [documented below](#060---2020-06-01).
 ### Maintenance
 
 - Standardized web targeting terminology. ([#1013] by [@xStrom])
+- X11: Ported the X11 backend to `x11rb`. ([#1025] by [@jneem])
 
 ### Outside News
 
@@ -327,6 +328,7 @@ Last release without a changelog :(
 [#1008]: https://github.com/xi-editor/druid/pull/1008
 [#1011]: https://github.com/xi-editor/druid/pull/1011
 [#1013]: https://github.com/xi-editor/druid/pull/1013
+[#1025]: https://github.com/xi-editor/druid/pull/1025
 [#1028]: https://github.com/xi-editor/druid/pull/1028
 [#1042]: https://github.com/xi-editor/druid/pull/1042
 [#1043]: https://github.com/xi-editor/druid/pull/1043

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -39,7 +39,7 @@ gtk = { version = "0.8.1", optional = true }
 glib = { version = "0.9.3", optional = true }
 glib-sys = { version = "0.9.1", optional = true }
 gtk-sys = { version = "0.9.2", optional = true }
-x11rb = { version = "0.5.0", features = ["allow-unsafe-code", "randr"], optional = true }
+x11rb = { version = "0.6.0", features = ["allow-unsafe-code", "randr"], optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 wio = "0.2.2"

--- a/druid-shell/Cargo.toml
+++ b/druid-shell/Cargo.toml
@@ -14,7 +14,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]
-x11 = ["xcb", "cairo-sys-rs"]
+x11 = ["x11rb", "cairo-sys-rs"]
 
 [dependencies]
 # NOTE: When changing the piet or kurbo versions, ensure that
@@ -39,7 +39,7 @@ gtk = { version = "0.8.1", optional = true }
 glib = { version = "0.9.3", optional = true }
 glib-sys = { version = "0.9.1", optional = true }
 gtk-sys = { version = "0.9.2", optional = true }
-xcb = { version = "0.9.0", features = ["thread", "xlib_xcb", "randr"], optional = true }
+x11rb = { version = "0.5.0", features = ["allow-unsafe-code", "randr"], optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 wio = "0.2.2"
@@ -57,7 +57,7 @@ core-graphics = "0.19.0"
 foreign-types = "0.3.2"
 bitflags = "1.2.1"
 
-# TODO(x11/dependencies): only use feature "xcb" if using XCB
+# TODO(x11/dependencies): only use feature "xcb" if using X11
 [target.'cfg(target_os="linux")'.dependencies]
 cairo-rs = { version = "0.8.1", default_features = false, features = ["xcb"] }
 gio = "0.8.1"

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -123,6 +123,8 @@ impl Application {
             )?
             .check()?
         {
+            // TODO: https://github.com/psychon/x11rb/pull/469 will make error handling easier with
+            // the next x11rb release.
             return Err(x11rb::errors::ReplyError::X11Error(err).into());
         }
 

--- a/druid-shell/src/platform/x11/application.rs
+++ b/druid-shell/src/platform/x11/application.rs
@@ -79,7 +79,7 @@ impl Application {
         // libxcb, you should call XSetEventQueueOwner(dpy, XCBOwnsEventQueue). Otherwise, libX11
         // might randomly eat your events / move them to its own event queue.
         //
-        // https://github.com/xi-editor/druid/pull/1025/files/76b923417183bd103f61e56b56a56474b7417cec#r442777892
+        // https://github.com/xi-editor/druid/pull/1025#discussion_r442777892
         let (conn, screen_num) = XCBConnection::connect(None)?;
         let connection = Rc::new(conn);
         let window_id = Application::create_event_window(&connection, screen_num as i32)?;

--- a/druid-shell/src/platform/x11/mod.rs
+++ b/druid-shell/src/platform/x11/mod.rs
@@ -18,11 +18,12 @@
 //     Might be related to the "sleep scheduler" in XWindow::render()?
 // TODO(x11/render_improvements): double-buffering / present strategies / etc?
 
+#[macro_use]
+mod util;
+
 pub mod application;
 pub mod clipboard;
 pub mod error;
 pub mod keycodes;
 pub mod menu;
 pub mod window;
-
-mod util;

--- a/druid-shell/src/platform/x11/util.rs
+++ b/druid-shell/src/platform/x11/util.rs
@@ -14,33 +14,42 @@
 
 //! Miscellaneous utility functions for working with X11.
 
-use xcb::{Connection, Screen, Visualtype, Window};
+use std::rc::Rc;
+
+use x11rb::errors::ReplyError;
+use x11rb::protocol::randr::{ConnectionExt, ModeFlag};
+use x11rb::protocol::xproto::{Screen, Visualtype, Window};
+use x11rb::xcb_ffi::XCBConnection;
 
 // See: https://github.com/rtbo/rust-xcb/blob/master/examples/randr_screen_modes.rs
-pub fn refresh_rate(conn: &Connection, window_id: Window) -> Option<f64> {
-    let cookie = xcb::randr::get_screen_resources(conn, window_id);
-    let reply = cookie.get_reply().unwrap();
-    let mut modes = reply.modes();
+pub fn refresh_rate(conn: &Rc<XCBConnection>, window_id: Window) -> Option<f64> {
+    let reply =
+        (|| -> Result<_, ReplyError> { Ok(conn.randr_get_screen_resources(window_id)?.reply()?) })(
+        );
+    let reply = match reply {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
 
     // TODO(x11/render_improvements): Figure out a more correct way of getting the screen's refresh rate.
     //     Or maybe we don't even need this function if I figure out a better way to schedule redraws?
     //     Assuming the first mode is the one we want to use. This is probably a bug on some setups.
     //     Any better way to find the correct one?
-    let refresh_rate = modes.next().and_then(|mode_info| {
-        let flags = mode_info.mode_flags();
+    let refresh_rate = reply.modes.first().and_then(|mode_info| {
+        let flags = mode_info.mode_flags;
         let vtotal = {
-            let mut val = mode_info.vtotal();
-            if (flags & xcb::randr::MODE_FLAG_DOUBLE_SCAN) != 0 {
+            let mut val = mode_info.vtotal;
+            if (flags & u32::from(ModeFlag::DoubleScan)) != 0 {
                 val *= 2;
             }
-            if (flags & xcb::randr::MODE_FLAG_INTERLACE) != 0 {
+            if (flags & u32::from(ModeFlag::Interlace)) != 0 {
                 val /= 2;
             }
             val
         };
 
-        if vtotal != 0 && mode_info.htotal() != 0 {
-            Some((mode_info.dot_clock() as f64) / (vtotal as f64 * mode_info.htotal() as f64))
+        if vtotal != 0 && mode_info.htotal != 0 {
+            Some((mode_info.dot_clock as f64) / (vtotal as f64 * mode_info.htotal as f64))
         } else {
             None
         }
@@ -50,13 +59,25 @@ pub fn refresh_rate(conn: &Connection, window_id: Window) -> Option<f64> {
 }
 
 // Apparently you have to get the visualtype this way :|
-pub fn get_visual_from_screen(screen: &Screen<'_>) -> Option<Visualtype> {
-    for depth in screen.allowed_depths() {
-        for visual in depth.visuals() {
-            if visual.visual_id() == screen.root_visual() {
-                return Some(visual);
+pub fn get_visual_from_screen(screen: &Screen) -> Option<Visualtype> {
+    for depth in &screen.allowed_depths {
+        for visual in &depth.visuals {
+            if visual.visual_id == screen.root_visual {
+                return Some(*visual);
             }
         }
     }
     None
+}
+
+macro_rules! log_x11 {
+    ($val:expr) => {
+        if let Err(e) = $val {
+            // We probably don't want to include file/line numbers. This logging is done in
+            // a context where X11 errors probably just mean that the connection to the X server
+            // was lost. In particular, it doesn't represent a druid-shell bug for which we want
+            // more context.
+            log::error!("X11 error: {}", e);
+        }
+    };
 }

--- a/druid-shell/src/platform/x11/util.rs
+++ b/druid-shell/src/platform/x11/util.rs
@@ -16,46 +16,52 @@
 
 use std::rc::Rc;
 
-use x11rb::errors::ReplyError;
+use anyhow::{anyhow, Error};
 use x11rb::protocol::randr::{ConnectionExt, ModeFlag};
 use x11rb::protocol::xproto::{Screen, Visualtype, Window};
 use x11rb::xcb_ffi::XCBConnection;
 
 // See: https://github.com/rtbo/rust-xcb/blob/master/examples/randr_screen_modes.rs
 pub fn refresh_rate(conn: &Rc<XCBConnection>, window_id: Window) -> Option<f64> {
-    let reply =
-        (|| -> Result<_, ReplyError> { Ok(conn.randr_get_screen_resources(window_id)?.reply()?) })(
-        );
-    let reply = match reply {
-        Ok(r) => r,
-        Err(_) => return None,
+    let try_refresh_rate = || -> Result<f64, Error> {
+        let reply = conn.randr_get_screen_resources(window_id)?.reply()?;
+
+        // TODO(x11/render_improvements): Figure out a more correct way of getting the screen's refresh rate.
+        //     Or maybe we don't even need this function if I figure out a better way to schedule redraws?
+        //     Assuming the first mode is the one we want to use. This is probably a bug on some setups.
+        //     Any better way to find the correct one?
+        reply
+            .modes
+            .first()
+            .ok_or_else(|| anyhow!("didn't get any modes"))
+            .and_then(|mode_info| {
+                let flags = mode_info.mode_flags;
+                let vtotal = {
+                    let mut val = mode_info.vtotal;
+                    if (flags & u32::from(ModeFlag::DoubleScan)) != 0 {
+                        val *= 2;
+                    }
+                    if (flags & u32::from(ModeFlag::Interlace)) != 0 {
+                        val /= 2;
+                    }
+                    val
+                };
+
+                if vtotal != 0 && mode_info.htotal != 0 {
+                    Ok((mode_info.dot_clock as f64) / (vtotal as f64 * mode_info.htotal as f64))
+                } else {
+                    Err(anyhow!("got nonsensical mode values"))
+                }
+            })
     };
 
-    // TODO(x11/render_improvements): Figure out a more correct way of getting the screen's refresh rate.
-    //     Or maybe we don't even need this function if I figure out a better way to schedule redraws?
-    //     Assuming the first mode is the one we want to use. This is probably a bug on some setups.
-    //     Any better way to find the correct one?
-    let refresh_rate = reply.modes.first().and_then(|mode_info| {
-        let flags = mode_info.mode_flags;
-        let vtotal = {
-            let mut val = mode_info.vtotal;
-            if (flags & u32::from(ModeFlag::DoubleScan)) != 0 {
-                val *= 2;
-            }
-            if (flags & u32::from(ModeFlag::Interlace)) != 0 {
-                val /= 2;
-            }
-            val
-        };
-
-        if vtotal != 0 && mode_info.htotal != 0 {
-            Some((mode_info.dot_clock as f64) / (vtotal as f64 * mode_info.htotal as f64))
-        } else {
+    match try_refresh_rate() {
+        Err(e) => {
+            log::error!("failed to find refresh rate: {}", e);
             None
         }
-    })?;
-
-    Some(refresh_rate)
+        Ok(r) => Some(r),
+    }
 }
 
 // Apparently you have to get the visualtype this way :|

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -41,8 +41,13 @@ use super::application::Application;
 use super::menu::Menu;
 use super::util;
 
-/// A version of XCB's `xcb_visualtype_t` struct. This was copied from the example in x11rb; it
+/// A version of XCB's `xcb_visualtype_t` struct. This was copied from the [example] in x11rb; it
 /// is used to interoperate with cairo.
+///
+/// The official upstream reference for this struct definition is [here].
+///
+/// [example]: https://github.com/psychon/x11rb/blob/master/cairo-example/src/main.rs
+/// [here]: https://xcb.freedesktop.org/manual/structxcb__visualtype__t.html
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct xcb_visualtype_t {
@@ -386,7 +391,7 @@ impl Window {
             false,
             self.id,
             EventMask::Exposure,
-            expose_event
+            expose_event,
         ));
     }
 


### PR DESCRIPTION
This ports the X11 backend from the `xcb` crate to the `x11rb` crate, as discussed in #989. Overall, I have a positive impression of `x11rb`, as compared to `xcb`: it's actively maintained, it uses actual rust enums in many places, and it doesn't need unsafe for event handling. Also, it supports the present extension (a blocker for #989) and the xinput extension (which presumably we'll need at some point), unlike `xcb`.