### PR TITLE
Specify example feature requirements in a standard way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ You can find its changes [documented below](#060---2020-06-01).
 
 ### Examples
 
+- Specify feature requirements in a standard way. ([#1050] by [@xStrom])
+
 ### Maintenance
 
 - Standardized web targeting terminology. ([#1013] by [@xStrom])
@@ -334,6 +336,7 @@ Last release without a changelog :(
 [#1028]: https://github.com/xi-editor/druid/pull/1028
 [#1042]: https://github.com/xi-editor/druid/pull/1042
 [#1043]: https://github.com/xi-editor/druid/pull/1043
+[#1050]: https://github.com/xi-editor/druid/pull/1050
 
 [Unreleased]: https://github.com/xi-editor/druid/compare/v0.6.0...master
 [0.6.0]: https://github.com/xi-editor/druid/compare/v0.5.0...v0.6.0

--- a/druid/Cargo.toml
+++ b/druid/Cargo.toml
@@ -50,3 +50,15 @@ console_log = "0.2.0"
 float-cmp = { version = "0.8.0", features = ["std"], default-features = false }
 tempfile = "3.1.0"
 piet-common = { version = "0.1.1", features = ["png"] }
+
+[[example]]
+name = "image"
+required-features = ["image"]
+
+[[example]]
+name = "list"
+required-features = ["im"]
+
+[[example]]
+name = "svg"
+required-features = ["svg"]

--- a/druid/examples/image.rs
+++ b/druid/examples/image.rs
@@ -13,54 +13,43 @@
 // limitations under the License.
 
 //! This example shows how to draw an png image.
-//!
-//! Requires the non-default "image" feature to be enabled:
-//! `cargo run --example image --features "images"`
-//!
 
-#[cfg(not(feature = "image"))]
+use druid::{
+    widget::{FillStrat, Flex, Image, ImageData, WidgetExt},
+    AppLauncher, Color, Widget, WindowDesc,
+};
+
 pub fn main() {
-    eprintln!("This examples requires the \"image\" feature to be enabled:");
-    eprintln!("cargo run --example image --features \"image\"");
-}
-
-#[cfg(feature = "image")]
-pub fn main() {
-    use druid::{
-        widget::{FillStrat, Flex, Image, ImageData, WidgetExt},
-        AppLauncher, Color, Widget, WindowDesc,
-    };
-
-    fn ui_builder() -> impl Widget<u32> {
-        let png_data = ImageData::from_data(include_bytes!("./assets/PicWithAlpha.png")).unwrap();
-
-        let mut col = Flex::column();
-
-        col.add_flex_child(
-            Image::new(png_data.clone())
-                .border(Color::WHITE, 1.0)
-                .fix_width(100.0)
-                .center(),
-            1.0,
-        );
-
-        /*
-        // If you want to change the fill stratagy you can but you need the widget to be mut
-        let mut otherimage = Image::new(png_data);
-        otherimage.set_fill(FillStrat::FitWidth);
-        */
-
-        let otherimage = Image::new(png_data)
-            .fill_mode(FillStrat::FitWidth)
-            .border(Color::WHITE, 1.0);
-        col.add_flex_child(otherimage, 1.0);
-        col
-    };
-
     let main_window = WindowDesc::new(ui_builder);
     let data = 0_u32;
     AppLauncher::with_window(main_window)
         .use_simple_logger()
         .launch(data)
         .expect("launch failed");
+}
+
+fn ui_builder() -> impl Widget<u32> {
+    let png_data = ImageData::from_data(include_bytes!("./assets/PicWithAlpha.png")).unwrap();
+
+    let mut col = Flex::column();
+
+    col.add_flex_child(
+        Image::new(png_data.clone())
+            .border(Color::WHITE, 1.0)
+            .fix_width(100.0)
+            .center(),
+        1.0,
+    );
+
+    /*
+    // If you want to change the fill stratagy you can but you need the widget to be mut
+    let mut otherimage = Image::new(png_data);
+    otherimage.set_fill(FillStrat::FitWidth);
+    */
+
+    let otherimage = Image::new(png_data)
+        .fill_mode(FillStrat::FitWidth)
+        .border(Color::WHITE, 1.0);
+    col.add_flex_child(otherimage, 1.0);
+    col
 }

--- a/druid/examples/list.rs
+++ b/druid/examples/list.rs
@@ -14,122 +14,108 @@
 
 //! Demos basic list widget and list manipulations.
 
-#[cfg(not(feature = "im"))]
-pub fn main() {
-    eprintln!("This examples requires the \"im\" feature to be enabled:");
-    eprintln!("cargo run --example list --features im");
+use druid::im::{vector, Vector};
+use druid::lens::{self, LensExt};
+use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll};
+use druid::{
+    AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WidgetExt, WindowDesc,
+};
+
+#[derive(Clone, Data, Lens)]
+struct AppData {
+    left: Vector<u32>,
+    right: Vector<u32>,
 }
 
-#[cfg(feature = "im")]
 pub fn main() {
-    example::main()
-}
-
-#[cfg(feature = "im")]
-mod example {
-    use druid::im::{vector, Vector};
-    use druid::lens::{self, LensExt};
-    use druid::widget::{Button, CrossAxisAlignment, Flex, Label, List, Scroll};
-    use druid::{
-        AppLauncher, Color, Data, Lens, LocalizedString, UnitPoint, Widget, WidgetExt, WindowDesc,
+    let main_window = WindowDesc::new(ui_builder)
+        .title(LocalizedString::new("list-demo-window-title").with_placeholder("List Demo"));
+    // Set our initial data
+    let data = AppData {
+        left: vector![1, 2],
+        right: vector![1, 2, 3],
     };
+    AppLauncher::with_window(main_window)
+        .use_simple_logger()
+        .launch(data)
+        .expect("launch failed");
+}
 
-    #[derive(Clone, Data, Lens)]
-    struct AppData {
-        left: Vector<u32>,
-        right: Vector<u32>,
-    }
+fn ui_builder() -> impl Widget<AppData> {
+    let mut root = Flex::column();
 
-    pub fn main() {
-        let main_window = WindowDesc::new(ui_builder)
-            .title(LocalizedString::new("list-demo-window-title").with_placeholder("List Demo"));
-        // Set our initial data
-        let data = AppData {
-            left: vector![1, 2],
-            right: vector![1, 2, 3],
-        };
-        AppLauncher::with_window(main_window)
-            .use_simple_logger()
-            .launch(data)
-            .expect("launch failed");
-    }
+    // Build a button to add children to both lists
+    root.add_child(
+        Button::new("Add")
+            .on_click(|_, data: &mut AppData, _| {
+                // Add child to left list
+                let value = data.left.len() + 1;
+                data.left.push_back(value as u32);
 
-    fn ui_builder() -> impl Widget<AppData> {
-        let mut root = Flex::column();
+                // Add child to right list
+                let value = data.right.len() + 1;
+                data.right.push_back(value as u32);
+            })
+            .fix_height(30.0)
+            .expand_width(),
+    );
 
-        // Build a button to add children to both lists
-        root.add_child(
-            Button::new("Add")
-                .on_click(|_, data: &mut AppData, _| {
-                    // Add child to left list
-                    let value = data.left.len() + 1;
-                    data.left.push_back(value as u32);
+    let mut lists = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);
 
-                    // Add child to right list
-                    let value = data.right.len() + 1;
-                    data.right.push_back(value as u32);
-                })
-                .fix_height(30.0)
-                .expand_width(),
-        );
+    // Build a simple list
+    lists.add_flex_child(
+        Scroll::new(List::new(|| {
+            Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
+                .align_vertical(UnitPoint::LEFT)
+                .padding(10.0)
+                .expand()
+                .height(50.0)
+                .background(Color::rgb(0.5, 0.5, 0.5))
+        }))
+        .vertical()
+        .lens(AppData::left),
+        1.0,
+    );
 
-        let mut lists = Flex::row().cross_axis_alignment(CrossAxisAlignment::Start);
-
-        // Build a simple list
-        lists.add_flex_child(
-            Scroll::new(List::new(|| {
-                Label::new(|item: &u32, _env: &_| format!("List item #{}", item))
-                    .align_vertical(UnitPoint::LEFT)
-                    .padding(10.0)
-                    .expand()
-                    .height(50.0)
-                    .background(Color::rgb(0.5, 0.5, 0.5))
-            }))
-            .vertical()
-            .lens(AppData::left),
-            1.0,
-        );
-
-        // Build a list with shared data
-        lists.add_flex_child(
-            Scroll::new(List::new(|| {
-                Flex::row()
-                    .with_child(
-                        Label::new(|(_, item): &(Vector<u32>, u32), _env: &_| {
-                            format!("List item #{}", item)
+    // Build a list with shared data
+    lists.add_flex_child(
+        Scroll::new(List::new(|| {
+            Flex::row()
+                .with_child(
+                    Label::new(|(_, item): &(Vector<u32>, u32), _env: &_| {
+                        format!("List item #{}", item)
+                    })
+                    .align_vertical(UnitPoint::LEFT),
+                )
+                .with_flex_spacer(1.0)
+                .with_child(
+                    Button::new("Delete")
+                        .on_click(|_ctx, (shared, item): &mut (Vector<u32>, u32), _env| {
+                            // We have access to both child's data and shared data.
+                            // Remove element from right list.
+                            shared.retain(|v| v != item);
                         })
-                        .align_vertical(UnitPoint::LEFT),
-                    )
-                    .with_flex_spacer(1.0)
-                    .with_child(
-                        Button::new("Delete")
-                            .on_click(|_ctx, (shared, item): &mut (Vector<u32>, u32), _env| {
-                                // We have access to both child's data and shared data.
-                                // Remove element from right list.
-                                shared.retain(|v| v != item);
-                            })
-                            .fix_size(80.0, 20.0)
-                            .align_vertical(UnitPoint::CENTER),
-                    )
-                    .padding(10.0)
-                    .background(Color::rgb(0.5, 0.0, 0.5))
-                    .fix_height(50.0)
-            }))
-            .vertical()
-            .lens(lens::Id.map(
-                // Expose shared data with children data
-                |d: &AppData| (d.right.clone(), d.right.clone()),
-                |d: &mut AppData, x: (Vector<u32>, Vector<u32>)| {
-                    // If shared data was changed reflect the changes in our AppData
-                    d.right = x.0
-                },
-            )),
-            1.0,
-        );
+                        .fix_size(80.0, 20.0)
+                        .align_vertical(UnitPoint::CENTER),
+                )
+                .padding(10.0)
+                .background(Color::rgb(0.5, 0.0, 0.5))
+                .fix_height(50.0)
+        }))
+        .vertical()
+        .lens(lens::Id.map(
+            // Expose shared data with children data
+            |d: &AppData| (d.right.clone(), d.right.clone()),
+            |d: &mut AppData, x: (Vector<u32>, Vector<u32>)| {
+                // If shared data was changed reflect the changes in our AppData
+                d.right = x.0
+            },
+        )),
+        1.0,
+    );
 
-        root.add_flex_child(lists, 1.0);
+    root.add_flex_child(lists, 1.0);
 
-        // Mark the widget as needing its layout rects painted
-        root.debug_paint_layout()
-    }
+    // Mark the widget as needing its layout rects painted
+    root.debug_paint_layout()
 }

--- a/druid/examples/svg.rs
+++ b/druid/examples/svg.rs
@@ -13,25 +13,15 @@
 // limitations under the License.
 
 //! This example shows how to draw an SVG.
-//!
-//! Requires the non-default "svg" feature to be enabled:
-//! `cargo run --example svg --features "svg"`
 
-#[cfg(not(feature = "svg"))]
+use log::error;
+
+use druid::{
+    widget::{FillStrat, Flex, Svg, SvgData, WidgetExt},
+    AppLauncher, LocalizedString, Widget, WindowDesc,
+};
+
 pub fn main() {
-    eprintln!("This examples requires the \"svg\" feature to be enabled:");
-    eprintln!("cargo run --example svg --features \"svg\"");
-}
-
-#[cfg(feature = "svg")]
-pub fn main() {
-    use log::error;
-
-    use druid::{
-        widget::{FillStrat, Flex, Svg, SvgData, WidgetExt},
-        AppLauncher, LocalizedString, Widget, WindowDesc,
-    };
-
     let main_window = WindowDesc::new(ui_builder)
         .title(LocalizedString::new("svg-demo-window-title").with_placeholder("Rawr!"));
     let data = 0_u32;
@@ -39,22 +29,22 @@ pub fn main() {
         .use_simple_logger()
         .launch(data)
         .expect("launch failed");
+}
 
-    fn ui_builder() -> impl Widget<u32> {
-        let tiger_svg = match include_str!("./assets/tiger.svg").parse::<SvgData>() {
-            Ok(svg) => svg,
-            Err(err) => {
-                error!("{}", err);
-                error!("Using an empty SVG instead.");
-                SvgData::default()
-            }
-        };
+fn ui_builder() -> impl Widget<u32> {
+    let tiger_svg = match include_str!("./assets/tiger.svg").parse::<SvgData>() {
+        Ok(svg) => svg,
+        Err(err) => {
+            error!("{}", err);
+            error!("Using an empty SVG instead.");
+            SvgData::default()
+        }
+    };
 
-        let mut col = Flex::column();
+    let mut col = Flex::column();
 
-        col.add_flex_child(Svg::new(tiger_svg.clone()).fix_width(60.0).center(), 1.0);
-        col.add_flex_child(Svg::new(tiger_svg.clone()).fill_mode(FillStrat::Fill), 1.0);
-        col.add_flex_child(Svg::new(tiger_svg), 1.0);
-        col.debug_paint_layout()
-    }
+    col.add_flex_child(Svg::new(tiger_svg.clone()).fix_width(60.0).center(), 1.0);
+    col.add_flex_child(Svg::new(tiger_svg.clone()).fill_mode(FillStrat::Fill), 1.0);
+    col.add_flex_child(Svg::new(tiger_svg), 1.0);
+    col.debug_paint_layout()
 }

--- a/druid/examples/web/Cargo.toml
+++ b/druid/examples/web/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-druid = { path="../.." }
+druid = { path="../..", features = ["im", "image"] }
 
 wasm-bindgen = "0.2.63"
 console_error_panic_hook = "0.1.6"


### PR DESCRIPTION
This PR adds the various example feature requirements to `Cargo.toml` via the [`required-features`](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-required-features-field) field.

This allows the examples themselves to be cleaned up from all the cfg guards, which add needless confusion for new developers.

```
$ cargo run --example list
error: target `list` in package `druid` requires the features: `im`
Consider enabling them by passing, e.g., `--features="im"`
```
