### PR TITLE
Simplify Scale by removing DPI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ You can find its changes [documented below](#060---2020-06-01).
 ### Changed
 
 - `Image` and `ImageData` exported by default. ([#1011] by [@covercash2])
+- `Scale::from_scale` to `Scale::new`, and `Scale` methods `scale_x` / `scale_y` to `x` / `y`. ([#1042] by [@xStrom])
 
 ### Deprecated
 
 ### Removed
 
-- DPI related functions/methods from `Scale`. ([#1042] by [@xStrom])
+- `Scale::from_dpi`, `Scale::dpi_x`, and `Scale::dpi_y`. ([#1042] by [@xStrom])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ You can find its changes [documented below](#060---2020-06-01).
 
 ### Removed
 
+- DPI related functions/methods from `Scale`. ([#1042] by [@xStrom])
+
 ### Fixed
 
 - macOS: Timers not firing during modal loop. ([#1028] by [@xStrom])
@@ -324,6 +326,7 @@ Last release without a changelog :(
 [#1011]: https://github.com/xi-editor/druid/pull/1011
 [#1013]: https://github.com/xi-editor/druid/pull/1013
 [#1028]: https://github.com/xi-editor/druid/pull/1028
+[#1042]: https://github.com/xi-editor/druid/pull/1042
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/xi-editor/druid/compare/v0.5.0...v0.6.0

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -47,7 +47,9 @@ use super::dialog;
 use super::menu::Menu;
 use super::util;
 
-/// When the GTK reported DPI differs from this we will scale coordinates to achieve it.
+/// The platform target DPI.
+/// 
+/// GTK considers 96 the default value which represents a 1.0 scale factor.
 const SCALE_TARGET_DPI: f64 = 96.0;
 
 /// Taken from https://gtk-rs.org/docs-src/tutorial/closures
@@ -175,7 +177,7 @@ impl WindowBuilder {
         // Get the scale factor based on the GTK reported DPI
         let scale_factor = window
             .get_display()
-            .map(|c| c.get_default_screen().get_resolution() as f64)
+            .map(|c| c.get_default_screen().get_resolution())
             .unwrap_or(SCALE_TARGET_DPI)
             / SCALE_TARGET_DPI;
         let scale = Scale::new(scale_factor, scale_factor);

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -290,7 +290,7 @@ impl WindowBuilder {
                 if let Ok(mut handler_borrow) = state.handler.try_borrow_mut() {
                     // For some reason piet needs a mutable context, so give it one I guess.
                     let mut context = context.clone();
-                    context.scale(scale.scale_x(), scale.scale_y());
+                    context.scale(scale.x(), scale.y());
                     let (x0, y0, x1, y1) = context.clip_extents();
                     let invalid_rect = Rect::new(x0, y0, x1, y1);
 

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -48,7 +48,7 @@ use super::menu::Menu;
 use super::util;
 
 /// The platform target DPI.
-/// 
+///
 /// GTK considers 96 the default value which represents a 1.0 scale factor.
 const SCALE_TARGET_DPI: f64 = 96.0;
 

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -884,7 +884,7 @@ impl WindowHandle {
     /// Get the `Scale` of the window.
     pub fn get_scale(&self) -> Result<Scale, Error> {
         // TODO: Get actual Scale
-        Ok(Scale::from_dpi(96.0, 96.0))
+        Ok(Scale::new(1.0, 1.0))
     }
 }
 

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -137,7 +137,7 @@ impl WindowState {
     /// Updates the canvas size and scale factor and returns `Scale` and `ScaledArea`.
     fn update_scale_and_area(&self) -> (Scale, ScaledArea) {
         let (css_width, css_height, dpr) = self.get_window_size_and_dpr();
-        let scale = Scale::from_scale(dpr, dpr);
+        let scale = Scale::new(dpr, dpr);
         let area = ScaledArea::from_dp(Size::new(css_width, css_height), &scale);
         let size_px = area.size_px();
         self.canvas.set_width(size_px.width as u32);
@@ -373,7 +373,7 @@ impl WindowBuilder {
         // Create the Scale for resolution scaling
         let scale = {
             let dpr = window.device_pixel_ratio();
-            Scale::from_scale(dpr, dpr)
+            Scale::new(dpr, dpr)
         };
         let area = {
             // The initial size in display points isn't necessarily the final size in display points

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -142,7 +142,7 @@ impl WindowState {
         let size_px = area.size_px();
         self.canvas.set_width(size_px.width as u32);
         self.canvas.set_height(size_px.height as u32);
-        let _ = self.context.scale(scale.scale_x(), scale.scale_y());
+        let _ = self.context.scale(scale.x(), scale.y());
         self.scale.set(scale);
         self.area.set(area);
         (scale, area)
@@ -383,7 +383,7 @@ impl WindowBuilder {
         let size_px = area.size_px();
         canvas.set_width(size_px.width as u32);
         canvas.set_height(size_px.height as u32);
-        let _ = context.scale(scale.scale_x(), scale.scale_y());
+        let _ = context.scale(scale.x(), scale.y());
         let size_dp = area.size_dp();
 
         set_cursor(&canvas, &self.cursor);

--- a/druid-shell/src/platform/windows/paint.rs
+++ b/druid-shell/src/platform/windows/paint.rs
@@ -40,6 +40,7 @@ use crate::scale::Scale;
 
 use super::error::Error;
 use super::util::as_result;
+use super::window::SCALE_TARGET_DPI;
 
 pub(crate) unsafe fn create_render_target(
     d2d_factory: &D2DFactory,
@@ -82,8 +83,8 @@ pub(crate) unsafe fn create_render_target_dxgi(
             format: DXGI_FORMAT_B8G8R8A8_UNORM,
             alphaMode: D2D1_ALPHA_MODE_IGNORE,
         },
-        dpiX: scale.dpi_x() as f32,
-        dpiY: scale.dpi_y() as f32,
+        dpiX: (scale.x() * SCALE_TARGET_DPI) as f32,
+        dpiY: (scale.y() * SCALE_TARGET_DPI) as f32,
         usage: D2D1_RENDER_TARGET_USAGE_NONE,
         minLevel: D2D1_FEATURE_LEVEL_DEFAULT,
     };

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -66,7 +66,7 @@ use crate::scale::{Scale, ScaledArea};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 
 /// The platform target DPI.
-/// 
+///
 /// Windows considers 96 the default value which represents a 1.0 scale factor.
 pub(crate) const SCALE_TARGET_DPI: f64 = 96.0;
 

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -65,7 +65,9 @@ use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::scale::{Scale, ScaledArea};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 
-/// When the OS reported DPI differs from this we will scale coordinates to achieve it.
+/// The platform target DPI.
+/// 
+/// Windows considers 96 the default value which represents a 1.0 scale factor.
 pub(crate) const SCALE_TARGET_DPI: f64 = 96.0;
 
 extern "system" {

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -65,6 +65,9 @@ use crate::mouse::{Cursor, MouseButton, MouseButtons, MouseEvent};
 use crate::scale::{Scale, ScaledArea};
 use crate::window::{IdleToken, Text, TimerToken, WinHandler};
 
+/// When the OS reported DPI differs from this we will scale coordinates to achieve it.
+pub(crate) const SCALE_TARGET_DPI: f64 = 96.0;
+
 extern "system" {
     pub fn DwmFlush();
 }
@@ -1026,16 +1029,16 @@ impl WindowBuilder {
                 present_strategy: self.present_strategy,
             };
 
-            // Simple scaling based on System DPI (96 is equivalent to 100%)
-            let dpi = if let Some(func) = OPTIONAL_FUNCTIONS.GetDpiForSystem {
+            // Simple scaling based on System DPI
+            let scale_factor = if let Some(func) = OPTIONAL_FUNCTIONS.GetDpiForSystem {
                 // Only supported on Windows 10
-                func() as f64
+                func() as f64 / SCALE_TARGET_DPI
             } else {
                 // TODO GetDpiForMonitor is supported on Windows 8.1, try falling back to that here
                 // Probably GetDeviceCaps(..., LOGPIXELSX) is the best to do pre-10
-                96.0
+                1.0
             };
-            let scale = Scale::from_dpi(dpi, dpi);
+            let scale = Scale::new(scale_factor, scale_factor);
             let area = ScaledArea::from_dp(self.size, &scale);
             let size_px = area.size_px();
 

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -476,7 +476,7 @@ impl Window {
 
     fn get_scale(&self) -> Result<Scale, Error> {
         // TODO(x11/dpi_scaling): figure out DPI scaling
-        Ok(Scale::from_dpi(96.0, 96.0))
+        Ok(Scale::new(1.0, 1.0))
     }
 
     pub fn handle_expose(&self, expose: &xcb::ExposeEvent) -> Result<(), Error> {
@@ -820,7 +820,7 @@ impl WindowHandle {
             Ok(w.get_scale()?)
         } else {
             log::error!("Window {} has already been dropped", self.id);
-            Ok(Scale::from_dpi(96.0, 96.0))
+            Ok(Scale::new(1.0, 1.0))
         }
     }
 }

--- a/druid-shell/src/scale.rs
+++ b/druid-shell/src/scale.rs
@@ -16,11 +16,9 @@
 
 use crate::kurbo::{Insets, Line, Point, Rect, Size, Vec2};
 
-const SCALE_TARGET_DPI: f64 = 96.0;
-
 /// Coordinate scaling between pixels and display points.
 ///
-/// This holds the platform DPI and the equivalent scale factors.
+/// This holds the platform scale factors.
 ///
 /// ## Pixels and Display Points
 ///
@@ -35,26 +33,22 @@ const SCALE_TARGET_DPI: f64 = 96.0;
 /// ## Converting with `Scale`
 ///
 /// To translate coordinates between pixels and display points you should use one of the
-/// helper conversion methods of `Scale` or for manual conversion [`scale_x`] / [`scale_y`].
+/// helper conversion methods of `Scale` or for manual conversion [`x`] / [`y`].
 ///
-/// `Scale` is designed for responsive applications, including responding to platform DPI changes.
-/// The platform DPI can change quickly, e.g. when moving a window from one monitor to another.
+/// `Scale` is designed for responsive applications, including responding to platform scale changes.
+/// The platform scale can change quickly, e.g. when moving a window from one monitor to another.
 ///
-/// A copy of `Scale` will be stale as soon as the platform DPI changes.
+/// A copy of `Scale` will be stale as soon as the platform scale changes.
 ///
-/// [`scale_x`]: #method.scale_x
-/// [`scale_y`]: #method.scale_y
+/// [`x`]: #method.x
+/// [`y`]: #method.y
 /// [in the druid book]: https://xi-editor.io/druid/resolution_independence.html
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Scale {
-    /// The platform reported DPI on the x axis.
-    dpi_x: f64,
-    /// The platform reported DPI on the y axis.
-    dpi_y: f64,
     /// The scale factor on the x axis.
-    scale_x: f64,
+    x: f64,
     /// The scale factor on the y axis.
-    scale_y: f64,
+    y: f64,
 }
 
 /// A specific area scaling state.
@@ -100,62 +94,26 @@ pub trait Scalable {
 
 impl Default for Scale {
     fn default() -> Scale {
-        Scale {
-            dpi_x: SCALE_TARGET_DPI,
-            dpi_y: SCALE_TARGET_DPI,
-            scale_x: 1.0,
-            scale_y: 1.0,
-        }
+        Scale { x: 1.0, y: 1.0 }
     }
 }
 
 impl Scale {
-    /// Create a new `Scale` state based on the specified DPIs.
-    ///
-    /// Use this constructor if the platform provided DPI is the most accurate number.
-    pub fn from_dpi(dpi_x: f64, dpi_y: f64) -> Scale {
-        Scale {
-            dpi_x,
-            dpi_y,
-            scale_x: dpi_x / SCALE_TARGET_DPI,
-            scale_y: dpi_y / SCALE_TARGET_DPI,
-        }
-    }
-
-    /// Create a new `Scale` state based on the specified scale factors.
-    ///
-    /// Use this constructor if the platform provided scale factor is the most accurate number.
-    pub fn from_scale(scale_x: f64, scale_y: f64) -> Scale {
-        Scale {
-            dpi_x: SCALE_TARGET_DPI * scale_x,
-            dpi_y: SCALE_TARGET_DPI * scale_y,
-            scale_x,
-            scale_y,
-        }
-    }
-
-    /// Returns the x axis platform DPI associated with this `Scale`.
-    #[inline]
-    pub fn dpi_x(&self) -> f64 {
-        self.dpi_x
-    }
-
-    /// Returns the y axis platform DPI associated with this `Scale`.
-    #[inline]
-    pub fn dpi_y(&self) -> f64 {
-        self.dpi_y
+    /// Create a new `Scale` based on the specified axis factors.
+    pub fn new(x: f64, y: f64) -> Scale {
+        Scale { x, y }
     }
 
     /// Returns the x axis scale factor.
     #[inline]
-    pub fn scale_x(&self) -> f64 {
-        self.scale_x
+    pub fn x(&self) -> f64 {
+        self.x
     }
 
     /// Returns the y axis scale factor.
     #[inline]
-    pub fn scale_y(&self) -> f64 {
-        self.scale_y
+    pub fn y(&self) -> f64 {
+        self.y
     }
 
     /// Converts the `item` from display points into pixels,
@@ -169,20 +127,20 @@ impl Scale {
     /// Converts from pixels into display points, using the x axis scale factor.
     #[inline]
     pub fn px_to_dp_x<T: Into<f64>>(&self, x: T) -> f64 {
-        x.into() / self.scale_x
+        x.into() / self.x
     }
 
     /// Converts from pixels into display points, using the y axis scale factor.
     #[inline]
     pub fn px_to_dp_y<T: Into<f64>>(&self, y: T) -> f64 {
-        y.into() / self.scale_y
+        y.into() / self.y
     }
 
     /// Converts from pixels into display points,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
     pub fn px_to_dp_xy<T: Into<f64>>(&self, x: T, y: T) -> (f64, f64) {
-        (x.into() / self.scale_x, y.into() / self.scale_y)
+        (x.into() / self.x, y.into() / self.y)
     }
 
     /// Converts the `item` from pixels into display points,
@@ -199,14 +157,14 @@ impl Scalable for Vec2 {
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
     fn to_px(&self, scale: &Scale) -> Vec2 {
-        Vec2::new(self.x * scale.scale_x, self.y * scale.scale_y)
+        Vec2::new(self.x * scale.x, self.y * scale.y)
     }
 
     /// Converts a `Vec2` from pixels into display points,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
     fn to_dp(&self, scale: &Scale) -> Vec2 {
-        Vec2::new(self.x / scale.scale_x, self.y / scale.scale_y)
+        Vec2::new(self.x / scale.x, self.y / scale.y)
     }
 }
 
@@ -215,14 +173,14 @@ impl Scalable for Point {
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
     fn to_px(&self, scale: &Scale) -> Point {
-        Point::new(self.x * scale.scale_x, self.y * scale.scale_y)
+        Point::new(self.x * scale.x, self.y * scale.y)
     }
 
     /// Converts a `Point` from pixels into display points,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
     fn to_dp(&self, scale: &Scale) -> Point {
-        Point::new(self.x / scale.scale_x, self.y / scale.scale_y)
+        Point::new(self.x / scale.x, self.y / scale.y)
     }
 }
 
@@ -248,7 +206,7 @@ impl Scalable for Size {
     /// and the y axis scale factor for `height`.
     #[inline]
     fn to_px(&self, scale: &Scale) -> Size {
-        Size::new(self.width * scale.scale_x, self.height * scale.scale_y)
+        Size::new(self.width * scale.x, self.height * scale.y)
     }
 
     /// Converts a `Size` from pixels into points,
@@ -256,7 +214,7 @@ impl Scalable for Size {
     /// and the y axis scale factor for `height`.
     #[inline]
     fn to_dp(&self, scale: &Scale) -> Size {
-        Size::new(self.width / scale.scale_x, self.height / scale.scale_y)
+        Size::new(self.width / scale.x, self.height / scale.y)
     }
 }
 
@@ -267,10 +225,10 @@ impl Scalable for Rect {
     #[inline]
     fn to_px(&self, scale: &Scale) -> Rect {
         Rect::new(
-            self.x0 * scale.scale_x,
-            self.y0 * scale.scale_y,
-            self.x1 * scale.scale_x,
-            self.y1 * scale.scale_y,
+            self.x0 * scale.x,
+            self.y0 * scale.y,
+            self.x1 * scale.x,
+            self.y1 * scale.y,
         )
     }
 
@@ -280,10 +238,10 @@ impl Scalable for Rect {
     #[inline]
     fn to_dp(&self, scale: &Scale) -> Rect {
         Rect::new(
-            self.x0 / scale.scale_x,
-            self.y0 / scale.scale_y,
-            self.x1 / scale.scale_x,
-            self.y1 / scale.scale_y,
+            self.x0 / scale.x,
+            self.y0 / scale.y,
+            self.x1 / scale.x,
+            self.y1 / scale.y,
         )
     }
 }
@@ -295,10 +253,10 @@ impl Scalable for Insets {
     #[inline]
     fn to_px(&self, scale: &Scale) -> Insets {
         Insets::new(
-            self.x0 * scale.scale_x,
-            self.y0 * scale.scale_y,
-            self.x1 * scale.scale_x,
-            self.y1 * scale.scale_y,
+            self.x0 * scale.x,
+            self.y0 * scale.y,
+            self.x1 * scale.x,
+            self.y1 * scale.y,
         )
     }
 
@@ -308,10 +266,10 @@ impl Scalable for Insets {
     #[inline]
     fn to_dp(&self, scale: &Scale) -> Insets {
         Insets::new(
-            self.x0 / scale.scale_x,
-            self.y0 / scale.scale_y,
-            self.x1 / scale.scale_x,
-            self.y1 / scale.scale_y,
+            self.x0 / scale.x,
+            self.y0 / scale.y,
+            self.x1 / scale.x,
+            self.y1 / scale.y,
         )
     }
 }


### PR DESCRIPTION
This PR removes any notion of DPI from `Scale` and makes it strictly scale factor based.

Previously `Scale` always considered 96 as the target DPI but with this change that decision is in the platform code's hands. This will allow for easier implementation of future platforms that have a different target DPI like Android with 160.

This also means that all the DPI-related stuff can be an implementation detail and it doesn't need to be surfaced to developers using druid. Especially as DPI doesn't really match any actual inches etc.