### PR TITLE
Fix macOS timer not firing during modal loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You can find its changes [documented below](#060---2020-06-01).
 
 ### Fixed
 
+- macOS: Timers not firing during modal loop. ([#1028] by [@xStrom])
 - GTK: Directory selection now properly ignores file filters. ([#957] by [@xStrom])
 
 ### Visual
@@ -322,6 +323,7 @@ Last release without a changelog :(
 [#1008]: https://github.com/xi-editor/druid/pull/1008
 [#1011]: https://github.com/xi-editor/druid/pull/1011
 [#1013]: https://github.com/xi-editor/druid/pull/1013
+[#1028]: https://github.com/xi-editor/druid/pull/1028
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/xi-editor/druid/compare/v0.5.0...v0.6.0

--- a/druid-shell/src/platform/mac/appkit.rs
+++ b/druid-shell/src/platform/mac/appkit.rs
@@ -22,6 +22,11 @@ use cocoa::base::id;
 use cocoa::foundation::NSRect;
 use objc::{class, msg_send, sel, sel_impl};
 
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {
+    pub static NSRunLoopCommonModes: id;
+}
+
 bitflags! {
     pub struct NSTrackingAreaOptions: i32 {
         const MouseEnteredAndExited = 1;

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -43,7 +43,9 @@ use objc::{class, msg_send, sel, sel_impl};
 use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::piet::{Piet, RenderContext};
 
-use super::appkit::{NSTrackingArea, NSTrackingAreaOptions, NSView as NSViewExt};
+use super::appkit::{
+    NSRunLoopCommonModes, NSTrackingArea, NSTrackingAreaOptions, NSView as NSViewExt,
+};
 use super::application::Application;
 use super::dialog;
 use super::menu::Menu;
@@ -804,7 +806,9 @@ impl WindowHandle {
             let user_info: id = msg_send![nsnumber, numberWithUnsignedInteger: token.into_raw()];
             let selector = sel!(handleTimer:);
             let view = self.nsview.load();
-            let _: id = msg_send![nstimer, scheduledTimerWithTimeInterval: ti target: view selector: selector userInfo: user_info repeats: NO];
+            let timer: id = msg_send![nstimer, timerWithTimeInterval: ti target: view selector: selector userInfo: user_info repeats: NO];
+            let runloop: id = msg_send![class!(NSRunLoop), currentRunLoop];
+            let () = msg_send![runloop, addTimer: timer forMode: NSRunLoopCommonModes];
         }
         token
     }


### PR DESCRIPTION
Currently the timers on macOS fire only when the application run loop is in default mode. This PR changes that to allow them to fire also during modal loops.

This can be tested easily with the `timer` example by opening the application menu. Without this PR the box stops moving.

This fixes the macOS part of #881.