### PR TITLE
Enable trivially_copy_pass_by_ref clippy lint.

### DIFF
--- a/druid-derive/src/lib.rs
+++ b/druid-derive/src/lib.rs
@@ -14,6 +14,8 @@
 
 //! derive macros for druid.
 
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 extern crate proc_macro;
 
 mod attr;

--- a/druid-shell/src/lib.rs
+++ b/druid-shell/src/lib.rs
@@ -20,6 +20,7 @@
 
 #![deny(intra_doc_link_resolution_failure)]
 #![allow(clippy::new_without_default)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 pub use kurbo;
 pub use piet_common as piet;

--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -181,7 +181,7 @@ impl WindowBuilder {
             .unwrap_or(SCALE_TARGET_DPI)
             / SCALE_TARGET_DPI;
         let scale = Scale::new(scale_factor, scale_factor);
-        let area = ScaledArea::from_dp(self.size, &scale);
+        let area = ScaledArea::from_dp(self.size, scale);
         let size_px = area.size_px();
 
         window.set_default_size(size_px.width as i32, size_px.height as i32);
@@ -247,7 +247,7 @@ impl WindowBuilder {
 
         // Set the minimum size
         if let Some(min_size_dp) = self.min_size {
-            let min_area = ScaledArea::from_dp(min_size_dp, &scale);
+            let min_area = ScaledArea::from_dp(min_size_dp, scale);
             let min_size_px = min_area.size_px();
             win_state
                 .drawing_area
@@ -279,7 +279,7 @@ impl WindowBuilder {
                 let extents = widget.get_allocation();
                 let size_px = Size::new(extents.width as f64, extents.height as f64);
                 if scale_changed || state.area.get().size_px() != size_px {
-                    let area = ScaledArea::from_px(size_px, &scale);
+                    let area = ScaledArea::from_px(size_px, scale);
                     let size_dp = area.size_dp();
                     state.area.set(area);
                     if let Ok(mut handler_borrow) = state.handler.try_borrow_mut() {

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -138,7 +138,7 @@ impl WindowState {
     fn update_scale_and_area(&self) -> (Scale, ScaledArea) {
         let (css_width, css_height, dpr) = self.get_window_size_and_dpr();
         let scale = Scale::new(dpr, dpr);
-        let area = ScaledArea::from_dp(Size::new(css_width, css_height), &scale);
+        let area = ScaledArea::from_dp(Size::new(css_width, css_height), scale);
         let size_px = area.size_px();
         self.canvas.set_width(size_px.width as u32);
         self.canvas.set_height(size_px.height as u32);
@@ -378,7 +378,7 @@ impl WindowBuilder {
         let area = {
             // The initial size in display points isn't necessarily the final size in display points
             let size_dp = Size::new(canvas.offset_width() as f64, canvas.offset_height() as f64);
-            ScaledArea::from_dp(size_dp, &scale)
+            ScaledArea::from_dp(size_dp, scale)
         };
         let size_px = area.size_px();
         canvas.set_width(size_px.width as u32);

--- a/druid-shell/src/platform/windows/paint.rs
+++ b/druid-shell/src/platform/windows/paint.rs
@@ -69,7 +69,7 @@ pub(crate) unsafe fn create_render_target(
 pub(crate) unsafe fn create_render_target_dxgi(
     d2d_factory: &D2DFactory,
     swap_chain: *mut IDXGISwapChain1,
-    scale: &Scale,
+    scale: Scale,
 ) -> Result<DxgiSurfaceRenderTarget, Error> {
     let mut buffer: *mut IDXGISurface = null_mut();
     as_result((*swap_chain).GetBuffer(

--- a/druid-shell/src/platform/windows/window.rs
+++ b/druid-shell/src/platform/windows/window.rs
@@ -294,7 +294,7 @@ fn is_point_in_client_rect(hwnd: HWND, x: i32, y: i32) -> bool {
 }
 
 impl WndState {
-    fn rebuild_render_target(&mut self, d2d: &D2DFactory, scale: &Scale) {
+    fn rebuild_render_target(&mut self, d2d: &D2DFactory, scale: Scale) {
         unsafe {
             let swap_chain = self.dcomp_state.as_ref().unwrap().swap_chain;
             let rt = paint::create_render_target_dxgi(d2d, swap_chain, scale)
@@ -533,7 +533,7 @@ impl WndProc for MyWndProc {
                         );
                         if SUCCEEDED(res) {
                             s.handler.rebuild_resources();
-                            s.rebuild_render_target(&self.d2d_factory, &self.scale());
+                            s.rebuild_render_target(&self.d2d_factory, self.scale());
                             s.render(
                                 &self.d2d_factory,
                                 &self.dwrite_factory,
@@ -566,7 +566,7 @@ impl WndProc for MyWndProc {
                     let width = LOWORD(lparam as u32) as u32;
                     let height = HIWORD(lparam as u32) as u32;
                     let scale = self.scale();
-                    let area = ScaledArea::from_px((width as f64, height as f64), &scale);
+                    let area = ScaledArea::from_px((width as f64, height as f64), scale);
                     let size_dp = area.size_dp();
                     self.set_area(area);
                     s.handler.size(size_dp);
@@ -601,7 +601,7 @@ impl WndProc for MyWndProc {
                             );
                         }
                         if SUCCEEDED(res) {
-                            s.rebuild_render_target(&self.d2d_factory, &scale);
+                            s.rebuild_render_target(&self.d2d_factory, scale);
                             s.render(
                                 &self.d2d_factory,
                                 &self.dwrite_factory,
@@ -942,7 +942,7 @@ impl WndProc for MyWndProc {
                 if let Ok(s) = self.state.try_borrow() {
                     let s = s.as_ref().unwrap();
                     if let Some(min_size_dp) = s.min_size {
-                        let min_area = ScaledArea::from_dp(min_size_dp, &self.scale());
+                        let min_area = ScaledArea::from_dp(min_size_dp, self.scale());
                         let min_size_px = min_area.size_px();
                         min_max_info.ptMinTrackSize.x = min_size_px.width as i32;
                         min_max_info.ptMinTrackSize.y = min_size_px.height as i32;
@@ -1041,7 +1041,7 @@ impl WindowBuilder {
                 1.0
             };
             let scale = Scale::new(scale_factor, scale_factor);
-            let area = ScaledArea::from_dp(self.size, &scale);
+            let area = ScaledArea::from_dp(self.size, scale);
             let size_px = area.size_px();
 
             let (hmenu, accels, has_menu) = match self.menu {

--- a/druid-shell/src/scale.rs
+++ b/druid-shell/src/scale.rs
@@ -84,12 +84,12 @@ pub trait Scalable {
     /// Converts the scalable item from display points into pixels,
     /// using the x axis scale factor for coordinates on the x axis
     /// and the y axis scale factor for coordinates on the y axis.
-    fn to_px(&self, scale: &Scale) -> Self;
+    fn to_px(&self, scale: Scale) -> Self;
 
     /// Converts the scalable item from pixels into display points,
     /// using the x axis scale factor for coordinates on the x axis
     /// and the y axis scale factor for coordinates on the y axis.
-    fn to_dp(&self, scale: &Scale) -> Self;
+    fn to_dp(&self, scale: Scale) -> Self;
 }
 
 impl Default for Scale {
@@ -106,13 +106,13 @@ impl Scale {
 
     /// Returns the x axis scale factor.
     #[inline]
-    pub fn x(&self) -> f64 {
+    pub fn x(self) -> f64 {
         self.x
     }
 
     /// Returns the y axis scale factor.
     #[inline]
-    pub fn y(&self) -> f64 {
+    pub fn y(self) -> f64 {
         self.y
     }
 
@@ -120,26 +120,26 @@ impl Scale {
     /// using the x axis scale factor for coordinates on the x axis
     /// and the y axis scale factor for coordinates on the y axis.
     #[inline]
-    pub fn to_px<T: Scalable>(&self, item: &T) -> T {
+    pub fn to_px<T: Scalable>(self, item: &T) -> T {
         item.to_px(self)
     }
 
     /// Converts from pixels into display points, using the x axis scale factor.
     #[inline]
-    pub fn px_to_dp_x<T: Into<f64>>(&self, x: T) -> f64 {
+    pub fn px_to_dp_x<T: Into<f64>>(self, x: T) -> f64 {
         x.into() / self.x
     }
 
     /// Converts from pixels into display points, using the y axis scale factor.
     #[inline]
-    pub fn px_to_dp_y<T: Into<f64>>(&self, y: T) -> f64 {
+    pub fn px_to_dp_y<T: Into<f64>>(self, y: T) -> f64 {
         y.into() / self.y
     }
 
     /// Converts from pixels into display points,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
-    pub fn px_to_dp_xy<T: Into<f64>>(&self, x: T, y: T) -> (f64, f64) {
+    pub fn px_to_dp_xy<T: Into<f64>>(self, x: T, y: T) -> (f64, f64) {
         (x.into() / self.x, y.into() / self.y)
     }
 
@@ -147,7 +147,7 @@ impl Scale {
     /// using the x axis scale factor for coordinates on the x axis
     /// and the y axis scale factor for coordinates on the y axis.
     #[inline]
-    pub fn to_dp<T: Scalable>(&self, item: &T) -> T {
+    pub fn to_dp<T: Scalable>(self, item: &T) -> T {
         item.to_dp(self)
     }
 }
@@ -156,14 +156,14 @@ impl Scalable for Vec2 {
     /// Converts a `Vec2` from display points into pixels,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
-    fn to_px(&self, scale: &Scale) -> Vec2 {
+    fn to_px(&self, scale: Scale) -> Vec2 {
         Vec2::new(self.x * scale.x, self.y * scale.y)
     }
 
     /// Converts a `Vec2` from pixels into display points,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
-    fn to_dp(&self, scale: &Scale) -> Vec2 {
+    fn to_dp(&self, scale: Scale) -> Vec2 {
         Vec2::new(self.x / scale.x, self.y / scale.y)
     }
 }
@@ -172,14 +172,14 @@ impl Scalable for Point {
     /// Converts a `Point` from display points into pixels,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
-    fn to_px(&self, scale: &Scale) -> Point {
+    fn to_px(&self, scale: Scale) -> Point {
         Point::new(self.x * scale.x, self.y * scale.y)
     }
 
     /// Converts a `Point` from pixels into display points,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
-    fn to_dp(&self, scale: &Scale) -> Point {
+    fn to_dp(&self, scale: Scale) -> Point {
         Point::new(self.x / scale.x, self.y / scale.y)
     }
 }
@@ -188,14 +188,14 @@ impl Scalable for Line {
     /// Converts a `Line` from display points into pixels,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
-    fn to_px(&self, scale: &Scale) -> Line {
+    fn to_px(&self, scale: Scale) -> Line {
         Line::new(self.p0.to_px(scale), self.p1.to_px(scale))
     }
 
     /// Converts a `Line` from pixels into display points,
     /// using the x axis scale factor for `x` and the y axis scale factor for `y`.
     #[inline]
-    fn to_dp(&self, scale: &Scale) -> Line {
+    fn to_dp(&self, scale: Scale) -> Line {
         Line::new(self.p0.to_dp(scale), self.p1.to_dp(scale))
     }
 }
@@ -205,7 +205,7 @@ impl Scalable for Size {
     /// using the x axis scale factor for `width`
     /// and the y axis scale factor for `height`.
     #[inline]
-    fn to_px(&self, scale: &Scale) -> Size {
+    fn to_px(&self, scale: Scale) -> Size {
         Size::new(self.width * scale.x, self.height * scale.y)
     }
 
@@ -213,7 +213,7 @@ impl Scalable for Size {
     /// using the x axis scale factor for `width`
     /// and the y axis scale factor for `height`.
     #[inline]
-    fn to_dp(&self, scale: &Scale) -> Size {
+    fn to_dp(&self, scale: Scale) -> Size {
         Size::new(self.width / scale.x, self.height / scale.y)
     }
 }
@@ -223,7 +223,7 @@ impl Scalable for Rect {
     /// using the x axis scale factor for `x0` and `x1`
     /// and the y axis scale factor for `y0` and `y1`.
     #[inline]
-    fn to_px(&self, scale: &Scale) -> Rect {
+    fn to_px(&self, scale: Scale) -> Rect {
         Rect::new(
             self.x0 * scale.x,
             self.y0 * scale.y,
@@ -236,7 +236,7 @@ impl Scalable for Rect {
     /// using the x axis scale factor for `x0` and `x1`
     /// and the y axis scale factor for `y0` and `y1`.
     #[inline]
-    fn to_dp(&self, scale: &Scale) -> Rect {
+    fn to_dp(&self, scale: Scale) -> Rect {
         Rect::new(
             self.x0 / scale.x,
             self.y0 / scale.y,
@@ -251,7 +251,7 @@ impl Scalable for Insets {
     /// using the x axis scale factor for `x0` and `x1`
     /// and the y axis scale factor for `y0` and `y1`.
     #[inline]
-    fn to_px(&self, scale: &Scale) -> Insets {
+    fn to_px(&self, scale: Scale) -> Insets {
         Insets::new(
             self.x0 * scale.x,
             self.y0 * scale.y,
@@ -264,7 +264,7 @@ impl Scalable for Insets {
     /// using the x axis scale factor for `x0` and `x1`
     /// and the y axis scale factor for `y0` and `y1`.
     #[inline]
-    fn to_dp(&self, scale: &Scale) -> Insets {
+    fn to_dp(&self, scale: Scale) -> Insets {
         Insets::new(
             self.x0 / scale.x,
             self.y0 / scale.y,
@@ -285,7 +285,7 @@ impl Default for ScaledArea {
 
 impl ScaledArea {
     /// Create a new scaled area from pixels.
-    pub fn from_px<T: Into<Size>>(size: T, scale: &Scale) -> ScaledArea {
+    pub fn from_px<T: Into<Size>>(size: T, scale: Scale) -> ScaledArea {
         let size_px = size.into();
         let size_dp = size_px.to_dp(scale);
         ScaledArea { size_dp, size_px }
@@ -298,7 +298,7 @@ impl ScaledArea {
     /// as the `size` given to this function. To find out the new size in points use [`size_dp`].
     ///
     /// [`size_dp`]: #method.size_dp
-    pub fn from_dp<T: Into<Size>>(size: T, scale: &Scale) -> ScaledArea {
+    pub fn from_dp<T: Into<Size>>(size: T, scale: Scale) -> ScaledArea {
         let size_px = size.into().to_px(scale).expand();
         let size_dp = size_px.to_dp(scale);
         ScaledArea { size_dp, size_px }

--- a/druid/src/lib.rs
+++ b/druid/src/lib.rs
@@ -122,6 +122,7 @@
 
 #![deny(intra_doc_link_resolution_failure, unsafe_code)]
 #![allow(clippy::new_ret_no_self, clippy::needless_doctest_main)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Allows to use macros from druid_derive in this crate


### PR DESCRIPTION
Rust 1.44 moved the `trivially_copy_pass_by_ref` clippy lint to pedantic. As discussed on [zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Scale.20clippy.20fail) let's turn it back on, at least for now.

This PR also fixes the corresponding error in relation to the recent `Scale` rework.